### PR TITLE
Pin terraform azurerm version to last known working version

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -13,7 +13,7 @@ terraform {
     key                  = "dev.tfstate"
   }
 
-  required_version = "1.9.5"
+  required_version = ">= 1.6.5"
 }
 
 provider "azurerm" {

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.83.0"
+      version = "4.0.1"
     }
   }
 
@@ -13,7 +13,7 @@ terraform {
     key                  = "dev.tfstate"
   }
 
-  required_version = ">= 1.6.5"
+  required_version = "1.9.5"
 }
 
 provider "azurerm" {


### PR DESCRIPTION
There is a bug with azurerm plugin version 4.1.0 which caused the plugin to crash. This has been raised and fixed by Hashicorp (https://github.com/hashicorp/terraform-provider-azurerm/issues/27301) just awaiting a release. So pinning version to last known working version of plugin until this is resolved.  