### PR TITLE
APPT-324 - Validation for negative numbers for slot length and capacity

### DIFF
--- a/src/api/Nhs.Appointments.Api/Validators/SessionValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/SessionValidator.cs
@@ -20,11 +20,11 @@ public class SessionValidator : AbstractValidator<Session>
         RuleFor(x => x.Capacity).Cascade(CascadeMode.Stop)
             .NotEmpty()
             .GreaterThanOrEqualTo(1)
-            .Configure(rule => rule.MessageBuilder = _ => "'capacity' must be greater than 0");
+            .Configure(rule => rule.MessageBuilder = _ => "'capacity' must be a positive integer");
         RuleFor(x => x.SlotLength).Cascade(CascadeMode.Stop)
             .NotEmpty()
             .GreaterThanOrEqualTo(1)
-            .Configure(rule => rule.MessageBuilder = _ => "'slotLength' must be greater than 0");
+            .Configure(rule => rule.MessageBuilder = _ => "'slotLength' must be a positive integer");
         RuleFor(x => x.Services)
             .NotEmpty()
             .WithMessage("'services' cannot be empty");

--- a/src/api/Nhs.Appointments.Api/Validators/SessionValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/SessionValidator.cs
@@ -17,12 +17,14 @@ public class SessionValidator : AbstractValidator<Session>
                         .GreaterThanOrEqualTo(x => x.From.AddMinutes(x.SlotLength))
                         .WithMessage("At least one slot must be available");
                 });
-        RuleFor(x => x.Capacity)
+        RuleFor(x => x.Capacity).Cascade(CascadeMode.Stop)
             .NotEmpty()
-            .WithMessage("'capacity' cannot be zero or null");
-        RuleFor(x => x.SlotLength)
+            .GreaterThanOrEqualTo(1)
+            .Configure(rule => rule.MessageBuilder = _ => "'capacity' must be greater than 0");
+        RuleFor(x => x.SlotLength).Cascade(CascadeMode.Stop)
             .NotEmpty()
-            .WithMessage("'slotLength' cannot be zero or null");
+            .GreaterThanOrEqualTo(1)
+            .Configure(rule => rule.MessageBuilder = _ => "'slotLength' must be greater than 0");
         RuleFor(x => x.Services)
             .NotEmpty()
             .WithMessage("'services' cannot be empty");

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/SessionValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/SessionValidatorTests.cs
@@ -27,6 +27,7 @@ public class SessionValidatorTests
     [Theory]
     [InlineData(null)]
     [InlineData(0)]
+    [InlineData(-1)]
     public void Validate_ReturnsError_WhenCapacityIsInvalid(int capacity)
     {
         var session = new Session()
@@ -46,6 +47,7 @@ public class SessionValidatorTests
     [Theory]
     [InlineData(null)]
     [InlineData(0)]
+    [InlineData(-1)]
     public void Validate_ReturnsError_WhenSlotLengthIsInvalid(int slotLength)
     {
         var session = new Session()


### PR DESCRIPTION
- Add rule to prevent negative numbers being sent for capacity and slot length in the session object
- Updated unit tests