### PR TITLE
Add dev variable group to dev stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,9 +169,9 @@ stages:
             condition: succeededOrFailed()
 
   - stage: DeployDev
-    condition: succeeded()
+    condition: and(succeeded(), eq(variables.isMain, true))
     variables:
-      - group: 'nbs-ems-dev'
+      - group: 'nbs-ams-dev'
     displayName: Deploy Dev
     jobs:
       - job: RunTerraformPlan

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,7 +169,9 @@ stages:
             condition: succeededOrFailed()
 
   - stage: DeployDev
-    condition: and(succeeded(), eq(variables.isMain, true))
+    condition: succeeded()
+    variables:
+      - group: 'nbs-ems-dev'
     displayName: Deploy Dev
     jobs:
       - job: RunTerraformPlan


### PR DESCRIPTION
- Explicitly lists dev variable group for dev deploy stage to prevent the auth values being overwritten by the EXP variable group which was added as part of the user testing deployment.