### PR TITLE
APPT-313: Yield not found page when removing invalid user

### DIFF
--- a/src/new-client/src/app/site/[site]/users/remove/page.tsx
+++ b/src/new-client/src/app/site/[site]/users/remove/page.tsx
@@ -18,7 +18,7 @@ export type UserPageProps = {
 };
 
 const Page = async ({ params, searchParams }: UserPageProps) => {
-  // TODO: Clean up these checks after appt-202 is merged and site/users reesults can be replied upon
+  // TODO: Clean up these checks after appt-202 is merged and site/users results can be relied upon
   if (searchParams?.user === undefined) {
     notFound();
   }

--- a/src/new-client/src/app/site/[site]/users/remove/page.tsx
+++ b/src/new-client/src/app/site/[site]/users/remove/page.tsx
@@ -4,6 +4,7 @@ import {
   fetchPermissions,
   fetchSite,
   fetchUserProfile,
+  fetchUsers,
 } from '@services/appointmentsService';
 import { notFound } from 'next/navigation';
 
@@ -17,13 +18,18 @@ export type UserPageProps = {
 };
 
 const Page = async ({ params, searchParams }: UserPageProps) => {
-  // TODO: Should we throw these from the service itself? What side effects does have on other calls?
+  // TODO: Clean up these checks after appt-202 is merged and site/users reesults can be replied upon
   if (searchParams?.user === undefined) {
     notFound();
   }
 
   const site = await fetchSite(params.site);
   if (site === undefined) {
+    notFound();
+  }
+
+  const users = await fetchUsers(params.site);
+  if (users === undefined || !users.some(u => u.id === searchParams?.user)) {
     notFound();
   }
 

--- a/src/new-client/testing/create-and-remove-user.spec.ts
+++ b/src/new-client/testing/create-and-remove-user.spec.ts
@@ -7,6 +7,7 @@ import SitePage from './page-objects/site';
 import UsersPage from './page-objects/users';
 import UserManagementPage from './page-objects/user-management';
 import ConfirmRemoveUserPage from './page-objects/confirm-remove-user';
+import NotFoundPage from './page-objects/not-found';
 
 const { TEST_USERS } = env;
 
@@ -17,6 +18,7 @@ let sitePage: SitePage;
 let usersPage: UsersPage;
 let userManagementPage: UserManagementPage;
 let confirmRemoveUserPage: ConfirmRemoveUserPage;
+let notFoundPage: NotFoundPage;
 
 test.beforeEach(async ({ page }) => {
   rootPage = new RootPage(page);
@@ -26,6 +28,7 @@ test.beforeEach(async ({ page }) => {
   usersPage = new UsersPage(page);
   userManagementPage = new UserManagementPage(page);
   confirmRemoveUserPage = new ConfirmRemoveUserPage(page);
+  notFoundPage = new NotFoundPage(page);
 
   await rootPage.goto();
   await rootPage.pageContentLogInButton.click();
@@ -158,4 +161,12 @@ test('Receives 403 error when trying to remove self', async ({ page }) => {
   await expect(
     page.getByText('Forbidden: You lack the necessary permissions'),
   ).toBeVisible();
+});
+
+test('Receives 404 when trying to remove an invalid user', async ({ page }) => {
+  await page.goto(`/site/ABC01/users/remove?user=not-a-user`);
+
+  await expect(notFoundPage.title).toBeVisible();
+  await expect(notFoundPage.warningCalloutHeading).toBeVisible();
+  await expect(notFoundPage.warningCalloutText).toBeVisible();
 });

--- a/src/new-client/testing/page-objects/user-management.ts
+++ b/src/new-client/testing/page-objects/user-management.ts
@@ -33,10 +33,12 @@ export default class UserManagementPage extends RootPage {
   }
 
   async userExists(email: string) {
-    expect(this.page.getByRole('cell', { name: email })).toBeVisible();
+    await expect(this.page.getByRole('cell', { name: email })).toBeVisible();
   }
 
   async userDoesNotExist(email: string) {
-    expect(this.page.getByRole('cell', { name: email })).not.toBeVisible();
+    await expect(
+      this.page.getByRole('cell', { name: email }),
+    ).not.toBeVisible();
   }
 }


### PR DESCRIPTION
We're not pre-validating the search parameter in the remove-user confirmation route, but we've been asked to yield a 404 page in this scenario. 

