### PR TITLE
APPT-166: React Hook Form and NHS UK Frontend component pattern

### DIFF
--- a/src/new-client/src/app/lib/components/nhsuk-frontend/button-group.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/button-group.test.tsx
@@ -1,0 +1,23 @@
+import { Button, ButtonGroup } from '@nhsuk-frontend-components';
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+
+describe('ButtonGroup', () => {
+  it('renders', () => {
+    render(
+      <ButtonGroup>
+        <Button>Click Me (one)</Button>
+        <Button>Click Me (two)</Button>
+      </ButtonGroup>,
+    );
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Click Me (one)' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Click Me (two)' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/button-group.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/button-group.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ReactNode, Children } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+const ButtonGroup = ({ children }: Props) => {
+  const childrenArray = Children.toArray(children);
+
+  return (
+    <ol className="nhsuk-list nhsuk-u-clear nhsuk-u-margin-0">
+      {childrenArray.map((child, index) => {
+        return (
+          <li
+            key={`button-list-${index}`}
+            className="nhsuk-u-margin-bottom-0 nhsuk-u-float-left nhsuk-u-margin-right-3 nhsuk-a-to-z-min-width"
+          >
+            {child}
+          </li>
+        );
+      })}
+    </ol>
+  );
+};
+
+export default ButtonGroup;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/button.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/button.test.tsx
@@ -1,0 +1,40 @@
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+import { Button } from '@nhsuk-frontend-components';
+
+describe('Button', () => {
+  it('renders', () => {
+    render(<Button>Click me!</Button>);
+
+    expect(
+      screen.getByRole('button', { name: 'Click me!' }),
+    ).toBeInTheDocument();
+  });
+
+  it('accepts an onClick handler', async () => {
+    const onClick = jest.fn();
+    const { user } = render(<Button onClick={onClick}>Click me!</Button>);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it.each([
+    { type: 'primary', expectedClass: 'nhsuk-button' },
+    { type: 'secondary', expectedClass: 'nhsuk-button--secondary' },
+    { type: 'reverse', expectedClass: 'nhsuk-button--reverse' },
+    { type: 'warning', expectedClass: 'nhsuk-button--warning' },
+  ])(
+    'uses the appropriate class for button type $type',
+    ({ type, expectedClass }) => {
+      render(
+        <Button type={type as 'primary' | 'secondary' | 'reverse' | 'warning'}>
+          Click me!
+        </Button>,
+      );
+
+      expect(screen.getByRole('button')).toHaveClass(expectedClass);
+    },
+  );
+});

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/button.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/button.test.tsx
@@ -29,7 +29,9 @@ describe('Button', () => {
     'uses the appropriate class for button type $type',
     ({ type, expectedClass }) => {
       render(
-        <Button type={type as 'primary' | 'secondary' | 'reverse' | 'warning'}>
+        <Button
+          styleType={type as 'primary' | 'secondary' | 'reverse' | 'warning'}
+        >
           Click me!
         </Button>,
       );

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/button.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/button.tsx
@@ -1,0 +1,41 @@
+import { HTMLProps } from 'react';
+
+type ButtonType = 'primary' | 'secondary' | 'reverse' | 'warning';
+
+type Props = HTMLProps<HTMLButtonElement> & {
+  type?: ButtonType;
+};
+
+/**
+ * A button component adhering to the NHS UK Frontend design system.
+ * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
+ * @see https://service-manual.nhs.uk/design-system/components/buttons
+ */
+const Button = ({ type = 'primary', onClick, children }: Props) => {
+  return (
+    <button
+      className={getClassForType(type)}
+      data-module="nhsuk-button"
+      type="submit"
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+const getClassForType = (type: ButtonType): string => {
+  switch (type) {
+    case 'secondary':
+      return 'nhsuk-button nhsuk-button--secondary';
+    case 'reverse':
+      return 'nhsuk-button nhsuk-button--reverse';
+    case 'warning':
+      return 'nhsuk-button nhsuk-button--warning';
+    case 'primary':
+    default:
+      return 'nhsuk-button';
+  }
+};
+
+export default Button;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/button.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/button.tsx
@@ -1,9 +1,10 @@
 import { HTMLProps } from 'react';
 
-type ButtonType = 'primary' | 'secondary' | 'reverse' | 'warning';
+type ButtonStyleType = 'primary' | 'secondary' | 'reverse' | 'warning';
 
 type Props = HTMLProps<HTMLButtonElement> & {
-  type?: ButtonType;
+  styleType?: ButtonStyleType;
+  type?: 'submit' | 'reset' | 'button';
 };
 
 /**
@@ -11,20 +12,28 @@ type Props = HTMLProps<HTMLButtonElement> & {
  * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
  * @see https://service-manual.nhs.uk/design-system/components/buttons
  */
-const Button = ({ type = 'primary', onClick, children }: Props) => {
+const Button = ({
+  styleType = 'primary',
+  onClick,
+  children,
+  type = 'button',
+  ...rest
+}: Props) => {
   return (
     <button
-      className={getClassForType(type)}
+      className={getClassForType(styleType)}
       data-module="nhsuk-button"
-      type="submit"
       onClick={onClick}
+      type={type}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...rest}
     >
       {children}
     </button>
   );
 };
 
-const getClassForType = (type: ButtonType): string => {
+const getClassForType = (type: ButtonStyleType): string => {
   switch (type) {
     case 'secondary':
       return 'nhsuk-button nhsuk-button--secondary';

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/checkbox.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/checkbox.tsx
@@ -2,6 +2,7 @@ import { forwardRef, HTMLProps } from 'react';
 
 type Props = {
   label: string;
+  hint?: string;
 } & HTMLProps<HTMLInputElement>;
 type Ref = HTMLInputElement;
 
@@ -16,12 +17,19 @@ export const CheckBox = forwardRef<Ref, Props>((props, ref) => (
       className="nhsuk-checkboxes__input"
       type="checkbox"
       ref={ref}
+      aria-describedby={props.hint ? `${props.id}-item-hint` : undefined}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     />
     <label className="nhsuk-label nhsuk-checkboxes__label" htmlFor={props.id}>
       {props.label}
     </label>
+    <div
+      className="nhsuk-hint nhsuk-checkboxes__hint"
+      id={`${props.id}-item-hint`}
+    >
+      {props.hint}
+    </div>
   </div>
 ));
 CheckBox.displayName = 'CheckBox';

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/checkbox.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/checkbox.tsx
@@ -1,0 +1,29 @@
+import { forwardRef, HTMLProps } from 'react';
+
+type Props = {
+  label: string;
+} & HTMLProps<HTMLInputElement>;
+type Ref = HTMLInputElement;
+
+/**
+ * A checkbox component adhering to the NHS UK Frontend design system.
+ * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
+ * @see https://service-manual.nhs.uk/design-system/components/checkboxes
+ */
+export const CheckBox = forwardRef<Ref, Props>((props, ref) => (
+  <div className="nhsuk-checkboxes__item">
+    <input
+      className="nhsuk-checkboxes__input"
+      type="checkbox"
+      ref={ref}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    />
+    <label className="nhsuk-label nhsuk-checkboxes__label" htmlFor={props.id}>
+      {props.label}
+    </label>
+  </div>
+));
+CheckBox.displayName = 'CheckBox';
+
+export default CheckBox;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.test.tsx
@@ -1,0 +1,53 @@
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+import { CheckBoxes, CheckBoxProps } from '@nhsuk-frontend-components';
+
+const mockCheckboxes: CheckBoxProps[] = [
+  {
+    prompt: 'Apples',
+    fieldValue: 'apples',
+    fieldId: 'checkbox-1',
+    fieldName: 'apples',
+  },
+  {
+    prompt: 'Oranges',
+    fieldValue: 'oranges',
+    fieldId: 'checkbox-2',
+    fieldName: 'oranges',
+  },
+  {
+    prompt: 'Bananas',
+    fieldValue: 'bananas',
+    fieldId: 'checkbox-3',
+    fieldName: 'bananas',
+  },
+];
+
+describe('Checkboxes', () => {
+  it('renders', () => {
+    render(<CheckBoxes checkboxes={mockCheckboxes} />);
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Apples' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Oranges' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Bananas' }),
+    ).toBeInTheDocument();
+  });
+
+  it('alters input when clicked', async () => {
+    const { user } = render(<CheckBoxes checkboxes={mockCheckboxes} />);
+
+    const checkBoxOne = screen.getByRole('checkbox', { name: 'Apples' });
+
+    expect(checkBoxOne).not.toBeChecked();
+    await user.click(checkBoxOne);
+    expect(checkBoxOne).toBeChecked();
+
+    await user.click(checkBoxOne);
+    expect(checkBoxOne).not.toBeChecked();
+  });
+});

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.test.tsx
@@ -1,31 +1,16 @@
 import render from '@testing/render';
 import { screen } from '@testing-library/react';
-import { CheckBoxes, CheckBoxProps } from '@nhsuk-frontend-components';
-
-const mockCheckboxes: CheckBoxProps[] = [
-  {
-    prompt: 'Apples',
-    fieldValue: 'apples',
-    fieldId: 'checkbox-1',
-    fieldName: 'apples',
-  },
-  {
-    prompt: 'Oranges',
-    fieldValue: 'oranges',
-    fieldId: 'checkbox-2',
-    fieldName: 'oranges',
-  },
-  {
-    prompt: 'Bananas',
-    fieldValue: 'bananas',
-    fieldId: 'checkbox-3',
-    fieldName: 'bananas',
-  },
-];
+import { CheckBox, CheckBoxes } from '@nhsuk-frontend-components';
 
 describe('Checkboxes', () => {
   it('renders', () => {
-    render(<CheckBoxes checkboxes={mockCheckboxes} />);
+    render(
+      <CheckBoxes>
+        <CheckBox label={'Apples'} value={'apples'} id="apples"></CheckBox>
+        <CheckBox label={'Oranges'} value={'oranges'} id="oranges"></CheckBox>
+        <CheckBox label={'Bananas'} value={'bananas'} id="bananas"></CheckBox>
+      </CheckBoxes>,
+    );
 
     expect(
       screen.getByRole('checkbox', { name: 'Apples' }),
@@ -39,7 +24,13 @@ describe('Checkboxes', () => {
   });
 
   it('alters input when clicked', async () => {
-    const { user } = render(<CheckBoxes checkboxes={mockCheckboxes} />);
+    const { user } = render(
+      <CheckBoxes>
+        <CheckBox label={'Apples'} value={'apples'} id="apples"></CheckBox>
+        <CheckBox label={'Oranges'} value={'oranges'} id="oranges"></CheckBox>
+        <CheckBox label={'Bananas'} value={'bananas'} id="bananas"></CheckBox>
+      </CheckBoxes>,
+    );
 
     const checkBoxOne = screen.getByRole('checkbox', { name: 'Apples' });
 

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.tsx
@@ -1,0 +1,52 @@
+export type CheckBoxProps = {
+  fieldValue: string;
+  fieldId: string;
+  fieldName: string;
+  prompt: string;
+};
+
+type Props = {
+  checkboxes: CheckBoxProps[];
+};
+
+const CheckBoxes = ({ checkboxes }: Props) => {
+  return (
+    <div className="nhsuk-checkboxes">
+      {checkboxes.map((checkbox, index) => {
+        return (
+          <CheckBox
+            key={`checkbox-item-${index}`}
+            fieldValue={checkbox.fieldValue}
+            fieldId={checkbox.fieldId}
+            fieldName={checkbox.fieldName}
+            prompt={checkbox.prompt}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+const CheckBox = ({
+  fieldValue,
+  fieldId,
+  fieldName,
+  prompt,
+}: CheckBoxProps) => {
+  return (
+    <div className="nhsuk-checkboxes__item">
+      <input
+        className="nhsuk-checkboxes__input"
+        id={fieldId}
+        name={fieldName}
+        type="checkbox"
+        value={fieldValue}
+      />
+      <label className="nhsuk-label nhsuk-checkboxes__label" htmlFor={fieldId}>
+        {prompt}
+      </label>
+    </div>
+  );
+};
+
+export default CheckBoxes;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.tsx
@@ -2,11 +2,6 @@ import { ReactNode } from 'react';
 
 type Props = {
   children: ReactNode;
-  prompt?: {
-    legend: string;
-    hint: string;
-    id: string;
-  };
 };
 
 /**
@@ -14,26 +9,8 @@ type Props = {
  * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
  * @see https://service-manual.nhs.uk/design-system/components/checkboxes
  */
-const CheckBoxes = ({ children, prompt }: Props) => {
-  return (
-    <div className="nhsuk-form-group">
-      <fieldset className="nhsuk-fieldset" aria-describedby={prompt?.id}>
-        {prompt && (
-          <>
-            <legend className="nhsuk-fieldset__legend nhsuk-fieldset__legend--1">
-              <h1 className="nhsuk-fieldset__heading">{prompt.legend}</h1>
-            </legend>
-
-            <div className="nhsuk-hint" id={prompt.id}>
-              {prompt.hint}
-            </div>
-          </>
-        )}
-
-        <div className="nhsuk-checkboxes">{children}</div>
-      </fieldset>
-    </div>
-  );
+const CheckBoxes = ({ children }: Props) => {
+  return <div className="nhsuk-checkboxes">{children}</div>;
 };
 
 export default CheckBoxes;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/checkboxes.tsx
@@ -1,50 +1,37 @@
-export type CheckBoxProps = {
-  fieldValue: string;
-  fieldId: string;
-  fieldName: string;
-  prompt: string;
-};
+import { ReactNode } from 'react';
 
 type Props = {
-  checkboxes: CheckBoxProps[];
+  children: ReactNode;
+  prompt?: {
+    legend: string;
+    hint: string;
+    id: string;
+  };
 };
 
-const CheckBoxes = ({ checkboxes }: Props) => {
+/**
+ * A checkbox component adhering to the NHS UK Frontend design system.
+ * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
+ * @see https://service-manual.nhs.uk/design-system/components/checkboxes
+ */
+const CheckBoxes = ({ children, prompt }: Props) => {
   return (
-    <div className="nhsuk-checkboxes">
-      {checkboxes.map((checkbox, index) => {
-        return (
-          <CheckBox
-            key={`checkbox-item-${index}`}
-            fieldValue={checkbox.fieldValue}
-            fieldId={checkbox.fieldId}
-            fieldName={checkbox.fieldName}
-            prompt={checkbox.prompt}
-          />
-        );
-      })}
-    </div>
-  );
-};
+    <div className="nhsuk-form-group">
+      <fieldset className="nhsuk-fieldset" aria-describedby={prompt?.id}>
+        {prompt && (
+          <>
+            <legend className="nhsuk-fieldset__legend nhsuk-fieldset__legend--1">
+              <h1 className="nhsuk-fieldset__heading">{prompt.legend}</h1>
+            </legend>
 
-const CheckBox = ({
-  fieldValue,
-  fieldId,
-  fieldName,
-  prompt,
-}: CheckBoxProps) => {
-  return (
-    <div className="nhsuk-checkboxes__item">
-      <input
-        className="nhsuk-checkboxes__input"
-        id={fieldId}
-        name={fieldName}
-        type="checkbox"
-        value={fieldValue}
-      />
-      <label className="nhsuk-label nhsuk-checkboxes__label" htmlFor={fieldId}>
-        {prompt}
-      </label>
+            <div className="nhsuk-hint" id={prompt.id}>
+              {prompt.hint}
+            </div>
+          </>
+        )}
+
+        <div className="nhsuk-checkboxes">{children}</div>
+      </fieldset>
     </div>
   );
 };

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/fieldset.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/fieldset.test.tsx
@@ -1,0 +1,19 @@
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+import { Fieldset } from '@nhsuk-frontend-components';
+
+describe('Fieldset', () => {
+  it('renders', () => {
+    render(
+      <Fieldset legend="What is your address?">
+        <div>Some inner content</div>
+      </Fieldset>,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'What is your address?' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Some inner content')).toBeInTheDocument();
+  });
+});

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/fieldset.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/fieldset.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+
+type Props = {
+  legend: string;
+  children: ReactNode;
+};
+
+/**
+ * A fieldset component adhering to the NHS UK Frontend design system.
+ * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
+ * @see https://service-manual.nhs.uk/design-system/components/fieldset
+ */
+const FieldSet = ({ legend, children }: Props) => {
+  return (
+    <fieldset className="nhsuk-fieldset">
+      <legend className="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+        <h1 className="nhsuk-fieldset__heading">{legend}</h1>
+      </legend>
+
+      {children}
+    </fieldset>
+  );
+};
+
+export default FieldSet;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/form-group.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/form-group.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from 'react';
+import FieldSet from './fieldset';
+
+type Props = {
+  children: ReactNode;
+  error?: string;
+  legend?: string;
+};
+
+const FormGroup = ({ children, error, legend }: Props) => {
+  return (
+    <div
+      className={`nhsuk-form-group ${error ? 'nhsuk-form-group--error' : ''}`}
+    >
+      {legend ? (
+        <FieldSet legend={legend}>
+          {error && (
+            <span className="nhsuk-error-message">
+              <span className="nhsuk-u-visually-hidden">Error: </span>
+              {error}
+            </span>
+          )}
+          {children}
+        </FieldSet>
+      ) : (
+        <>
+          {error && (
+            <span className="nhsuk-error-message">
+              <span className="nhsuk-u-visually-hidden">Error: </span>
+              {error}
+            </span>
+          )}
+          {children}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default FormGroup;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -2,19 +2,21 @@ import Breadcrumbs, { Breadcrumb } from './breadcrumbs';
 import Button from './button';
 import Header from './header';
 import NhsLogo from './icons/nhs-logo';
+import CheckBoxes, { CheckBoxProps } from './checkboxes';
 import Card from './card';
 import RightChevron from './icons/right-chevron';
 import Table from './table';
 import TextInput from './text-input';
 import WarningCallout from './warning-callout';
 
-export type { Breadcrumb };
+export type { Breadcrumb, CheckBoxProps };
 export {
   Breadcrumbs,
   Button,
+  Card,
+  CheckBoxes,
   Header,
   NhsLogo,
-  Card,
   RightChevron,
   Table,
   TextInput,

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -1,5 +1,6 @@
 import Breadcrumbs, { Breadcrumb } from './breadcrumbs';
 import Button from './button';
+import Fieldset from './fieldset';
 import Header from './header';
 import NhsLogo from './icons/nhs-logo';
 import CheckBox from './checkbox';
@@ -16,6 +17,7 @@ export type { Breadcrumb };
 export {
   Breadcrumbs,
   Button,
+  Fieldset,
   Card,
   CheckBox,
   CheckBoxes,

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -2,24 +2,28 @@ import Breadcrumbs, { Breadcrumb } from './breadcrumbs';
 import Button from './button';
 import Header from './header';
 import NhsLogo from './icons/nhs-logo';
-import CheckBoxes, { CheckBoxProps } from './checkboxes';
+import CheckBox from './checkbox';
+import CheckBoxes from './checkboxes';
 import Card from './card';
 import RightChevron from './icons/right-chevron';
 import Select from './select';
 import Table from './table';
+import TextArea from './text-area';
 import TextInput from './text-input';
 import WarningCallout from './warning-callout';
 
-export type { Breadcrumb, CheckBoxProps };
+export type { Breadcrumb };
 export {
   Breadcrumbs,
   Button,
   Card,
+  CheckBox,
   CheckBoxes,
   Header,
   NhsLogo,
   RightChevron,
   Select,
+  TextArea,
   Table,
   TextInput,
   WarningCallout,

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -1,5 +1,6 @@
 import Breadcrumbs, { Breadcrumb } from './breadcrumbs';
 import Button from './button';
+import ButtonGroup from './button-group';
 import Fieldset from './fieldset';
 import FormGroup from './form-group';
 import Header from './header';
@@ -18,6 +19,7 @@ export type { Breadcrumb };
 export {
   Breadcrumbs,
   Button,
+  ButtonGroup,
   Fieldset,
   FormGroup,
   Card,

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -1,6 +1,7 @@
 import Breadcrumbs, { Breadcrumb } from './breadcrumbs';
 import Button from './button';
 import Fieldset from './fieldset';
+import FormGroup from './form-group';
 import Header from './header';
 import NhsLogo from './icons/nhs-logo';
 import CheckBox from './checkbox';
@@ -18,6 +19,7 @@ export {
   Breadcrumbs,
   Button,
   Fieldset,
+  FormGroup,
   Card,
   CheckBox,
   CheckBoxes,

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -5,6 +5,7 @@ import NhsLogo from './icons/nhs-logo';
 import CheckBoxes, { CheckBoxProps } from './checkboxes';
 import Card from './card';
 import RightChevron from './icons/right-chevron';
+import Select from './select';
 import Table from './table';
 import TextInput from './text-input';
 import WarningCallout from './warning-callout';
@@ -18,6 +19,7 @@ export {
   Header,
   NhsLogo,
   RightChevron,
+  Select,
   Table,
   TextInput,
   WarningCallout,

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -1,18 +1,22 @@
 import Breadcrumbs, { Breadcrumb } from './breadcrumbs';
+import Button from './button';
 import Header from './header';
 import NhsLogo from './icons/nhs-logo';
 import Card from './card';
 import RightChevron from './icons/right-chevron';
 import Table from './table';
+import TextInput from './text-input';
 import WarningCallout from './warning-callout';
 
 export type { Breadcrumb };
 export {
   Breadcrumbs,
+  Button,
   Header,
   NhsLogo,
   Card,
   RightChevron,
   Table,
+  TextInput,
   WarningCallout,
 };

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/select.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/select.test.tsx
@@ -1,0 +1,27 @@
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+import { Select } from '@nhsuk-frontend-components';
+
+const mockOptions = [
+  { value: 'apples', label: 'Apples' },
+  { value: 'oranges', label: 'Oranges' },
+  { value: 'bananas', label: 'Bananas' },
+];
+
+describe('Select', () => {
+  it('renders', () => {
+    render(<Select options={mockOptions} />);
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('allows the user to select an option', async () => {
+    const { user } = render(<Select options={mockOptions} />);
+
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement).toHaveValue('apples');
+
+    await user.selectOptions(selectElement, 'oranges');
+    expect(selectElement).toHaveValue('oranges');
+  });
+});

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/select.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/select.test.tsx
@@ -10,13 +10,17 @@ const mockOptions = [
 
 describe('Select', () => {
   it('renders', () => {
-    render(<Select options={mockOptions} />);
+    render(
+      <Select label="Which fruit would you like?" options={mockOptions} />,
+    );
 
     expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
 
   it('allows the user to select an option', async () => {
-    const { user } = render(<Select options={mockOptions} />);
+    const { user } = render(
+      <Select label="Which fruit would you like?" options={mockOptions} />,
+    );
 
     const selectElement = screen.getByRole('combobox');
     expect(selectElement).toHaveValue('apples');

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/select.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/select.tsx
@@ -1,0 +1,41 @@
+import { HTMLProps } from 'react';
+
+type Option = {
+  value: string;
+  label: string;
+};
+
+type Props = HTMLProps<HTMLSelectElement> & {
+  options: Option[];
+};
+
+/**
+ * A select component adhering to the NHS UK Frontend design system.
+ * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
+ * @see https://service-manual.nhs.uk/design-system/components/select
+ */
+const Select = ({ options, ...rest }: Props) => {
+  return (
+    <div className="nhsuk-form-group">
+      <label className="nhsuk-label" htmlFor="select-1">
+        Label text goes here
+      </label>
+
+      <select
+        className="nhsuk-select"
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
+      >
+        {options.map((option, index) => {
+          return (
+            <option key={index} value={option.value}>
+              {option.label}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+};
+
+export default Select;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/select.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/select.tsx
@@ -1,41 +1,44 @@
-import { HTMLProps } from 'react';
+import { forwardRef, HTMLProps } from 'react';
 
 type Option = {
   value: string;
   label: string;
 };
 
-type Props = HTMLProps<HTMLSelectElement> & {
-  options: Option[];
-};
+type Props = {
+  label: string;
+  options?: Option[];
+} & HTMLProps<HTMLSelectElement>;
+type Ref = HTMLSelectElement;
 
 /**
  * A select component adhering to the NHS UK Frontend design system.
  * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
  * @see https://service-manual.nhs.uk/design-system/components/select
  */
-const Select = ({ options, ...rest }: Props) => {
-  return (
-    <div className="nhsuk-form-group">
-      <label className="nhsuk-label" htmlFor="select-1">
-        Label text goes here
-      </label>
+export const Select = forwardRef<Ref, Props>((props, ref) => (
+  <div className="nhsuk-form-group">
+    <label className="nhsuk-label" htmlFor={props.id}>
+      {props.label}
+    </label>
 
-      <select
-        className="nhsuk-select"
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...rest}
-      >
-        {options.map((option, index) => {
-          return (
-            <option key={index} value={option.value}>
-              {option.label}
-            </option>
-          );
-        })}
-      </select>
-    </div>
-  );
-};
+    <select
+      className="nhsuk-select"
+      ref={ref}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    >
+      {props.options?.map((option, index) => {
+        return (
+          <option key={index} value={option.value}>
+            {option.label}
+          </option>
+        );
+      })}
+      {props.children}
+    </select>
+  </div>
+));
+Select.displayName = 'Select';
 
 export default Select;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/text-area.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/text-area.test.tsx
@@ -1,11 +1,11 @@
 import { screen } from '@testing-library/react';
 import render from '../../../testing/render';
-import { TextInput } from '@nhsuk-frontend-components';
+import { TextArea } from '@nhsuk-frontend-components';
 
-describe('Text Input', () => {
+describe('Text Area', () => {
   it('renders', () => {
     render(
-      <TextInput
+      <TextArea
         id={'123'}
         name={'test-field'}
         label={'Enter some text, please:'}
@@ -19,7 +19,7 @@ describe('Text Input', () => {
 
   it('permits user input', async () => {
     const { user } = render(
-      <TextInput
+      <TextArea
         id={'123'}
         name={'test-field'}
         label={'Enter some text, please:'}

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/text-area.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/text-area.tsx
@@ -2,28 +2,29 @@ import { forwardRef, HTMLProps } from 'react';
 
 type Props = {
   label: string;
-} & HTMLProps<HTMLInputElement>;
-type Ref = HTMLInputElement;
+} & HTMLProps<HTMLTextAreaElement>;
+type Ref = HTMLTextAreaElement;
 
 /**
- * A text input component adhering to the NHS UK Frontend design system.
+ * A text area component adhering to the NHS UK Frontend design system.
  * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
- * @see https://service-manual.nhs.uk/design-system/components/text-input
+ * @see https://service-manual.nhs.uk/design-system/components/text-area
  */
-export const TextInput = forwardRef<Ref, Props>((props, ref) => (
+export const TextArea = forwardRef<Ref, Props>((props, ref) => (
   <div className="nhsuk-form-group">
     <label className="nhsuk-label" htmlFor={props.id}>
       {props.label}
     </label>
-    <input
-      className="nhsuk-input"
+    <textarea
+      className="nhsuk-textarea"
       type="text"
       ref={ref}
+      rows={props.rows ?? 5}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     />
   </div>
 ));
-TextInput.displayName = 'TextInput';
+TextArea.displayName = 'TextArea';
 
-export default TextInput;
+export default TextArea;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/text-input.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/text-input.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from '@testing-library/react';
+import render from '../../../testing/render';
+import { TextInput } from '@nhsuk-frontend-components';
+
+describe('Text Input', () => {
+  it('renders', () => {
+    render(
+      <TextInput
+        fieldId={'123'}
+        fieldName={'test-field'}
+        prompt={'Enter some text, please:'}
+      />,
+    );
+
+    expect(
+      screen.getByRole('textbox', { name: 'Enter some text, please:' }),
+    ).toBeInTheDocument();
+  });
+
+  it('permits user input', async () => {
+    const { user } = render(
+      <TextInput
+        fieldId={'123'}
+        fieldName={'test-field'}
+        prompt={'Enter some text, please:'}
+      />,
+    );
+
+    const inputElement = screen.getByRole('textbox', {
+      name: /enter some text, please:/i,
+    });
+
+    await user.type(inputElement, 'some mock user input');
+
+    expect(inputElement).toHaveValue('some mock user input');
+  });
+});

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/text-input.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/text-input.tsx
@@ -1,0 +1,23 @@
+type Props = {
+  fieldId: string;
+  fieldName: string;
+  prompt: string;
+};
+
+const TextInput = ({ prompt, fieldId, fieldName }: Props) => {
+  return (
+    <div className="nhsuk-form-group">
+      <label className="nhsuk-label" htmlFor={fieldId}>
+        {prompt}
+      </label>
+      <input
+        className="nhsuk-input"
+        id={fieldId}
+        name={fieldName}
+        type="text"
+      />
+    </div>
+  );
+};
+
+export default TextInput;

--- a/src/new-client/src/app/site/[site]/users/manage/assign-roles-form.test.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/assign-roles-form.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import AssignRolesForm from './assign-roles-form';
 import { RoleAssignment } from '@types';
 import { useRouter } from 'next/navigation';
-import userEvent from '@testing-library/user-event';
 import { mockRoles } from '@testing/data';
+import render from '@testing/render';
 import * as appointmentsService from '@services/appointmentsService';
 
 jest.mock('next/navigation');
@@ -51,7 +51,7 @@ describe('Assign Roles Form', () => {
     expect(screen.getByRole('checkbox', { name: 'Role 3' })).toBeChecked();
   });
   it('display a validation error when attempting to submit the form with no roles selected', async () => {
-    render(
+    const { user } = render(
       <AssignRolesForm
         site="TEST"
         user="test@nhs.net"
@@ -59,15 +59,17 @@ describe('Assign Roles Form', () => {
         roles={mockRoles}
       />,
     );
-    const submitButton = screen.getByRole('button', { name: 'save user' });
-    await userEvent.click(submitButton);
+    const submitButton = screen.getByRole('button', {
+      name: 'Confirm and save',
+    });
+    await user.click(submitButton);
 
     expect(
       screen.getByText('You have not selected any roles for this user'),
     ).toBeVisible();
   });
   it('returns the user to the users list when they cancel', async () => {
-    render(
+    const { user } = render(
       <AssignRolesForm
         site="TEST"
         user="test@nhs.net"
@@ -75,13 +77,13 @@ describe('Assign Roles Form', () => {
         roles={mockRoles}
       />,
     );
-    const cancelButton = screen.getByRole('button', { name: 'cancel' });
-    await userEvent.click(cancelButton);
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await user.click(cancelButton);
 
     expect(mockReplace).toHaveBeenCalledWith('/site/TEST/users');
   });
   it('calls the save function when saved', async () => {
-    render(
+    const { user } = render(
       <AssignRolesForm
         site="TEST"
         user="test@nhs.net"
@@ -90,9 +92,9 @@ describe('Assign Roles Form', () => {
       />,
     );
     const checkBox = screen.getByRole('checkbox', { name: 'Role 1' });
-    await userEvent.click(checkBox);
-    const saveButton = screen.getByRole('button', { name: 'save user' });
-    await userEvent.click(saveButton);
+    await user.click(checkBox);
+    const saveButton = screen.getByRole('button', { name: 'Confirm and save' });
+    await user.click(saveButton);
 
     expect(mockSaveUserRoleAssignments).toHaveBeenCalledWith(
       'TEST',

--- a/src/new-client/src/app/site/[site]/users/manage/assign-roles-form.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/assign-roles-form.tsx
@@ -10,6 +10,7 @@ import {
   FormGroup,
   CheckBoxes,
   CheckBox,
+  ButtonGroup,
 } from '@nhsuk-frontend-components';
 
 type FormFields = {
@@ -68,18 +69,12 @@ const AssignRolesForm = ({
         </CheckBoxes>
       </FormGroup>
 
-      <div className="nhsuk-grid-row">
-        <div className="nhsuk-grid-row">
-          <div className="nhsuk-grid-column-one-half">
-            <Button type="submit">Confirm and save</Button>
-          </div>
-          <div className="nhsuk-grid-column-one-half">
-            <Button styleType="secondary" onClick={cancel}>
-              Cancel
-            </Button>
-          </div>
-        </div>
-      </div>
+      <ButtonGroup>
+        <Button type="submit">Confirm and save</Button>
+        <Button styleType="secondary" onClick={cancel}>
+          Cancel
+        </Button>
+      </ButtonGroup>
     </form>
   );
 };

--- a/src/new-client/src/app/site/[site]/users/manage/assign-roles-form.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/assign-roles-form.tsx
@@ -5,6 +5,12 @@ import { SubmitHandler, useForm } from 'react-hook-form';
 import { Role, RoleAssignment } from '@types';
 import { useRouter } from 'next/navigation';
 import { saveUserRoleAssignments } from '@services/appointmentsService';
+import {
+  Button,
+  FormGroup,
+  CheckBoxes,
+  CheckBox,
+} from '@nhsuk-frontend-components';
 
 type FormFields = {
   roles: string[];
@@ -40,64 +46,38 @@ const AssignRolesForm = ({
 
   return (
     <form onSubmit={handleSubmit(submitForm)}>
-      <div
-        className={`nhsuk-form-group ${errors.roles ? 'nhsuk-form-group--error' : ''}`}
+      <FormGroup
+        error={
+          errors.roles
+            ? 'You have not selected any roles for this user'
+            : undefined
+        }
+        legend="Roles"
       >
-        <fieldset className="nhsuk-fieldset">
-          <legend className="nhsuk-fieldset__legend nhsuk-fieldset__legend--m">
-            <h1 className="nhsuk-fieldset__heading">Roles</h1>
-          </legend>
-          {errors.roles && (
-            <span className="nhsuk-error-message">
-              <span className="nhsuk-u-visually-hidden">Error:</span> You have
-              not selected any roles for this user
-            </span>
-          )}
-          <div className="nhsuk-checkboxes">
-            {roles.map(r => (
-              <div key={r.id} className="nhsuk-checkboxes__item">
-                <input
-                  id={r.id}
-                  type="checkbox"
-                  className="nhsuk-checkboxes__input"
-                  value={r.id}
-                  {...register('roles', { required: true })}
-                />
-                <label
-                  htmlFor={r.id}
-                  className="nhsuk-label nhsuk-checkboxes__label"
-                >
-                  {r.displayName}
-                </label>
-                <div
-                  className="nhsuk-hint nhsuk-checkboxes__hint"
-                  id="nationality-1-item-hint"
-                >
-                  {r.description}
-                </div>
-              </div>
-            ))}
-          </div>
-        </fieldset>
-      </div>
+        <CheckBoxes>
+          {roles.map(r => (
+            <CheckBox
+              id={r.id}
+              label={r.displayName}
+              hint={r.description}
+              key={`checkbox-key-${r.id}`}
+              value={r.id}
+              {...register('roles', { required: true })}
+            />
+          ))}
+        </CheckBoxes>
+      </FormGroup>
 
-      <div style={{ marginTop: '20px' }}>
-        <div className="nhsuk-navigation">
-          <button
-            type="submit"
-            aria-label="save user"
-            className="nhsuk-button nhsuk-u-margin-bottom-0"
-          >
-            Confirm and save
-          </button>
-          <button
-            type="button"
-            aria-label="cancel"
-            className="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-3 nhsuk-u-margin-bottom-0"
-            onClick={cancel}
-          >
-            Cancel
-          </button>
+      <div className="nhsuk-grid-row">
+        <div className="nhsuk-grid-row">
+          <div className="nhsuk-grid-column-one-half">
+            <Button type="submit">Confirm and save</Button>
+          </div>
+          <div className="nhsuk-grid-column-one-half">
+            <Button styleType="secondary" onClick={cancel}>
+              Cancel
+            </Button>
+          </div>
         </div>
       </div>
     </form>

--- a/src/new-client/src/app/site/[site]/users/manage/find-user-form.test.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/find-user-form.test.tsx
@@ -31,7 +31,7 @@ describe('FindUserForm', () => {
 
     const searchButton = screen.getByRole('button', { name: 'Search user' });
     const emailInput = screen.getByRole('textbox', {
-      name: 'enter an email address',
+      name: 'Enter an email address',
     });
 
     await user.type(emailInput, 'test@test.com');
@@ -45,7 +45,7 @@ describe('FindUserForm', () => {
   it('takes the user to the main user page when they cancel', async () => {
     const { user } = render(<FindUserForm site="TEST" />);
 
-    const cancelButton = screen.getByRole('button', { name: 'cancel' });
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
     await user.click(cancelButton);
 
     expect(mockReplace).toHaveBeenCalledWith('/site/TEST/users');
@@ -56,7 +56,7 @@ describe('FindUserForm', () => {
 
     const searchButton = screen.getByRole('button', { name: 'Search user' });
     const emailInput = screen.getByRole('textbox', {
-      name: 'enter an email address',
+      name: 'Enter an email address',
     });
 
     await user.type(emailInput, 'test@nhs.net');

--- a/src/new-client/src/app/site/[site]/users/manage/find-user-form.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/find-user-form.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { EMAIL_REGEX } from '../../../../../constants';
+import { TextInput, FormGroup, Button } from '@nhsuk-frontend-components';
 
 type FormFields = {
   email: string;
@@ -37,47 +38,31 @@ const FindUserForm = ({ site }: { site: string }) => {
 
   return (
     <form onSubmit={handleSubmit(submitForm)}>
-      <div
-        className={`nhsuk-form-group ${errors.email ? 'nhsuk-form-group--error' : ''}`}
+      <FormGroup
+        error={
+          errors.email
+            ? 'You have not entered a valid NHS email address'
+            : undefined
+        }
       >
-        <div className="nhsuk-form-group">
-          {errors.email && (
-            <span className="nhsuk-error-message">
-              <span className="nhsuk-u-visually-hidden">Error:</span> You have
-              not entered a valid NHS email address
-            </span>
-          )}
-          <label htmlFor="email" className="nhsuk-label">
-            Email
-          </label>
-          <input
-            id="email"
-            aria-label="enter an email address"
-            className="nhsuk-input nhsuk-input--width-20"
-            type="text"
-            {...register('email', {
-              required: true,
-              pattern: EMAIL_REGEX,
-            })}
-          />
-        </div>
+        <TextInput
+          id="email"
+          label="Enter an email address"
+          {...register('email', {
+            required: true,
+            pattern: EMAIL_REGEX,
+          })}
+        ></TextInput>
+      </FormGroup>
 
-        <div className="nhsuk-navigation">
-          <button
-            type="submit"
-            aria-label="Search user"
-            className="nhsuk-button nhsuk-u-margin-bottom-0"
-          >
-            Search user
-          </button>
-          <button
-            type="button"
-            aria-label="cancel"
-            className="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-left-3 nhsuk-u-margin-bottom-0"
-            onClick={cancel}
-          >
+      <div className="nhsuk-grid-row">
+        <div className="nhsuk-grid-column-one-half">
+          <Button type="submit">Search user</Button>
+        </div>
+        <div className="nhsuk-grid-column-one-quarter">
+          <Button styleType="secondary" onClick={cancel}>
             Cancel
-          </button>
+          </Button>
         </div>
       </div>
     </form>

--- a/src/new-client/src/app/site/[site]/users/manage/find-user-form.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/find-user-form.tsx
@@ -4,7 +4,12 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import React from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { EMAIL_REGEX } from '../../../../../constants';
-import { TextInput, FormGroup, Button } from '@nhsuk-frontend-components';
+import {
+  TextInput,
+  FormGroup,
+  Button,
+  ButtonGroup,
+} from '@nhsuk-frontend-components';
 
 type FormFields = {
   email: string;
@@ -55,16 +60,12 @@ const FindUserForm = ({ site }: { site: string }) => {
         ></TextInput>
       </FormGroup>
 
-      <div className="nhsuk-grid-row">
-        <div className="nhsuk-grid-column-one-half">
-          <Button type="submit">Search user</Button>
-        </div>
-        <div className="nhsuk-grid-column-one-quarter">
-          <Button styleType="secondary" onClick={cancel}>
-            Cancel
-          </Button>
-        </div>
-      </div>
+      <ButtonGroup>
+        <Button type="submit">Search user</Button>
+        <Button styleType="secondary" onClick={cancel}>
+          Cancel
+        </Button>
+      </ButtonGroup>
     </form>
   );
 };


### PR DESCRIPTION
* Creates a raft of nhs-uk styled form components.
* Establishes a pattern for using them with RHF by passing down the `ref` component using React's `forwardRef` feature. 
* Re-factors the Assign Roles Form and Find User Form to use this new pattern
