### PR TITLE
Enforce npm and node version on install

### DIFF
--- a/src/new-client/.npmrc
+++ b/src/new-client/.npmrc
@@ -1,6 +1,1 @@
 engine-strict=true
-legacy-peer-deps=false
-include=prod
-include=peer
-include=dev
-include=optional

--- a/src/new-client/.npmrc
+++ b/src/new-client/.npmrc
@@ -1,0 +1,6 @@
+engine-strict=true
+legacy-peer-deps=false
+include=prod
+include=peer
+include=dev
+include=optional

--- a/src/new-client/package-lock.json
+++ b/src/new-client/package-lock.json
@@ -54,6 +54,10 @@
         "stylelint-config-sass-guidelines": "^10.0.0",
         "stylelint-prettier": "^4.0.2",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/src/new-client/package-lock.json
+++ b/src/new-client/package-lock.json
@@ -18,12 +18,8 @@
         "react-hook-form": "^7.53.1"
       },
       "devDependencies": {
-<<<<<<< HEAD
-        "@playwright/test": "^1.48.1",
         "@testing-library/dom": "^10.4.0",
-=======
         "@playwright/test": "^1.48.2",
->>>>>>> origin/main
         "@testing-library/jest-dom": "^6.6.2",
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.5.2",

--- a/src/new-client/package-lock.json
+++ b/src/new-client/package-lock.json
@@ -18,8 +18,8 @@
         "react-hook-form": "^7.53.1"
       },
       "devDependencies": {
-        "@testing-library/dom": "^10.4.0",
         "@playwright/test": "^1.48.2",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.2",
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.5.2",
@@ -52,8 +52,8 @@
         "typescript": "^5"
       },
       "engines": {
-        "node": ">=20.0.0",
-        "npm": ">=10.0.0"
+        "node": "^20.0.0",
+        "npm": ">=10.7.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1598,7 +1598,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1706,8 +1705,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3478,8 +3476,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -7330,7 +7327,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8377,7 +8373,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8392,7 +8387,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8541,8 +8535,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/read-pkg": {
       "version": "6.0.0",

--- a/src/new-client/package.json
+++ b/src/new-client/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0",
-    "npm": ">=10.0.0"
+    "node": "^20.0.0",
+    "npm": ">=10.7.0"
   },
   "scripts": {
     "prepare": "cd ../../ && husky src/new-client/.husky",

--- a/src/new-client/package.json
+++ b/src/new-client/package.json
@@ -2,6 +2,10 @@
   "name": "appointments-booking-service",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  },
   "scripts": {
     "prepare": "cd ../../ && husky src/new-client/.husky",
     "tsc": "tsc --noEmit",


### PR DESCRIPTION
We don't currently enforce any particular version of node or npm during build. 

This PR pins us to npm >= 10 and node >= 20, and sets engine-strict to true which will fail the build if these requirements aren't met. 

It also forces peer, dev, and optional dependencies to be included on install in case local settings are set differently.