### PR TITLE
Appt 191 192 193 195/UI cleanup

### DIFF
--- a/src/new-client/src/app/global.css
+++ b/src/new-client/src/app/global.css
@@ -1,54 +1,51 @@
-.nhsuk-button--link:hover,
-.nhsuk-header__transactional .header__user-control-link:hover {
-  text-decoration: none;
+.nhsuk-header-custom__user-controls {
+  position: relative;
+  text-align: right;
 }
 
-.nhsuk-button--link:focus,
-.nhsuk-header__transactional .header__user-control-link:focus {
-  background-color: #ffeb3b;
-  box-shadow:
-    0 -2px #ffeb3b,
-    0 4px #212b32;
-  color: #212b32;
-  outline: 4px solid transparent;
-}
-
-.nhsuk-header__container {
-  max-width: 100%;
-  margin: 0 32px;
-}
-
-.nhsuk-header__transactional .header__content {
-  margin-left: auto;
-}
-
-.nhsuk-header__transactional .header__user-control-list {
-  display: flex;
-  column-gap: 2rem;
-  list-style: none;
-  padding-top: 3px;
-  align-items: baseline;
-}
-
-.nhsuk-header__transactional .header__user-control-item {
-  color: #fff;
-}
-
-.nhsuk-header__transactional .header__user-control-link {
+.nhsuk-header-custom__user-control {
   background: none;
-  border: none;
-  color: inherit;
-  text-decoration: underline;
-  cursor: pointer;
+  border: 0;
+  color: #fff;
+  text-decoration: none;
   font-size: 1.1875rem;
+  padding-right: 16px;
+  line-height: normal;
 }
 
-.nhsuk-width-container {
-  margin: 0 auto;
-  max-width: 960px;
+@media (max-width: 40.0625em) {
+  .nhsuk-header-custom__user-control {
+    font-size: 1.1875rem;
+  }
 }
 
-.nhsuk-list--border li:first-of-type {
-  border-top: 1px solid #d8dde0;
-  padding: 16px 0;
+.nhsuk-header-custom__user-control-link {
+  cursor: pointer;
+  padding-inline-start: inherit;
+  padding-inline-end: inherit;
+  padding-block-start: inherit;
+  padding-block-end: inherit;
+}
+
+.nhsuk-header-custom__user-control-link:hover {
+  box-shadow: 'none';
+  text-decoration: underline;
+}
+
+.nhsuk-header-custom__user-control-wrap {
+  text-align: left;
+}
+
+@media (min-width: 40.0625em) {
+  .nhsuk-header-custom__user-control-wrap {
+    display: flex;
+    text-align: right;
+  }
+}
+
+@media (max-width: 40.0525em) {
+  .nhsuk-header-custom__user-control-wrap::after {
+    display: block;
+    text-align: left;
+  }
 }

--- a/src/new-client/src/app/lib/components/log-in-button.tsx
+++ b/src/new-client/src/app/lib/components/log-in-button.tsx
@@ -1,0 +1,14 @@
+import redirectToIdServer from '../../auth/redirectToIdServer';
+import { Button } from '@nhsuk-frontend-components';
+
+const LogInButton = () => {
+  return (
+    <form action={redirectToIdServer.bind(null, undefined)}>
+      <Button aria-label="Sign in to service" type="submit">
+        Sign in to service
+      </Button>
+    </form>
+  );
+};
+
+export default LogInButton;

--- a/src/new-client/src/app/lib/components/nhs-header-log-in.tsx
+++ b/src/new-client/src/app/lib/components/nhs-header-log-in.tsx
@@ -5,7 +5,7 @@ const NhsHeaderLogIn = () => {
     <form action={redirectToIdServer.bind(null, undefined)}>
       <button
         aria-label="log in"
-        className="header__user-control-link"
+        className="nhsuk-header-custom__user-control nhsuk-header-custom__user-control-link"
         type="submit"
       >
         Log in

--- a/src/new-client/src/app/lib/components/nhs-header-log-out.tsx
+++ b/src/new-client/src/app/lib/components/nhs-header-log-out.tsx
@@ -5,7 +5,7 @@ const NhsHeaderLogOut = () => {
     <form action={signOut}>
       <button
         aria-label="log out"
-        className="header__user-control-link"
+        className="nhsuk-header-custom__user-control nhsuk-header-custom__user-control-link"
         type="submit"
       >
         Log out

--- a/src/new-client/src/app/lib/components/nhs-header.tsx
+++ b/src/new-client/src/app/lib/components/nhs-header.tsx
@@ -19,35 +19,11 @@ export const NhsHeader = ({
     <Header>
       <When condition={showAuthControls}>
         <When condition={userEmail !== undefined}>
-          <div className="header__content" id="content-header">
-            <div
-              className="header__user-control"
-              role="navigation"
-              aria-label="Primary navigation"
-            >
-              <ul className="header__user-control-list">
-                <li className="header__user-control-item">{userEmail}</li>
-                <li className="header__user-control-item">
-                  <NhsHeaderLogOut />
-                </li>
-              </ul>
-            </div>
-          </div>
+          <span className="nhsuk-header-custom__user-control">{userEmail}</span>
+          <NhsHeaderLogOut />
         </When>
         <When condition={userEmail === undefined}>
-          <div className="header__content" id="content-header">
-            <div
-              className="header__user-control"
-              role="navigation"
-              aria-label="Primary navigation"
-            >
-              <ul className="header__user-control-list">
-                <li className="header__user-control-item">
-                  <NhsHeaderLogIn />
-                </li>
-              </ul>
-            </div>
-          </div>
+          <NhsHeaderLogIn />
         </When>
       </When>
     </Header>

--- a/src/new-client/src/app/lib/components/nhs-page.tsx
+++ b/src/new-client/src/app/lib/components/nhs-page.tsx
@@ -48,13 +48,15 @@ const NhsPage = async ({
         </main>
       </div>
       <Footer
-        supportLinks={[
-          { text: 'Accessibility statement', href: '/accessibility-statement' },
-          { text: 'Contact us', href: '/contact-us' },
-          { text: 'Cookies', href: '/cookies' },
-          { text: 'Privacy policy', href: '/privacy-policy' },
-          { text: 'Terms and conditions', href: '/terms-and-conditions' },
-        ]}
+        supportLinks={
+          [
+            // { text: 'Accessibility statement', href: '/accessibility-statement' },
+            // { text: 'Contact us', href: '/contact-us' },
+            // { text: 'Cookies', href: '/cookies' },
+            // { text: 'Privacy policy', href: '/privacy-policy' },
+            // { text: 'Terms and conditions', href: '/terms-and-conditions' },
+          ]
+        }
       />
     </>
   );

--- a/src/new-client/src/app/lib/components/nhs-page.tsx
+++ b/src/new-client/src/app/lib/components/nhs-page.tsx
@@ -1,11 +1,8 @@
-import {
-  Breadcrumbs,
-  Breadcrumb,
-  WarningCallout,
-} from '@nhsuk-frontend-components';
+import { Breadcrumbs, Breadcrumb, Footer } from '@nhsuk-frontend-components';
 import { ReactNode } from 'react';
 import { NhsHeader } from './nhs-header';
 import { fetchUserProfile } from '@services/appointmentsService';
+import LogInButton from './log-in-button';
 
 type Props = {
   title: string;
@@ -30,33 +27,35 @@ const NhsPage = async ({
           ...(!omitTitleFromBreadcrumbs ? [{ name: title }] : []),
         ]}
       />
-      <div className="nhsuk-width-container app-width-container">
-        <main
-          className="govuk-main-wrapper app-main-wrapper"
-          id="main-content"
-          role="main"
-        >
+      <div className="nhsuk-width-container">
+        <main className="nhsuk-main-wrapper" id="main-content" role="main">
           <div className="nhsuk-grid-row">
-            <div className="nhsuk-grid-column-full app-component-reading-width">
-              <div className="app-pane">
-                <div className="app-pane__main-content">
-                  <h1 className="app-page-heading">{title}</h1>
-                  {userProfile === undefined ? (
-                    <WarningCallout title="You cannot access this site">
-                      <p>
-                        You are currently not signed in. To use this site,
-                        please sign in.
-                      </p>
-                    </WarningCallout>
-                  ) : (
-                    children
-                  )}
-                </div>
-              </div>
+            <div className="nhsuk-grid-column-full">
+              <h1 className="app-page-heading">{title}</h1>
+              {userProfile === undefined ? (
+                <>
+                  <p>
+                    You are currently not signed in. You must sign in to access
+                    this service.
+                  </p>
+                  <LogInButton />
+                </>
+              ) : (
+                children
+              )}
             </div>
           </div>
         </main>
       </div>
+      <Footer
+        supportLinks={[
+          { text: 'Accessibility statement', href: '/accessibility-statement' },
+          { text: 'Contact us', href: '/contact-us' },
+          { text: 'Cookies', href: '/cookies' },
+          { text: 'Privacy policy', href: '/privacy-policy' },
+          { text: 'Terms and conditions', href: '/terms-and-conditions' },
+        ]}
+      />
     </>
   );
 };

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/breadcrumbs.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/breadcrumbs.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { Breadcrumb, Breadcrumbs } from '@nhsuk-frontend-components';
 
 const breadcrumbTrail: Breadcrumb[] = [
+  { name: 'Home', href: '/' },
   { name: 'Page 1', href: '/page1' },
   { name: 'Page 2', href: '/page1/page2' },
   { name: 'Page 3' },
@@ -14,16 +15,6 @@ describe('NHSBreadcrumbs', () => {
     expect(
       screen.getByRole('navigation', { name: 'Breadcrumb' }),
     ).toBeInTheDocument();
-  });
-
-  it('always renders the home crumb by default', () => {
-    render(<Breadcrumbs />);
-
-    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute(
-      'href',
-      '/',
-    );
   });
 
   it('constructs a trail of breadcrumbs', () => {
@@ -60,7 +51,9 @@ describe('NHSBreadcrumbs', () => {
   });
 
   it('renders an invisible back to home button if only one page away from home', () => {
-    render(<Breadcrumbs trail={[{ name: 'Page 1' }]} />);
+    render(
+      <Breadcrumbs trail={[{ name: 'Home', href: '/' }, { name: 'Page 1' }]} />,
+    );
     expect(screen.getByRole('link', { name: /Back to Home/ })).toHaveAttribute(
       'href',
       '/',

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/breadcrumbs.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/breadcrumbs.tsx
@@ -16,16 +16,13 @@ type Props = {
  * @see https://service-manual.nhs.uk/design-system/components/breadcrumbs
  */
 const Breadcrumbs = ({ trail = [] }: Props) => {
-  const trailWithHome = [{ name: 'Home', href: '/' }, ...trail];
-
-  const previousCrumb =
-    trailWithHome.length > 1 ? trailWithHome.slice(-2)[0] : undefined;
+  const previousCrumb = trail.length > 1 ? trail.slice(-2)[0] : undefined;
 
   return (
     <nav className="nhsuk-breadcrumb" aria-label="Breadcrumb">
       <div className="nhsuk-width-container">
-        <ol className="nhsuk-breadcrumbs__list">
-          {trailWithHome.map((breadcrumb, index) => {
+        <ol className="nhsuk-breadcrumb__list">
+          {trail.map((breadcrumb, index) => {
             return (
               <li
                 key={`$breadcrumb_${index}`}

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/footer.test.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/footer.test.tsx
@@ -1,0 +1,21 @@
+import { Footer } from '@nhsuk-frontend-components';
+import { screen } from '@testing-library/react';
+import render from '@testing/render';
+
+describe('Footer', () => {
+  it('renders', () => {
+    render(
+      <Footer supportLinks={[{ text: 'Contact us', href: '/contact-us' }]} />,
+    );
+
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: 'Contact us' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Contact us' })).toHaveAttribute(
+      'href',
+      '/contact-us',
+    );
+  });
+});

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/footer.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/footer.tsx
@@ -1,0 +1,44 @@
+type supportLink = {
+  text: string;
+  href: string;
+};
+
+type FooterProps = {
+  supportLinks: supportLink[];
+};
+
+/**
+ * A footer component adhering to the NHS UK Frontend design system.
+ * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
+ * @see https://service-manual.nhs.uk/design-system/components/footer
+ */
+const Footer = ({ supportLinks }: FooterProps) => {
+  return (
+    <footer role="contentinfo">
+      <div className="nhsuk-footer-container">
+        <div className="nhsuk-width-container">
+          <h2 className="nhsuk-u-visually-hidden">Support links</h2>
+          <div className="nhsuk-footer">
+            <ul className="nhsuk-footer__list">
+              {supportLinks.map((link, index) => (
+                <li
+                  key={`support-link-${index}`}
+                  className="nhsuk-footer__list-item nhsuk-footer-default__list-item"
+                >
+                  <a className="nhsuk-footer__list-item-link" href={link.href}>
+                    {link.text}
+                  </a>
+                </li>
+              ))}
+            </ul>
+            <div>
+              <p className="nhsuk-footer__copyright">© NHS England</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/header.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/header.tsx
@@ -14,20 +14,32 @@ type Props = {
  */
 const Header = ({ children }: Props) => {
   return (
-    <header className="nhsuk-header nhsuk-header__transactional" role="banner">
+    <header className="nhsuk-header" role="banner">
       <div className="nhsuk-header__container">
-        <div className="nhsuk-header__logo nhsuk-header__transactional--logo">
-          <NhsLogo />
-        </div>
-        <div className="nhsuk-header__transactional-service-name">
+        <div className="nhsuk-header__logo">
           <Link
-            className="nhsuk-header__transactional-service-name--link"
+            className="nhsuk-header__link nhsuk-header__link--service"
             href="/"
+            aria-label="NHS homepage"
           >
-            NHS Appointment Book
+            <NhsLogo />
+
+            <span className="nhsuk-header__service-name">
+              NHS Appointment Book
+            </span>
           </Link>
         </div>
-        {children}
+
+        <div className="nhsuk-header__content" id="content-header">
+          <div className="nhsuk-header-custom__user-controls">
+            <div
+              className="nhsuk-header-custom__user-control-wrap"
+              id="wrap-user-controls"
+            >
+              {children}
+            </div>
+          </div>
+        </div>
       </div>
     </header>
   );

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/header.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/header.tsx
@@ -20,7 +20,7 @@ const Header = ({ children }: Props) => {
           <Link
             className="nhsuk-header__link nhsuk-header__link--service"
             href="/"
-            aria-label="NHS homepage"
+            aria-label="NHS Appointment Book"
           >
             <NhsLogo />
 

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -2,6 +2,7 @@ import Breadcrumbs, { Breadcrumb } from './breadcrumbs';
 import Button from './button';
 import ButtonGroup from './button-group';
 import Fieldset from './fieldset';
+import Footer from './footer';
 import FormGroup from './form-group';
 import Header from './header';
 import NhsLogo from './icons/nhs-logo';
@@ -21,6 +22,7 @@ export {
   Button,
   ButtonGroup,
   Fieldset,
+  Footer,
   FormGroup,
   Card,
   CheckBox,

--- a/src/new-client/src/app/site/[site]/page.tsx
+++ b/src/new-client/src/app/site/[site]/page.tsx
@@ -26,7 +26,7 @@ const Page = async ({ params }: PageProps) => {
   // before it renders we need to know what to pass as title and breadcrumbs
   const siteMoniker = site?.name ?? `Site ${params.site}`;
   return (
-    <NhsPage title={siteMoniker}>
+    <NhsPage breadcrumbs={[{ name: 'Home', href: '/' }]} title={siteMoniker}>
       <SitePage site={site} permissions={sitePermissions} />
     </NhsPage>
   );

--- a/src/new-client/src/app/site/[site]/users/manage/page.tsx
+++ b/src/new-client/src/app/site/[site]/users/manage/page.tsx
@@ -27,6 +27,7 @@ const AssignRolesPage = async ({ params, searchParams }: UserPageProps) => {
     <NhsPage
       title="Staff Role Management"
       breadcrumbs={[
+        { name: 'Home', href: '/' },
         { name: siteMoniker, href: `/site/${params.site}` },
         { name: 'Users', href: `/site/${params.site}/users` },
       ]}

--- a/src/new-client/src/app/site/[site]/users/page.tsx
+++ b/src/new-client/src/app/site/[site]/users/page.tsx
@@ -23,7 +23,10 @@ const Page = async ({ params }: PageProps) => {
   return (
     <NhsPage
       title="Manage Staff Roles"
-      breadcrumbs={[{ name: siteMoniker, href: `/site/${params.site}` }]}
+      breadcrumbs={[
+        { name: 'Home', href: '/' },
+        { name: siteMoniker, href: `/site/${params.site}` },
+      ]}
     >
       <UsersPage
         users={users}

--- a/src/new-client/testing/log-in.spec.ts
+++ b/src/new-client/testing/log-in.spec.ts
@@ -11,7 +11,23 @@ test('User visits the site origin, signs in and see the Site Selection menu', as
   const siteSelectionPage = new SiteSelectionPage(page);
 
   await rootPage.goto();
-  await rootPage.logInButton.click();
+  await rootPage.pageContentLogInButton.click();
+
+  await oAuthPage.signIn();
+
+  await expect(rootPage.logOutButton).toBeVisible();
+  await expect(siteSelectionPage.siteSelectionCardHeading).toBeVisible();
+});
+
+test('User signs in using the log in button in the header', async ({
+  page,
+}) => {
+  const rootPage = new RootPage(page);
+  const oAuthPage = new OAuthLoginPage(page);
+  const siteSelectionPage = new SiteSelectionPage(page);
+
+  await rootPage.goto();
+  await rootPage.headerLogInButton.click();
 
   await oAuthPage.signIn();
 
@@ -27,7 +43,7 @@ test('User visits the site origin, signs in, then signs out again', async ({
   const siteSelectionPage = new SiteSelectionPage(page);
 
   await rootPage.goto();
-  await rootPage.logInButton.click();
+  await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn();
 
   await expect(rootPage.logOutButton).toBeVisible();
@@ -37,14 +53,14 @@ test('User visits the site origin, signs in, then signs out again', async ({
   await siteSelectionPage.logOutButton.click();
 
   await expect(
-    page.getByRole('heading', { name: 'You cannot access this site' }),
+    page.getByRole('heading', { name: 'Appointment Management Service' }),
   ).toBeVisible();
 
   await expect(
     page.getByText(
-      'You are currently not signed in. To use this site, please sign in.',
+      'You are currently not signed in. You must sign in to access this service.',
     ),
   ).toBeVisible();
 
-  await expect(rootPage.logInButton).toBeVisible();
+  await expect(rootPage.pageContentLogInButton).toBeVisible();
 });

--- a/src/new-client/testing/not-found.spec.ts
+++ b/src/new-client/testing/not-found.spec.ts
@@ -7,7 +7,7 @@ test('Invalid roots yield a styled 404 page', async ({ page }) => {
   const rootPage = new RootPage(page);
   const oAuthPage = new OAuthLoginPage(page);
   await rootPage.goto();
-  await rootPage.logInButton.click();
+  await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn();
 
   await page.goto('/this-route-does-not-exist');

--- a/src/new-client/testing/page-objects/root.ts
+++ b/src/new-client/testing/page-objects/root.ts
@@ -2,7 +2,8 @@ import { type Locator, type Page } from '@playwright/test';
 
 export default class RootPage {
   readonly page: Page;
-  readonly logInButton: Locator;
+  readonly headerLogInButton: Locator;
+  readonly pageContentLogInButton: Locator;
   readonly logOutButton: Locator;
   readonly serviceName: Locator;
   readonly homeBreadcrumb: Locator;
@@ -10,7 +11,10 @@ export default class RootPage {
   constructor(page: Page) {
     this.page = page;
     this.serviceName = page.getByRole('link', { name: 'NHS Appointment Book' });
-    this.logInButton = page.getByRole('button', { name: 'Log In' });
+    this.headerLogInButton = page.getByRole('button', { name: 'Log In' });
+    this.pageContentLogInButton = page.getByRole('button', {
+      name: 'Sign in to service',
+    });
     this.logOutButton = page.getByRole('button', { name: 'Log Out' });
     this.homeBreadcrumb = page.getByRole('link', {
       name: 'Home',

--- a/src/new-client/testing/user-management-permissions.spec.ts
+++ b/src/new-client/testing/user-management-permissions.spec.ts
@@ -27,7 +27,7 @@ test.beforeEach(async ({ page }) => {
 
 test('A user with the appropriate permission can view other users at a site but not edit them', async () => {
   await rootPage.goto();
-  await rootPage.logInButton.click();
+  await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser2);
   await siteSelectionPage.selectSite('Robin Lane Medical Centre');
   await sitePage.userManagementCard.click();
@@ -41,7 +41,7 @@ test('A user with the appropriate permission can view other users at a site but 
 
 test('A user with the appropriate permission can view other users at a site and also edit them', async () => {
   await rootPage.goto();
-  await rootPage.logInButton.click();
+  await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser1);
   await siteSelectionPage.selectSite('Robin Lane Medical Centre');
   await sitePage.userManagementCard.click();
@@ -56,7 +56,7 @@ test('Navigating straight to the user management page works as expected', async 
   page,
 }) => {
   await rootPage.goto();
-  await rootPage.logInButton.click();
+  await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser1);
 
   await page.goto('/site/1000/users');
@@ -67,7 +67,7 @@ test('Navigating straight to the user management page displays an appropriate er
   page,
 }) => {
   await rootPage.goto();
-  await rootPage.logInButton.click();
+  await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser3);
 
   await page.goto('/site/1000/users');
@@ -85,7 +85,7 @@ test('Navigating straight to the user management page displays an appropriate er
 
 test('permissions are applied per site', async () => {
   await rootPage.goto();
-  await rootPage.logInButton.click();
+  await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser2);
 
   // First check Edit column exists at Church Lane

--- a/src/new-client/testing/user-management-permissions.spec.ts
+++ b/src/new-client/testing/user-management-permissions.spec.ts
@@ -83,7 +83,7 @@ test('Navigating straight to the user management page displays an appropriate er
   ).toBeVisible();
 });
 
-test('permissions are applied per site', async ({ page }) => {
+test('permissions are applied per site', async () => {
   await rootPage.goto();
   await rootPage.logInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser2);


### PR DESCRIPTION
PR for tickets

1. [191](https://nhsd-jira.digital.nhs.uk/browse/APPT-191)
2. [192](https://nhsd-jira.digital.nhs.uk/browse/APPT-192)
3. [193](https://nhsd-jira.digital.nhs.uk/browse/APPT-193)
4. [194](https://nhsd-jira.digital.nhs.uk/browse/APPT-194)
5. [195](https://nhsd-jira.digital.nhs.uk/browse/APPT-195)

The breadcrumbs now properly render in mobile view (turns out it was just a typo in the classname `crumbs` vs `crumb` :D 
The login page design has been updated to include a button
The Home breadcrumb no longer appears on the login page
The root CSS styling has been updated - responsive views now have horizontal padding (actually turns out it was our custom styles which were breaking that previously, so I've re-jigged them)
Breadcrumb back links render in mobile view
An NHS footer has been added with dummy links - not sure if we'd rather comment these out or leave them 404'ing - I think we agreed to comment them out? Have left them for now so so if you pull the branch you can see them, but will remove before merging

<img width="632" alt="1" src="https://github.com/user-attachments/assets/62035fb9-b448-4be1-ac73-9bdc55105d39">
<img width="607" alt="2" src="https://github.com/user-attachments/assets/1a65dbd4-3803-4e88-b512-1b2af0d5dd9e">
