### PR TITLE
APPT-37 Run web client tests in pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ bld/
 *.VisualState.xml
 TestResult.xml
 
+#JUnit
+junit.xml
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,64 +16,90 @@ variables:
   isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 
 stages:
-  - stage: Build 
+  - stage: Build
     displayName: Build
     jobs:
       - job: "Build"
         steps:
-        - task: DotNetCoreCLI@2
-          displayName: dotnet Publish
-          inputs:
-            command: publish
-            publishWebProjects: false
-            projects: "$(apiProjectPath)"
-            arguments: "--configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)"
-            zipAfterPublish: false
-            modifyOutputPath: false
-        - task: DotNetCoreCLI@2
-          displayName: "Run Api Unit Tests"
-          inputs:
-            command: "test"
-            projects: "$(apiUnitTestProjectPath)"
-        - task: DotNetCoreCLI@2
-          displayName: "Run Core Unit Tests"
-          inputs:
-            command: "test"
-            projects: "$(coreUnitTestProjectPath)"
-        - task: DotNetCoreCLI@2
-          displayName: "Run Persistance Unit Tests"
-          inputs:
-            command: "test"
-            projects: "$(persistanceUnitTestProjectPath)"
-        - task: ArchiveFiles@2
-          displayName: Zip Api
-          inputs:
-            rootFolderOrFile: "$(Build.ArtifactStagingDirectory)"
-            includeRootFolder: false
-            archiveType: "zip"
-            archiveFile: "$(Build.ArtifactStagingDirectory)/out/appts-alpha-api-$(Build.BuildId).zip"
-            replaceExistingArchive: true
-        - task: PublishBuildArtifacts@1
-          displayName: "Publish Artifact"
-          inputs:
-            PathtoPublish: "$(Build.ArtifactStagingDirectory)/out"
-            ArtifactName: "drop_api"
-            publishLocation: "Container"
-        - task: PublishBuildArtifacts@1
-          displayName: "Publish Terraform"
-          inputs:
+          - task: DotNetCoreCLI@2
+            displayName: dotnet Publish
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "$(apiProjectPath)"
+              arguments: "--configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)"
+              zipAfterPublish: false
+              modifyOutputPath: false
+          - task: DotNetCoreCLI@2
+            displayName: "Run Api Unit Tests"
+            inputs:
+              command: "test"
+              projects: "$(apiUnitTestProjectPath)"
+          - task: DotNetCoreCLI@2
+            displayName: "Run Core Unit Tests"
+            inputs:
+              command: "test"
+              projects: "$(coreUnitTestProjectPath)"
+          - task: DotNetCoreCLI@2
+            displayName: "Run Persistance Unit Tests"
+            inputs:
+              command: "test"
+              projects: "$(persistanceUnitTestProjectPath)"
+          - task: ArchiveFiles@2
+            displayName: Zip Api
+            inputs:
+              rootFolderOrFile: "$(Build.ArtifactStagingDirectory)"
+              includeRootFolder: false
+              archiveType: "zip"
+              archiveFile: "$(Build.ArtifactStagingDirectory)/out/appts-api-$(Build.BuildId).zip"
+              replaceExistingArchive: true
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish API Artifact"
+            inputs:
+              PathtoPublish: "$(Build.ArtifactStagingDirectory)/out"
+              ArtifactName: "drop_api"
+              publishLocation: "Container"
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish Terraform"
+            inputs:
               PathtoPublish: "$(Build.SourcesDirectory)/infrastructure"
               ArtifactName: "drop_terraform"
               publishLocation: "Container"
-        - task: PublishBuildArtifacts@1
-          displayName: "Publish Web"
-          inputs:
-              PathtoPublish: "$(Build.SourcesDirectory)/src/client"
+          - task: UseNode@1
+            displayName: "Install Node"
+            inputs:
+              version: 20.x
+          - script: |
+              cd ./src/client
+              npm install 
+              npm run test:ci
+            displayName: "Run Web Client Tests"
+          - task: PublishTestResults@2
+            displayName: "Publish Web Client Test Results"
+            inputs:
+              testResultsFiles: "junit.xml"
+              testRunTitle: NBS Appointments Management Service Client Tests
+              testResultsFormat: "JUnit"
+              publishRunAttachments: true
+              searchFolder: '$(Build.SourcesDirectory)'
+          - task: CopyFiles@2
+            displayName: "Copy Client Files"
+            inputs:
+              SourceFolder: "$(Build.SourcesDirectory)/src/client"
+              Contents: |
+                **/*
+                !node_modules/**/*
+                !junit.xml
+              TargetFolder: "$(Build.ArtifactStagingDirectory)/client"
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish Web Client"
+            inputs:
+              PathtoPublish: "$(Build.ArtifactStagingDirectory)/client"
               ArtifactName: "drop_web"
               publishLocation: "Container"
       - job: "RunIntegrationTests"
         displayName: Run integration tests
-        pool: 
+        pool:
           vmImage: windows-latest
         steps:
           - task: Powershell@2
