### PR TITLE
Create Not Found page

### DIFF
--- a/src/new-client/src/app/not-found.tsx
+++ b/src/new-client/src/app/not-found.tsx
@@ -1,0 +1,16 @@
+import NhsPage from '@components/nhs-page';
+import { WarningCallout } from '@components/nhsuk-frontend';
+
+// TODO: Update this page with approved copy
+export default function NotFound() {
+  return (
+    <NhsPage title="Appointment Management Service" omitTitleFromBreadcrumbs>
+      <WarningCallout title="Page not found">
+        <p>
+          The page or resource you're looking for does not exist. Please check
+          the address and try again.
+        </p>
+      </WarningCallout>
+    </NhsPage>
+  );
+}

--- a/src/new-client/testing/not-found.spec.ts
+++ b/src/new-client/testing/not-found.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import NotFoundPage from './page-objects/not-found';
+import RootPage from './page-objects/root';
+import OAuthLoginPage from './page-objects/oauth';
+
+test('Invalid roots yield a styled 404 page', async ({ page }) => {
+  const rootPage = new RootPage(page);
+  const oAuthPage = new OAuthLoginPage(page);
+  await rootPage.goto();
+  await rootPage.logInButton.click();
+  await oAuthPage.signIn();
+
+  await page.goto('/this-route-does-not-exist');
+  const notFoundPage = new NotFoundPage(page);
+
+  await expect(notFoundPage.title).toBeVisible();
+  await expect(notFoundPage.warningCalloutHeading).toBeVisible();
+  await expect(notFoundPage.warningCalloutText).toBeVisible();
+});

--- a/src/new-client/testing/page-objects/not-found.ts
+++ b/src/new-client/testing/page-objects/not-found.ts
@@ -1,0 +1,25 @@
+import { type Locator, type Page } from '@playwright/test';
+import RootPage from './root';
+
+export default class NotFoundPage extends RootPage {
+  readonly title: Locator;
+  readonly warningCalloutHeading: Locator;
+  readonly warningCalloutText: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.title = page.getByRole('heading', {
+      name: 'Appointment Management Service',
+    });
+    this.warningCalloutHeading = page.getByRole('heading', {
+      name: 'Page not found',
+    });
+    this.warningCalloutText = page.getByText(
+      `The page or resource you're looking for does not exist. Please check the address and try again.`,
+    );
+  }
+
+  async selectSite(siteName: string) {
+    await this.page.getByRole('link', { name: siteName }).click();
+  }
+}


### PR DESCRIPTION
NextJS automatically creates a 404 page to serve up for invalid routes

By creating a file called `not-found` within the `app` folder, we can style this to our liking. 

Future PRs -> consider throwing the `notFound()` method from `client.ts` if we receive a 404 from the backend to instantly invoke this page. Also ask Thomas et al for what the text on this page should be

Old page: 
<img width="464" alt="image" src="https://github.com/user-attachments/assets/95aa9dc3-2963-473e-b445-2bbb96fe6e91">

New page:
<img width="622" alt="image" src="https://github.com/user-attachments/assets/e6bc6eea-7ee2-4129-8ad4-76065b30e45f">
