### PR TITLE
Reintroduce missing code from previous PR

### DIFF
--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -13,7 +13,7 @@ public interface IBookingsService
     Task CancelBooking(string site, string bookingReference);
     Task<bool> SetBookingStatus(string bookingReference, string status);
     Task SendBookingReminders();
-    Task<bool> ConfirmProvisionalBooking(string bookingReference, IEnumerable<ContactItem> contactDetails);
+    Task<BookingConfirmationResult> ConfirmProvisionalBooking(string bookingReference, IEnumerable<ContactItem> contactDetails);
     Task RemoveUnconfirmedProvisionalBookings();
 }    
 
@@ -80,7 +80,7 @@ public class BookingsService(
             .ApplyAsync();
     }
 
-    public Task<bool> ConfirmProvisionalBooking(string bookingReference, IEnumerable<ContactItem> contactDetails)
+    public Task<BookingConfirmationResult> ConfirmProvisionalBooking(string bookingReference, IEnumerable<ContactItem> contactDetails)
     {
         return bookingDocumentStore.ConfirmProvisional(bookingReference, contactDetails);
     }

--- a/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
@@ -12,7 +12,7 @@ public interface IBookingsDocumentStore
     Task<bool> UpdateStatus(string bookingReference, string status);
     IDocumentUpdate<Booking> BeginUpdate(string site, string reference);
     Task SetReminderSent(string bookingReference, string site);
-    Task<bool> ConfirmProvisional(string bookingReference, IEnumerable<ContactItem> contactDetails);
+    Task<BookingConfirmationResult> ConfirmProvisional(string bookingReference, IEnumerable<ContactItem> contactDetails);
     Task RemoveUnconfirmedProvisionalBookings();
 }
 
@@ -31,4 +31,12 @@ public interface IDocumentUpdate<TModel>
 {
     IDocumentUpdate<TModel> UpdateProperty<TProp>(Expression<Func<TModel, TProp>> prop, TProp val);
     Task ApplyAsync();
+}
+
+public enum BookingConfirmationResult
+{
+    Unknown,
+    Success,
+    Expired,
+    NotFound
 }

--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -85,20 +85,24 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
         return true;
     }
 
-    public async Task<bool> ConfirmProvisional(string bookingReference, IEnumerable<ContactItem> contactDetails)
+    public async Task<BookingConfirmationResult> ConfirmProvisional(string bookingReference, IEnumerable<ContactItem> contactDetails)
     {
-        var bookingIndexDocument = await indexStore.GetDocument<BookingIndexDocument>(bookingReference);
+        var bookingIndexDocument = await indexStore.GetByIdOrDefaultAsync<BookingIndexDocument>(bookingReference);
         if (bookingIndexDocument != null)
         {
+            if (bookingIndexDocument.Created.AddMinutes(5) < time.GetUtcNow())
+                return BookingConfirmationResult.Expired;
+
             var updateStatusPatch = PatchOperation.Replace("/provisional", false);
             var addContactDetailsPath = PatchOperation.Add("/contactDetails", contactDetails);
             await indexStore.PatchDocument("booking_index", bookingReference, updateStatusPatch);
             await bookingStore.PatchDocument(bookingIndexDocument.Site, bookingReference, updateStatusPatch, addContactDetailsPath);
-            return true;
+            return BookingConfirmationResult.Success;
         }
 
-        return false;
+        return BookingConfirmationResult.NotFound;
     }