@@ -125,20 +151,20 @@ stages:
                 Write-Host "Running integration tests..."
                 dotnet test --logger:"trx;logfilename=apptsServiceTests.trx"    
           - task: PublishTestResults@2
-            displayName: 'Publish test results'
+            displayName: 'Publish API Test Results'
             inputs:
               testResultsFiles: 'apptsServiceTests.trx'
-              testRunTitle: Appointment Service Alpha Integration Tests
+              testRunTitle: NBS Appointments Management Service Integration Tests
               testResultsFormat: 'VSTest'
               publishRunAttachments: true
               searchFolder: '$(System.DefaultWorkingDirectory)\tests\Nhs.Appointments.Api.Integration\TestResults'
             condition: succeededOrFailed()
-            
+
   - stage: DeployDev
     condition: and(succeeded(), eq(variables.isMain, true))
     displayName: Deploy Dev
     jobs:
-    
+
       - job: RunTerraformPlan
         displayName: Run Terraform Plan
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,8 +82,9 @@ stages:
               testResultsFormat: "JUnit"
               publishRunAttachments: true
               searchFolder: '$(Build.SourcesDirectory)'
+            condition: succeededOrFailed()
           - task: CopyFiles@2
-            displayName: "Copy Client Files"
+            displayName: "Copy Web Client Files"
             inputs:
               SourceFolder: "$(Build.SourcesDirectory)/src/client"
               Contents: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,12 +59,6 @@ stages:
               PathtoPublish: "$(Build.ArtifactStagingDirectory)/out"
               ArtifactName: "drop_api"
               publishLocation: "Container"
-          - task: PublishBuildArtifacts@1
-            displayName: "Publish Terraform"
-            inputs:
-              PathtoPublish: "$(Build.SourcesDirectory)/infrastructure"
-              ArtifactName: "drop_terraform"
-              publishLocation: "Container"
           - task: UseNode@1
             displayName: "Install Node"
             inputs:
@@ -81,7 +75,7 @@ stages:
               testRunTitle: NBS Appointments Management Service Client Tests
               testResultsFormat: "JUnit"
               publishRunAttachments: true
-              searchFolder: '$(Build.SourcesDirectory)'
+              searchFolder: '$(Build.SourcesDirectory)/src/client'
             condition: succeededOrFailed()
           - task: CopyFiles@2
             displayName: "Copy Web Client Files"
@@ -97,6 +91,12 @@ stages:
             inputs:
               PathtoPublish: "$(Build.ArtifactStagingDirectory)/client"
               ArtifactName: "drop_web"
+              publishLocation: "Container"
+          - task: PublishBuildArtifacts@1
+            displayName: "Publish Terraform"
+            inputs:
+              PathtoPublish: "$(Build.SourcesDirectory)/infrastructure"
+              ArtifactName: "drop_terraform"
               publishLocation: "Container"
       - job: "RunIntegrationTests"
         displayName: Run integration tests

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -27,7 +27,8 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "@types/react-big-calendar": "^1.8.9"
+        "@types/react-big-calendar": "^1.8.9",
+        "jest-junit": "^16.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10613,6 +10614,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.5.1.tgz",
@@ -18127,6 +18155,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true
     },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -25,6 +25,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:ci": "react-scripts test --watchAll=false --reporters=jest-junit --reporters=default",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -46,6 +47,7 @@
     ]
   },
   "devDependencies": {
-    "@types/react-big-calendar": "^1.8.9"
+    "@types/react-big-calendar": "^1.8.9",
+    "jest-junit": "^16.0.0"
   }
 }

--- a/src/client/src/Components/ServiceSelector.test.tsx
+++ b/src/client/src/Components/ServiceSelector.test.tsx
@@ -23,6 +23,6 @@ describe("<SiteSelector>", () => {
         const presentOption = await screen.findByLabelText(context.siteConfig?.serviceConfiguration[0].displayName!);
         const missingOption = await screen.queryByText(context.siteConfig?.serviceConfiguration[1].displayName!);
         expect(presentOption).toBeVisible();
-        expect(missingOption).toBeInTheDocument();
+        expect(missingOption).not.toBeInTheDocument();
     });
 })

--- a/src/client/src/Components/ServiceSelector.test.tsx
+++ b/src/client/src/Components/ServiceSelector.test.tsx
@@ -23,6 +23,6 @@ describe("<SiteSelector>", () => {
         const presentOption = await screen.findByLabelText(context.siteConfig?.serviceConfiguration[0].displayName!);
         const missingOption = await screen.queryByText(context.siteConfig?.serviceConfiguration[1].displayName!);
         expect(presentOption).toBeVisible();
-        expect(missingOption).not.toBeInTheDocument();
+        expect(missingOption).toBeInTheDocument();
     });
 })


### PR DESCRIPTION
- Add web client tests to pipeline
- Output results to tests tab in run overview using junit reporter
- Web client is published only if tests pass
- Web client published without unwanted files i.e. node_modules and test report 