### PR TITLE
APPT - Ad Hoc - Formatter Line Endings

### DIFF
--- a/nbs-ams.code-workspace
+++ b/nbs-ams.code-workspace
@@ -30,7 +30,8 @@
     },
     "editor.formatOnSave": true,
     "editor.formatOnPaste": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "prettier.endOfLine": "crlf"
   },
   "extensions": {
     "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]

--- a/src/new-client/.prettierrc
+++ b/src/new-client/.prettierrc
@@ -1,6 +1,6 @@
 {
   "arrowParens": "avoid",
-  "endOfLine": "lf",
+  "endOfLine": "crlf",
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all"


### PR DESCRIPTION
Configure both prettier and the VS Code workspace to use CRLF line endings, rather than LF. 