### PR TITLE
Remove <text> tag which was triggering errors

### DIFF
--- a/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/information-for-citizens-page.test.tsx
+++ b/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/information-for-citizens-page.test.tsx
@@ -19,7 +19,7 @@ jest.mock('./add-information-for-citizens-form', () => {
     return (
       <>
         <div>Add information for citizen form</div>
-        <text>{information}</text>
+        <span>{information}</span>
       </>
     );
   };


### PR DESCRIPTION
I noticed one of our UI tests is causing console errors because of the use of a < text > element. It's only a mock element so it's now a span instead. 
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/72fc1e22-0b6e-4894-8c14-5841b00bd794">
