### PR TITLE
APPT-XXXX: Update usage of userEvent according to latest docs

### DIFF
--- a/src/new-client/src/app/home-page.test.tsx
+++ b/src/new-client/src/app/home-page.test.tsx
@@ -1,6 +1,6 @@
 import { HomePage } from './home-page';
 import { render, screen } from '@testing-library/react';
-import { mockSites } from './testing/data';
+import { mockSites } from '@testing/data';
 
 describe('Home Page', () => {
   it('should render the home page', () => {

--- a/src/new-client/src/app/site/[site]/site-page.test.tsx
+++ b/src/new-client/src/app/site/[site]/site-page.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { SitePage } from './site-page';
-import { mockSites } from '../../testing/data';
+import { mockSites } from '@testing/data';
 
 describe('Site Page', () => {
   it('should render the appropriate site information', async () => {

--- a/src/new-client/src/app/site/[site]/users/manage/assign-roles-form.test.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/assign-roles-form.test.tsx
@@ -3,7 +3,7 @@ import AssignRolesForm from './assign-roles-form';
 import { RoleAssignment } from '@types';
 import { useRouter } from 'next/navigation';
 import userEvent from '@testing-library/user-event';
-import { mockRoles } from '../../../../testing/data';
+import { mockRoles } from '@testing/data';
 import * as appointmentsService from '@services/appointmentsService';
 
 jest.mock('next/navigation');

--- a/src/new-client/src/app/site/[site]/users/manage/assign-roles.test.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/assign-roles.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import AssignRoles from './assign-roles';
 import { Role, RoleAssignment, User } from '@types';
-import { getMockUserAssignments, mockRoles } from '../../../../testing/data';
+import { getMockUserAssignments, mockRoles } from '@testing/data';
 import { fetchRoles, fetchUsers } from '@services/appointmentsService';
 
 jest.mock('./assign-roles-form', () => {

--- a/src/new-client/src/app/site/[site]/users/manage/find-user-form.test.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/find-user-form.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
 import FindUserForm from './find-user-form';
 import { usePathname, useRouter } from 'next/navigation';
+import render from '@testing/render';
 
 jest.mock('next/navigation');
 
@@ -17,9 +17,9 @@ describe('FindUserForm', () => {
     });
   });
   it('shows a validation error when no data is submitted', async () => {
-    render(<FindUserForm site="TEST" />);
+    const { user } = render(<FindUserForm site="TEST" />);
     const searchButton = screen.getByRole('button', { name: 'Search user' });
-    await userEvent.click(searchButton);
+    await user.click(searchButton);
 
     expect(
       await screen.findByText('You have not entered a valid NHS email address'),
@@ -27,15 +27,15 @@ describe('FindUserForm', () => {
   });
 
   it('shows a validation error when an none nhs.net email address is submitted', async () => {
-    render(<FindUserForm site="TEST" />);
+    const { user } = render(<FindUserForm site="TEST" />);
 
     const searchButton = screen.getByRole('button', { name: 'Search user' });
     const emailInput = screen.getByRole('textbox', {
       name: 'enter an email address',
     });
 
-    await userEvent.type(emailInput, 'test@test.com');
-    await userEvent.click(searchButton);
+    await user.type(emailInput, 'test@test.com');
+    await user.click(searchButton);
 
     expect(
       await screen.findByText('You have not entered a valid NHS email address'),
@@ -43,24 +43,24 @@ describe('FindUserForm', () => {
   });
 
   it('takes the user to the main user page when they cancel', async () => {
-    render(<FindUserForm site="TEST" />);
+    const { user } = render(<FindUserForm site="TEST" />);
 
     const cancelButton = screen.getByRole('button', { name: 'cancel' });
-    await userEvent.click(cancelButton);
+    await user.click(cancelButton);
 
     expect(mockReplace).toHaveBeenCalledWith('/site/TEST/users');
   });
 
   it('initiates the user edit when a valid email address is submitted', async () => {
-    render(<FindUserForm site="TEST" />);
+    const { user } = render(<FindUserForm site="TEST" />);
 
     const searchButton = screen.getByRole('button', { name: 'Search user' });
     const emailInput = screen.getByRole('textbox', {
       name: 'enter an email address',
     });
 
-    await userEvent.type(emailInput, 'test@nhs.net');
-    await userEvent.click(searchButton);
+    await user.type(emailInput, 'test@nhs.net');
+    await user.click(searchButton);
 
     expect(
       await screen.queryByText(

--- a/src/new-client/src/app/site/[site]/users/users-page.test.tsx
+++ b/src/new-client/src/app/site/[site]/users/users-page.test.tsx
@@ -1,6 +1,6 @@
 ﻿import { render, screen, waitFor } from '@testing-library/react';
 import { UsersPage } from './users-page';
-import { getMockUserAssignments, mockRoles } from '../../../testing/data';
+import { getMockUserAssignments, mockRoles } from '@testing/data';
 
 const mockSiteId = 'TEST';
 

--- a/src/new-client/src/app/testing/render.ts
+++ b/src/new-client/src/app/testing/render.ts
@@ -1,0 +1,14 @@
+import { render as baseRender, RenderResult } from '@testing-library/react';
+import userEvent, { UserEvent } from '@testing-library/user-event';
+import { ReactNode } from 'react';
+
+export interface CustomRenderResult extends RenderResult {
+  user: UserEvent;
+}
+
+export default function render(component: ReactNode): CustomRenderResult {
+  return {
+    ...(baseRender(component) as RenderResult),
+    user: userEvent.setup(),
+  };
+}

--- a/src/new-client/tsconfig.json
+++ b/src/new-client/tsconfig.json
@@ -23,7 +23,8 @@
         "./src/app/lib/components/nhsuk-frontend/index"
       ],
       "@types": ["./src/app/lib/types/index"],
-      "@services/*": ["./src/app/lib/services/*"]
+      "@services/*": ["./src/app/lib/services/*"],
+      "@testing/*": ["./src/app/testing/*"]
     }
   },
   "include": [


### PR DESCRIPTION
The documentation for React Testing Library changed last year and now has a slightly different pattern for how you should invoke `userEvent`. It now wants you call a `setup()` method and obtain a `user` object, from which the type/click etc. methods can be called. 

To make this change more seamless, I've created a wrapper around the `render` method which calls `setup()` for us and allows us to destructure `user` for future use. 

For the mentioned change of usage please see:
https://testing-library.com/docs/user-event/intro
https://testing-library.com/docs/user-event/setup