### PR TITLE
Fix warnings during tests by mocking out form components with server …

### DIFF
--- a/src/new-client/src/app/lib/components/nhs-page.test.tsx
+++ b/src/new-client/src/app/lib/components/nhs-page.test.tsx
@@ -8,6 +8,20 @@ const fetchUserProfileMock = fetchUserProfile as jest.Mock<
   Promise<UserProfile | undefined>
 >;
 
+jest.mock('@components/nhs-header-log-in', () => {
+  const MockNhsHeaderLogIn = () => {
+    return <button type="submit">log in</button>;
+  };
+  return MockNhsHeaderLogIn;
+});
+
+jest.mock('@components/nhs-header-log-out', () => {
+  const MockNhsHeaderLogOut = () => {
+    return <button type="submit">log out</button>;
+  };
+  return MockNhsHeaderLogOut;
+});
+
 describe('Nhs Page', () => {
   beforeEach(() => {
     fetchUserProfileMock.mockResolvedValue({


### PR DESCRIPTION
The Jest tests are currently passing but spitting out a console error from the `NhsPage.test.tsx` suite, because the Log In / Log Out buttons aren't being mocked and we can't currently render form server actions without error. This is possible in the React Canary, so hopefully will be included in future versions of React.

<img width="850" alt="image" src="https://github.com/user-attachments/assets/be82b606-8b58-43b7-91cc-c435a684ec60">
