### PR TITLE
Create VS Code Workspace and helpful tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .version
 
 *.code-workspace
-!project.code-workspace
+!nbs-ams.code-workspace
 
 # Please, add your custom content below!
 ## Ignore Visual Studio temporary files, build results, and
@@ -225,7 +225,6 @@ FakesAssemblies/
 *.opt
 
 # VS Code related folders and files
-.vscode/
 *.jfm
 
 # idea related folders and files

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,31 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Start local development containers",
+      "type": "docker-compose",
+      "dockerCompose": {
+        "up": {
+          "detached": true,
+          "build": true,
+          "services": ["cosmos", "mock-api", "oidc-server"]
+        },
+        "files": ["docker-compose.yml"]
+      }
+    },
+    {
+      "label": "Start cosmos container",
+      "type": "docker-compose",
+      "dockerCompose": {
+        "up": {
+          "detached": true,
+          "build": true,
+          "services": ["cosmos"]
+        },
+        "files": ["docker-compose.yml"]
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We will build a web based application for appointment and site management
 
 ## GitHub Repo and signed commits
 
-The repo has signed commits enabled. This means that only commits that are verified can be merged into the main branch. More information about signed commits can be found  [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
+The repo has signed commits enabled. This means that only commits that are verified can be merged into the main branch. More information about signed commits can be found [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
 
 Your workstation will need to be set up to use signed commits. Please follow this guide for [instructions](https://github.com/NHSDigital/software-engineering-quality-framework/blob/main/practices/guides/commit-signing.md).
 
@@ -53,16 +53,28 @@ Your workstation will need to be set up to use signed commits. Please follow thi
   Tools [instructions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=windows%2Cisolated-process%2Cnode-v4%2Cpython-v2%2Chttp-trigger%2Ccontainer-apps&pivots=programming-language-csharp)
 - Install NPM [instructions](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 
+#### VS Code Setup (optional)
+
+If you are using VS Code, you may find it beneficial to open the repo by opening the `nbs-ams.code-workspace` file itself. This will open a workspace configured with several productivity boons:
+
+- The Explorer window is split into folders for convenience and to make navigating the repo quicker/easier
+- Terminals can be opened straight into any of these folders using the `ctrl-shift-'` command
+- Default build tasks have been configured for Dotnet and Typescript. You can run these with the `ctrl-shift-b` command
+- Non-build tasks have been configured for starting the docker, dotnet, and NextJS services. These are configured in `tasks.json` folders and can be ran through `Terminal` -> `Run Task...`
+
 ### Running locally
 
 Each of the following steps needs to be done in a separate terminal window
 
 - Run the Cosmos Emulator and MockApi
   - From the root folder run `docker compose up`
+  - (OR if using VS Code) run the `Start local development containers` task
 - Run the API
   - From the folder `/src/api/Nhs.Appointments.Api` run the command `func start`
+  - (OR if using VS Code) run the `Clean and Run API` task
 - Run the Web Application
   - From the folder `/src/client/` run `npm install` and then run `npm run dev`
+  - (OR if using VS Code) run the `Run Client in Dev Mode` task
 
 ### Setting a cert for the OIDC server
 
@@ -100,61 +112,51 @@ insert the document again.
 
 ```json
 {
-    "id": "global_roles",
-    "docType": "roles",
-    "roles": [
-        {
-            "id": "canned:check-in",
-            "name": "Check-in",
-            "permissions": [
-                "booking:query",
-                "booking:set-status"
-            ]
-        },
-        {
-            "id": "canned:appointment-manager",
-            "name": "Appointment manager",
-            "permissions": [
-                "booking:make",
-                "booking:query",
-                "booking:cancel"
-            ]
-        },
-        {
-            "id": "canned:availability-manager",
-            "name": "Availability manager",
-            "permissions": [
-                "availability:get-setup",
-                "availability:set-setup",
-                "availability:query"
-            ]
-        },
-        {
-            "id": "canned:site-configuration-manager",
-            "name": "Site configuration manager",
-            "permissions": [
-                "site:get-config",
-                "site:set-config"
-            ]
-        },
-        {
-            "id": "canned:api-user",
-            "name": "Api User",
-            "permissions": [
-                "site:get-meta-data",
-                "availability:query",
-                "booking:make",
-                "booking:query",
-                "booking:cancel"
-            ]
-        }
-    ]
+  "id": "global_roles",
+  "docType": "roles",
+  "roles": [
+    {
+      "id": "canned:check-in",
+      "name": "Check-in",
+      "permissions": ["booking:query", "booking:set-status"]
+    },
+    {
+      "id": "canned:appointment-manager",
+      "name": "Appointment manager",
+      "permissions": ["booking:make", "booking:query", "booking:cancel"]
+    },
+    {
+      "id": "canned:availability-manager",
+      "name": "Availability manager",
+      "permissions": [
+        "availability:get-setup",
+        "availability:set-setup",
+        "availability:query"
+      ]
+    },
+    {
+      "id": "canned:site-configuration-manager",
+      "name": "Site configuration manager",
+      "permissions": ["site:get-config", "site:set-config"]
+    },
+    {
+      "id": "canned:api-user",
+      "name": "Api User",
+      "permissions": [
+        "site:get-meta-data",
+        "availability:query",
+        "booking:make",
+        "booking:query",
+        "booking:cancel"
+      ]
+    }
+  ]
 }
 ```
 
 ### Adding in User Site Assignments
 
-Add another document to represent a user with the following structure in to the index_data container. Each user is represented by a single document which contains the id of the user and all the roles that are assigned to the user at each site. Role assignments are site or global scoped - site scoped means that the user is assigned that role at the given site; global scope means that the user has been assigned that role and is valid for all sites. 
+Add another document to represent a user with the following structure in to the index_data container. Each user is represented by a single document which contains the id of the user and all the roles that are assigned to the user at each site. Role assignments are site or global scoped - site scoped means that the user is assigned that role at the given site; global scope means that the user has been assigned that role and is valid for all sites.
 
 This will have to be done once the function has started (so that the containers have been created) but before you can login. If you restart your cosmos database you will need to insert the document again.
 
@@ -180,6 +182,7 @@ This will have to be done once the function has started (so that the containers 
 ```
 
 Example of ApiUser with global scoped role:
+
 ```json
 {
   "id": "api@dev",

--- a/nbs-ams.code-workspace
+++ b/nbs-ams.code-workspace
@@ -1,0 +1,37 @@
+{
+  "folders": [
+    {
+      "name": "Client",
+      "path": "./src/client"
+    },
+    {
+      "name": "New Client",
+      "path": "./src/new-client"
+    },
+    {
+      "name": "API",
+      "path": "./src/api"
+    },
+    {
+      "name": "API Tests",
+      "path": "./tests"
+    },
+    {
+      "name": "Root",
+      "path": "./"
+    }
+  ],
+  "settings": {
+    "jest.disabledWorkspaceFolders": ["API", "API Tests", "Root"],
+    "window.title": "NBS AMS",
+    "jest.runMode": { "type": "on-demand", "revealOutput": "on-run" },
+    "[typescript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true
+  },
+  "extensions": {
+    "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+  }
+}

--- a/src/api/.vscode/tasks.json
+++ b/src/api/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Dotnet Build",
+      "command": "dotnet",
+      "type": "process",
+      "args": ["build", "Nhs.Appointments.Api/Nhs.Appointments.Api.csproj"],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Dotnet Clean",
+      "command": "dotnet",
+      "type": "process",
+      "args": ["clean", "Nhs.Appointments.Api/Nhs.Appointments.Api.csproj"],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Run API",
+      "command": "func",
+      "type": "process",
+      "args": ["start"],
+      "options": {
+        "cwd": "Nhs.Appointments.Api/"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Clean and Run API",
+      "command": "func",
+      "type": "process",
+      "args": ["start"],
+      "options": {
+        "cwd": "Nhs.Appointments.Api/"
+      },
+      "problemMatcher": "$msCompile",
+      "dependsOrder": "sequence",
+      "dependsOn": ["Dotnet Clean"]
+    }
+  ]
+}

--- a/src/client/.gitignore
+++ b/src/client/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log*
 .next
 next-env.d.ts
 dist
+tsconfig.tsbuildinfo

--- a/src/client/.vscode/tasks.json
+++ b/src/client/.vscode/tasks.json
@@ -1,0 +1,79 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build Typescript",
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "options": {
+        "args": ["--noEmit"]
+      },
+      "problemMatcher": ["$tsc"],
+      "group": {
+        "kind": "build"
+      }
+    },
+    {
+      "label": "Build Next App",
+      "type": "npm",
+      "script": "build",
+      "group": {
+        "kind": "build"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Client in Dev Mode",
+      "type": "npm",
+      "script": "dev",
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Client",
+      "type": "npm",
+      "script": "start",
+      "problemMatcher": [],
+      "dependsOrder": "sequence",
+      "dependsOn": ["Build Next App"]
+    },
+    {
+      "label": "Run Jest Tests",
+      "type": "npm",
+      "script": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "NPM Install",
+      "type": "npm",
+      "script": "install",
+      "problemMatcher": []
+    },
+    {
+      "label": "Full build",
+      "type": "shell",
+      "command": "echo Finished",
+      "dependsOrder": "sequence",
+      "dependsOn": ["NPM Install", "Build Typescript", "Build Next App"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Full build and test",
+      "type": "shell",
+      "command": "echo Finished",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "NPM Install",
+        "Build Typescript",
+        "Build Next App",
+        "Run Jest Tests"
+      ],
+      "problemMatcher": []
+    }
+  ]
+}

--- a/src/new-client/.vscode/tasks.json
+++ b/src/new-client/.vscode/tasks.json
@@ -1,0 +1,96 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build Typescript",
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "problemMatcher": ["$tsc"],
+      "group": {
+        "kind": "build"
+      }
+    },
+    {
+      "label": "Build Next App",
+      "type": "npm",
+      "script": "build",
+      "group": {
+        "kind": "build"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Client in Dev Mode",
+      "type": "npm",
+      "script": "dev",
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Client",
+      "type": "npm",
+      "script": "start",
+      "problemMatcher": [],
+      "dependsOrder": "sequence",
+      "dependsOn": ["Build Next App"]
+    },
+    {
+      "label": "Run ES Lint",
+      "type": "npm",
+      "script": "lint",
+      "problemMatcher": ["$eslint-stylish"]
+    },
+    {
+      "label": "Run Prettier",
+      "type": "npm",
+      "script": "format",
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Jest Tests",
+      "type": "npm",
+      "script": "test",
+      "problemMatcher": []
+    },
+    {
+      "label": "NPM Install",
+      "type": "npm",
+      "script": "install",
+      "problemMatcher": []
+    },
+    {
+      "label": "Full build",
+      "type": "shell",
+      "command": "echo Finished",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "NPM Install",
+        "Build Typescript",
+        "Build Next App",
+        "Run ES Lint",
+        "Run Prettier"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Full build and test",
+      "type": "shell",
+      "command": "echo Finished",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "NPM Install",
+        "Build Typescript",
+        "Build Next App",
+        "Run ES Lint",
+        "Run Prettier",
+        "Run Jest Tests"
+      ],
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
Creates a VS Code Workspace file as an entirely optional productivity tool for team members who wish to use VS Code. 

Includes tasks for: 
* Cleaning, building, then running the API functions
* Starting the docker services
* Building, testing and running the existing NextJS frontend
* Building, linting, formatting and running the new NextJS frontend we're about to start building. Naturally, running these tasks will fail until we've added this.

The workspace also includes a few local setting overrides, such as using prettier as the formatter for typescript files and enabling Format on Save. 