### PR TITLE
Appt 270 additional site info validation

### DIFF
--- a/src/new-client/src/app/lib/components/nhsuk-frontend/text-area.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/text-area.tsx
@@ -23,7 +23,6 @@ export const TextArea = forwardRef<Ref, Props>((props, ref) => (
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
       aria-label={props.label}
-      maxLength={props.maxLength ?? 150}
     />
   </div>
 ));

--- a/src/new-client/src/app/lib/components/nhsuk-frontend/text-area.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/text-area.tsx
@@ -23,6 +23,7 @@ export const TextArea = forwardRef<Ref, Props>((props, ref) => (
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
       aria-label={props.label}
+      maxLength={props.maxLength ?? 150}
     />
   </div>
 ));

--- a/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens-form.tsx
+++ b/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens-form.tsx
@@ -22,11 +22,12 @@ const AddInformationForCitizensForm = ({
   site: string;
 }) => {
   const { replace } = useRouter();
-  const { register, handleSubmit } = useForm<FormFields>({
+  const { register, handleSubmit, formState } = useForm<FormFields>({
     defaultValues: {
       informationForCitizen: information,
     },
   });
+  const { errors } = formState;
 
   const cancel = () => {
     replace(`/site/${site}/details`);
@@ -48,13 +49,35 @@ const AddInformationForCitizensForm = ({
     replace(`/site/${site}/details`);
   };
 
+  const isValidTextInput = (text: string): boolean => {
+    const urlRegex = new RegExp(
+      '([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?([^ ])+',
+    );
+    if (urlRegex.test(text)) {
+      return false;
+    }
+
+    const specialCharacterRegex = /^[-\w \.\,\-]+$/;
+    return specialCharacterRegex.test(text);
+  };
+
   return (
     <form onSubmit={handleSubmit(submitForm)}>
-      <FormGroup legend="Information for citizens">
+      <FormGroup
+        legend="Information for citizens"
+        error={errors.informationForCitizen?.message}
+      >
         <div className="nhsuk-form-group">
           <TextArea
             label="What information would you like to include?"
-            {...register('informationForCitizen')}
+            maxLength={150}
+            {...register('informationForCitizen', {
+              validate: value => {
+                if (!isValidTextInput(value)) {
+                  return "Text cannot contain a URL or special characters outside of '.' ',' '-'";
+                }
+              },
+            })}
           />
         </div>
       </FormGroup>

--- a/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens-form.tsx
+++ b/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens-form.tsx
@@ -8,6 +8,7 @@ import {
 import { setSiteInformationForCitizen } from '@services/appointmentsService';
 import { SetAttributesRequest } from '@types';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 type FormFields = {
@@ -28,6 +29,8 @@ const AddInformationForCitizensForm = ({
     },
   });
   const { errors } = formState;
+  const [textInputLength, setTextInputLength] = useState(0);
+  const maxLength = 150;
 
   const cancel = () => {
     replace(`/site/${site}/details`);
@@ -61,26 +64,45 @@ const AddInformationForCitizensForm = ({
     return specialCharacterRegex.test(text);
   };
 
+  const handleTextInputUpdate = (inputLength: number): void => {
+    setTextInputLength(inputLength);
+  };
+
   return (
     <form onSubmit={handleSubmit(submitForm)}>
-      <FormGroup
-        legend="Information for citizens"
-        error={errors.informationForCitizen?.message}
+      <div
+        className="nhsuk-character-count"
+        data-module="nhsuk-character-count"
+        data-maxlength="150"
       >
-        <div className="nhsuk-form-group">
-          <TextArea
-            label="What information would you like to include?"
-            maxLength={150}
-            {...register('informationForCitizen', {
-              validate: value => {
-                if (!isValidTextInput(value)) {
-                  return "Text cannot contain a URL or special characters outside of '.' ',' '-'";
-                }
-              },
-            })}
-          />
-        </div>
-      </FormGroup>
+        <FormGroup
+          legend="Information for citizens"
+          error={errors.informationForCitizen?.message}
+        >
+          <div className="nhsuk-form-group">
+            <TextArea
+              label="What information would you like to include?"
+              maxLength={maxLength}
+              {...register('informationForCitizen', {
+                validate: value => {
+                  if (!isValidTextInput(value)) {
+                    return "Text cannot contain a URL or special characters outside of '.' ',' '-'";
+                  }
+                },
+                onChange: e => {
+                  handleTextInputUpdate(e.target.value.length);
+                },
+              })}
+            />
+          </div>
+          <div
+            className="nhsuk-hint nhsuk-character-count__message"
+            id="more-detail-info"
+          >
+            You have {maxLength - textInputLength} characters remaining
+          </div>
+        </FormGroup>
+      </div>
       <br />
       <ButtonGroup>
         <Button type="submit">Confirm site details</Button>

--- a/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens-form.tsx
+++ b/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens-form.tsx
@@ -54,41 +54,34 @@ const AddInformationForCitizensForm = ({
 
   return (
     <form onSubmit={handleSubmit(submitForm)}>
-      <div
-        className="nhsuk-character-count"
-        data-module="nhsuk-character-count"
-        data-maxlength="150"
+      <FormGroup
+        legend="Information for citizens"
+        error={
+          errors.informationForCitizen
+            ? 'Site information cannot contain a URL or special characters except full stops, commas, and hyphens'
+            : ''
+        }
       >
-        <FormGroup
-          legend="Information for citizens"
-          error={
-            errors.informationForCitizen
-              ? 'Site information cannot contain a URL or special characters except full stops, commas, and hyphens'
-              : ''
-          }
+        <div className="nhsuk-form-group">
+          <TextArea
+            label="What information would you like to include?"
+            maxLength={maxLength}
+            {...register('informationForCitizen', {
+              validate: {
+                validInput: value =>
+                  !URL_REGEX.test(value) && SPECIAL_CHARACTER_REGEX.test(value),
+              },
+              maxLength: 150,
+            })}
+          />
+        </div>
+        <div
+          className="nhsuk-hint nhsuk-character-count__message"
+          id="more-detail-info"
         >
-          <div className="nhsuk-form-group">
-            <TextArea
-              label="What information would you like to include?"
-              maxLength={maxLength}
-              {...register('informationForCitizen', {
-                validate: {
-                  validInput: value =>
-                    !URL_REGEX.test(value) &&
-                    SPECIAL_CHARACTER_REGEX.test(value),
-                },
-                maxLength: 150,
-              })}
-            />
-          </div>
-          <div
-            className="nhsuk-hint nhsuk-character-count__message"
-            id="more-detail-info"
-          >
-            You have {maxLength - infoWatch.length} characters remaining
-          </div>
-        </FormGroup>
-      </div>
+          You have {maxLength - infoWatch.length} characters remaining
+        </div>
+      </FormGroup>
       <br />
       <ButtonGroup>
         <Button type="submit">Confirm site details</Button>

--- a/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens.test.tsx
+++ b/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens.test.tsx
@@ -66,4 +66,39 @@ describe('Add Information For Citizen Form', () => {
       expectedPayload,
     );
   });
+
+  it('should display a validation error when user input is invalid', async () => {
+    const { user } = render(
+      <AddInformationForCitizensForm information="" site="TEST" />,
+    );
+    const textArea = screen.getByRole('textbox', {
+      name: /What information would you like to include?/i,
+    });
+    await user.type(textArea, 'test user input which is inv@lid!');
+    const saveButton = screen.getByRole('button', {
+      name: 'Confirm site details',
+    });
+    await user.click(saveButton);
+
+    expect(
+      screen.getByText(
+        "Text cannot contain a URL or special characters outside of '.' ',' '-'",
+      ),
+    ).toBeInTheDocument();
+    expect(mockSetSiteInformationForCitizen).not.toHaveBeenCalled();
+  });
+
+  it('should display characters remaining text', async () => {
+    const { user } = render(
+      <AddInformationForCitizensForm information="" site="TEST" />,
+    );
+    const textArea = screen.getByRole('textbox', {
+      name: /What information would you like to include?/i,
+    });
+    await user.type(textArea, 'test user input');
+
+    expect(
+      screen.getByText('You have 135 characters remaining'),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens.test.tsx
+++ b/src/new-client/src/app/site/[site]/details/edit-information-for-citizens/add-information-for-citizens.test.tsx
@@ -82,7 +82,7 @@ describe('Add Information For Citizen Form', () => {
 
     expect(
       screen.getByText(
-        "Text cannot contain a URL or special characters outside of '.' ',' '-'",
+        'Site information cannot contain a URL or special characters except full stops, commas, and hyphens',
       ),
     ).toBeInTheDocument();
     expect(mockSetSiteInformationForCitizen).not.toHaveBeenCalled();

--- a/src/new-client/src/constants.tsx
+++ b/src/new-client/src/constants.tsx
@@ -1,1 +1,5 @@
 ﻿export const EMAIL_REGEX = new RegExp(/[\w-.]+@nhs.net/i);
+export const URL_REGEX = new RegExp(
+  '([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?([^ ])+',
+);
+export const SPECIAL_CHARACTER_REGEX = /^[-\w \.\,\-]+$/;


### PR DESCRIPTION
- Adding a max length of 150 to the site information text area
- Including remaining character count beneath the text area
- Adding checks to see if the text contains certain special characters or a URL and if so, fail validation, don't allow for submission and display a validation message