+
 
     public async Task SetReminderSent(string bookingReference, string site)
     {

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBooking.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBooking.feature
@@ -11,3 +11,39 @@
       When I confirm the booking
       Then the call should be successful
       And the booking is no longer marked as provisional
+
+    Scenario: Confirmation can record contact details
+    Given the site is configured for MYA
+      And the following sessions
+        | Date       | From  | Until | Services | Slot Length | Capacity |
+        | 2077-01-01 | 09:00 | 10:00 | COVID    | 5           | 1        |
+      And the following provisional bookings have been made
+        | Date       | Time  | Duration | Service | 
+        | 2077-01-01 | 09:00 | 5        | COVID   |
+      When I confirm the booking with the following contact information
+      | Email         | Phone         |
+      | test@test.com | 07654 3210987 |
+      Then the call should be successful      
+      And the booking should have stored my contact details as follows
+      | Email         | Phone         |
+      | test@test.com | 07654 3210987 |
+
+
+    Scenario: Cannot confirm an appointment that does not exist
+      Given the site is configured for MYA
+      And the following sessions
+        | Date       | From  | Until | Services | Slot Length | Capacity |
+        | 2077-01-01 | 09:00 | 10:00 | COVID    | 5           | 1        |
+      When I confirm the booking
+      Then the call should fail with 404
+    
+    Scenario: Cannot confirm a provisional appointment that has expired
+      Given the site is configured for MYA
+      And the following sessions
+        | Date       | From  | Until | Services | Slot Length | Capacity |
+        | 2077-01-01 | 09:00 | 10:00 | COVID    | 5           | 1        |
+      And the following expired provisional bookings have been made
+        | Date       | Time  | Duration | Service | 
+        | 2077-01-01 | 09:00 | 5        | COVID   |
+      When I confirm the booking
+      Then the call should fail with 410

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBookingFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBookingFeatureSteps.cs
@@ -1,5 +1,7 @@
 ﻿using FluentAssertions;
+using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Persistance.Models;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit.Gherkin.Quick;
@@ -18,10 +20,33 @@ public sealed class ConfirmBookingFeatureSteps : BaseFeatureSteps
         _response = await Http.PostAsJsonAsync($"http://localhost:7071/api/booking/{bookingReference}/confirm", new StringContent(""));
     }
 
+    [When("I confirm the booking with the following contact information")]
+    public async Task ConfirmBookingWithContactDetails(Gherkin.Ast.DataTable dataTable)
+    {
+        var cells = dataTable.Rows.ElementAt(1).Cells;
+
+        var payload = new
+        {
+            contactDetails = new[]
+            {
+                new ContactItem("email", cells.ElementAt(0).Value),
+                new ContactItem("phone", cells.ElementAt(1).Value),
+            }
+        };
+        var bookingReference = GetBookingReference("0", BookingType.Provisional);
+        _response = await Http.PostAsJsonAsync($"http://localhost:7071/api/booking/{bookingReference}/confirm", payload);
+    }
+
     [Then("the call should be successful")]
     public void AssertHttpOk()
     {
         _response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+    }    
+
+    [Then(@"the call should fail with (\d*)")]
+    public void AssertFailureCode(int statusCode)
+    {
+        _response.StatusCode.Should().Be((System.Net.HttpStatusCode)statusCode);
     }
 
     [And("the booking is no longer marked as provisional")]
@@ -34,6 +59,23 @@ public sealed class ConfirmBookingFeatureSteps : BaseFeatureSteps
 
         var actualBookingIndex = await Client.GetContainer("appts", "index_data").ReadItemAsync<BookingIndexDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey("booking_index"));
         actualBookingIndex.Resource.Provisional.Should().BeFalse();
+    }
+
+    [And("the booking should have stored my contact details as follows")]
+    public async Task AssertBookingContactDetails(Gherkin.Ast.DataTable dataTable)
+    {
+        var cells = dataTable.Rows.ElementAt(1).Cells;
+
+        var expectedContactDetails = new[]
+        {
+            new ContactItem("email", cells.ElementAt(0).Value),
+            new ContactItem("phone", cells.ElementAt(1).Value),
+        };
+
+        var siteId = GetSiteId();
+        var bookingReference = GetBookingReference("0", BookingType.Provisional);
+        var actualBooking = await Client.GetContainer("appts", "booking_data").ReadItemAsync<BookingDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey(siteId));
+        actualBooking.Resource.ContactDetails.Should().BeEquivalentTo(expectedContactDetails);
     }
 }
 


### PR DESCRIPTION
Some code was intended to go into the PR for provisional bookings but was missed. It tackles a few edge cases and makes the process more robust