### PR TITLE
APPT-242: Add create availability card and tests

### DIFF
--- a/src/new-client/src/app/site/[site]/create-availability/page.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/page.tsx
@@ -1,0 +1,28 @@
+import { fetchSite } from '@services/appointmentsService';
+import NhsPage from '@components/nhs-page';
+
+type PageProps = {
+  params: {
+    site: string;
+  };
+};
+
+const Page = async ({ params }: PageProps) => {
+  const site = await fetchSite(params.site);
+  const siteMoniker = site?.name ?? `Site ${params.site}`;
+
+  return (
+    <NhsPage
+      title="Create Availability"
+      breadcrumbs={[
+        { name: 'Home', href: '/' },
+        { name: siteMoniker, href: `/site/${params.site}` },
+      ]}
+    >
+      {/* This will be covered in APPT-240 */}
+      <span></span>
+    </NhsPage>
+  );
+};
+
+export default Page;

--- a/src/new-client/src/app/site/[site]/site-page.test.tsx
+++ b/src/new-client/src/app/site/[site]/site-page.test.tsx
@@ -74,4 +74,19 @@ describe('Site Page', () => {
       screen.queryByRole('link', { name: 'Site Management' }),
     ).not.toBeInTheDocument();
   });
+
+  // TODO: Maybe parameterise these tests over permission/card pairs
+  // once we have more cards (i.e. during APPT-62 which adds in permission checking for this card)
+  it('shows the create availability page', () => {
+    const mockSite = mockSites[0];
+
+    render(<SitePage site={mockSite} permissions={mockAllPermissions} />);
+
+    expect(
+      screen.getByRole('link', { name: 'Create Availability' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Create Availability' }),
+    ).toHaveAttribute('href', `${mockSite.id}/create-availability`);
+  });
 });

--- a/src/new-client/src/app/site/[site]/site-page.tsx
+++ b/src/new-client/src/app/site/[site]/site-page.tsx
@@ -23,29 +23,34 @@ export const SitePage = ({ site, permissions }: SitePageProps) => {
           <p className="nhsuk-card__description">{site.address}</p>
         </div>
       </div>
-      {permissionsRelevantToCards.length > 0 && (
-        <ul className="nhsuk-grid-row nhsuk-card-group">
-          {permissionsRelevantToCards.includes('users:view') && (
-            <li className="nhsuk-grid-column-one-half nhsuk-card-group__item">
-              <Card
-                href={`${site.id}/users`}
-                title="User Management"
-                description="Assign roles to users to give them access to features at this site"
-              />
-            </li>
-          )}
-          {(permissionsRelevantToCards.includes('site:manage') ||
-            permissionsRelevantToCards.includes('site:view')) && (
-            <li className="nhsuk-grid-column-one-half nhsuk-card-group__item">
-              <Card
-                href={`${site.id}/details`}
-                title="Site Management"
-                description="Assign accessibility attributes to this site"
-              />
-            </li>
-          )}
-        </ul>
-      )}
+      <ul className="nhsuk-grid-row nhsuk-card-group">
+        <li className="nhsuk-grid-column-one-half nhsuk-card-group__item">
+          <Card
+            href={`${site.id}/create-availability`}
+            title="Create Availability"
+            description="Create and publish availability for appointments at this site"
+          />
+        </li>
+        {permissionsRelevantToCards.includes('users:view') && (
+          <li className="nhsuk-grid-column-one-half nhsuk-card-group__item">
+            <Card
+              href={`${site.id}/users`}
+              title="User Management"
+              description="Assign roles to users to give them access to features at this site"
+            />
+          </li>
+        )}
+        {(permissionsRelevantToCards.includes('site:manage') ||
+          permissionsRelevantToCards.includes('site:view')) && (
+          <li className="nhsuk-grid-column-one-half nhsuk-card-group__item">
+            <Card
+              href={`${site.id}/details`}
+              title="Site Management"
+              description="Assign accessibility attributes to this site"
+            />
+          </li>
+        )}
+      </ul>
     </>
   );
 };

--- a/src/new-client/testing/create-availability.spec.ts
+++ b/src/new-client/testing/create-availability.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import RootPage from './page-objects/root';
+import OAuthLoginPage from './page-objects/oauth';
+import SiteSelectionPage from './page-objects/site-selection';
+import SitePage from './page-objects/site';
+import CreateAvailabilityPage from './page-objects/create-availability';
+
+let rootPage: RootPage;
+let oAuthPage: OAuthLoginPage;
+let siteSelectionPage: SiteSelectionPage;
+let sitePage: SitePage;
+let createAvailabilityPage: CreateAvailabilityPage;
+
+test.beforeEach(async ({ page }) => {
+  rootPage = new RootPage(page);
+  oAuthPage = new OAuthLoginPage(page);
+  siteSelectionPage = new SiteSelectionPage(page);
+  sitePage = new SitePage(page);
+  createAvailabilityPage = new CreateAvailabilityPage(page);
+});
+
+test('A user can navigate to the Create Availability flow from the site page', async ({
+  page,
+}) => {
+  await rootPage.goto();
+  await rootPage.pageContentLogInButton.click();
+  await oAuthPage.signIn();
+  await siteSelectionPage.selectSite('Church Lane Pharmacy');
+  await sitePage.createAvailabilityCard.click();
+
+  await page.waitForURL('**/site/ABC02/create-availability');
+  await expect(createAvailabilityPage.title).toBeVisible();
+});

--- a/src/new-client/testing/page-objects/create-availability.ts
+++ b/src/new-client/testing/page-objects/create-availability.ts
@@ -1,0 +1,13 @@
+import { type Locator, type Page } from '@playwright/test';
+import RootPage from './root';
+
+export default class CreateAvailabilityPage extends RootPage {
+  readonly title: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.title = page.getByRole('heading', {
+      name: 'Create Availability',
+    });
+  }
+}

--- a/src/new-client/testing/page-objects/site.ts
+++ b/src/new-client/testing/page-objects/site.ts
@@ -4,6 +4,7 @@ import RootPage from './root';
 export default class SitePage extends RootPage {
   readonly userManagementCard: Locator;
   readonly siteManagementCard: Locator;
+  readonly createAvailabilityCard: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -12,6 +13,9 @@ export default class SitePage extends RootPage {
     });
     this.siteManagementCard = this.page.getByRole('link', {
       name: 'Site Management',
+    });
+    this.createAvailabilityCard = this.page.getByRole('link', {
+      name: 'Create Availability',
     });
   }
 }


### PR DESCRIPTION
Creates a "Create Availability" card on the site landing page. Permission checking for this card is out of scope for this ticket, being covered instead in APPT-62. 