### PR TITLE
RSV booking cancellation notifications

### DIFF
--- a/infrastructure/resources/api.tf
+++ b/infrastructure/resources/api.tf
@@ -130,6 +130,11 @@ resource "azurerm_servicebus_queue" "nbs_mya_sbq_booking_made" {
   namespace_id = azurerm_servicebus_namespace.nbs_mya_service_bus.id
 }
 
+resource "azurerm_servicebus_queue" "nbs_mya_sbq_booking_cancelled" {
+  name         = "booking-cancelled"
+  namespace_id = azurerm_servicebus_namespace.nbs_mya_service_bus.id
+}
+
 resource "azurerm_servicebus_queue" "nbs_mya_sbq_bookingreminder" {
   name         = "booking-reminder"
   namespace_id = azurerm_servicebus_namespace.nbs_mya_service_bus.id

--- a/mock-data/CosmosDbSeeder/items/index_data/notification_config.json
+++ b/mock-data/CosmosDbSeeder/items/index_data/notification_config.json
@@ -55,8 +55,12 @@
       "emailTemplate": "b560d593-34d8-4641-8517-ec563e8122ad",
       "smsTemplate": "b21afedd-e6a2-417e-a146-6f1b7ae2865c",
       "eventType": "BookingReminder"
+    },
+    {
+      "services": [ "RSV:Adult" ],
+      "emailTemplate": "2bb90de1-2d7d-45b9-bc6e-88d0c04f0021",
+      "smsTemplate": "2ef9995c-32b9-4088-a630-97c2546062d0",
+      "eventType": "BookingCancelled"
     }
-
-
   ]
 }

--- a/src/api/Nhs.Appointments.Api/Consumers/BookingCancelledConsumer.cs
+++ b/src/api/Nhs.Appointments.Api/Consumers/BookingCancelledConsumer.cs
@@ -1,0 +1,44 @@
+﻿using MassTransit;
+using Nhs.Appointments.Api.Notifications;
+using Nhs.Appointments.Core.Messaging.Events;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nhs.Appointments.Api.Consumers;
+
+public class BookingCancelledConsumer(IBookingCancelledNotifier notifier, TimeProvider time) : IConsumer<BookingCancelled>
+{
+    public Task Consume(ConsumeContext<BookingCancelled> context)
+    {
+        if(context.Message.ContactDetails == null)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (BookingIsInThePast(context.Message))
+        {
+            return Task.CompletedTask;
+        }
+
+        var email = context.Message.ContactDetails.FirstOrDefault(x => x.Type == "email")?.Value;
+        var phone = context.Message.ContactDetails.FirstOrDefault(x => x.Type == "phone")?.Value;
+
+        return notifier.Notify(
+            nameof(BookingCancelled),
+            context.Message.Service,
+            context.Message.Reference,
+            context.Message.Site,
+            context.Message.FirstName,
+            DateOnly.FromDateTime(context.Message.From),
+            TimeOnly.FromDateTime(context.Message.From),
+            email,
+            phone
+            );
+    }
+
+    private bool BookingIsInThePast(BookingCancelled message)
+    {
+        return message.From < time.GetUtcNow();
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Functions/NotifyBookingCancelledFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/NotifyBookingCancelledFunction.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using MassTransit;
+using Microsoft.Azure.Functions.Worker;
+using Azure.Messaging.ServiceBus;
+using System.Threading;
+using Nhs.Appointments.Api.Consumers;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Nhs.Appointments.Api.Functions;
+
+public class NotifyBookingCancelledFunction(IMessageReceiver receiver)
+{
+    public const string QueueName = "booking-cancelled";
+
+    [Function("NotifyBookingCancelled")]
+    [AllowAnonymous]
+    public Task NotifyBookingCancelledAsync([ServiceBusTrigger(QueueName, Connection = "ServiceBusConnectionString")] ServiceBusReceivedMessage message, CancellationToken cancellationToken)
+    {
+        return receiver.HandleConsumer<BookingCancelledConsumer>(QueueName, message, cancellationToken);
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Notifications/BookingNotifier.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/BookingNotifier.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Nhs.Appointments.Api.Notifications;
 
-public class BookingNotifier(ISendNotifications notificationClient, INotificationConfigurationStore notificationConfigurationStore, ISiteService siteService) : IBookingMadeNotifier, IBookingReminderNotifier
+public class BookingNotifier(ISendNotifications notificationClient, INotificationConfigurationStore notificationConfigurationStore, ISiteService siteService) : IBookingMadeNotifier, IBookingReminderNotifier, IBookingCancelledNotifier
 {
     public async Task Notify(string eventType, string service, string bookingRef, string siteId, string firstName, DateOnly date, TimeOnly time, string email, string phoneNumber)
     {

--- a/src/api/Nhs.Appointments.Api/Notifications/ConsoleLogNotifications.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ConsoleLogNotifications.cs
@@ -21,7 +21,7 @@ public class ConsoleLogNotifications : IMessageBus
     protected virtual void ProcessMessage<T>(T message) { }
 }
 
-public class ConsoleLogWithMessageDelivery(IConsumer<UserRolesChanged> userRolesChangedConsumer, IConsumer<BookingMade> bookingMadeConsumer, IConsumer<BookingReminder> bookingReminderConsumer) : ConsoleLogNotifications
+public class ConsoleLogWithMessageDelivery(IConsumer<UserRolesChanged> userRolesChangedConsumer, IConsumer<BookingMade> bookingMadeConsumer, IConsumer<BookingReminder> bookingReminderConsumer, IConsumer<BookingCancelled> bookingCancelledConsumer) : ConsoleLogNotifications
 {
     protected override void ProcessMessage<T>(T message)
     {
@@ -38,6 +38,11 @@ public class ConsoleLogWithMessageDelivery(IConsumer<UserRolesChanged> userRoles
         if (message is BookingReminder bookingReminder)
         {
             bookingReminderConsumer.Consume(new DummyConsumeContext<BookingReminder>() { Message = bookingReminder });
+        }
+
+        if(message is BookingCancelled bookingCancelled)
+        {
+            bookingCancelledConsumer.Consume(new DummyConsumeContext<BookingCancelled>() {  Message = bookingCancelled });
         }
     }
 

--- a/src/api/Nhs.Appointments.Api/Notifications/IBookingCancelledNotifier.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/IBookingCancelledNotifier.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Nhs.Appointments.Api.Notifications;
+
+public interface IBookingCancelledNotifier
+{
+    Task Notify(string eventType, string service, string bookingRef, string siteId, string firstName, DateOnly date, TimeOnly time, string email, string phoneNumber);
+}

--- a/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
@@ -24,6 +24,7 @@ public static class ServiceRegistration
             services
                 .AddScoped<IConsumer<UserRolesChanged>, UserRolesChangedConsumer>()
                 .AddScoped<IConsumer<BookingMade>, BookingMadeConsumer>()
+                .AddScoped<IConsumer<BookingCancelled>, BookingCancelledConsumer>()
                 .AddScoped<IConsumer<BookingReminder>, BookingReminderConsumer>()
                 .AddScoped<IMessageBus, ConsoleLogWithMessageDelivery>()
                 .AddScoped<ISendNotifications, FakeNotificationClient>();
@@ -35,15 +36,18 @@ public static class ServiceRegistration
                 .AddScoped<IMessageBus, MassTransitBusWrapper>()
                 .AddScoped<NotifyUserRolesChangedFunction>()
                 .AddScoped<NotifyBookingMadeFunction>()
+                .AddScoped<NotifyBookingCancelledFunction>()
                 .AddScoped<ScheduledBookingRemindersFunction>()
                 .AddMassTransitForAzureFunctions(cfg =>
                 {
                     EndpointConvention.Map<UserRolesChanged>(new Uri($"queue:{NotifyUserRolesChangedFunction.QueueName}"));
                     EndpointConvention.Map<BookingMade>(new Uri($"queue:{NotifyBookingMadeFunction.QueueName}"));
+                    EndpointConvention.Map<BookingCancelled>(new Uri($"queue:{NotifyBookingCancelledFunction.QueueName}"));
                     EndpointConvention.Map<BookingReminder>(new Uri($"queue:{NotifyBookingReminderFunction.QueueName}"));
                     cfg.AddConsumer<UserRolesChangedConsumer>();
                     cfg.AddConsumer<BookingReminderConsumer>();
                     cfg.AddConsumer<BookingMadeConsumer>();
+                    cfg.AddConsumer<BookingCancelledConsumer>();
                 },
                 connectionStringConfigurationKey: "ServiceBusConnectionString");
         }

--- a/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
@@ -17,6 +17,7 @@ public static class ServiceRegistration
         services.AddTransient<IUserRolesChangedNotifier, UserRolesChangedNotifier>()
                 .AddTransient<IBookingMadeNotifier, BookingNotifier>()
                 .AddTransient<IBookingReminderNotifier, BookingNotifier>()
+                .AddTransient<IBookingCancelledNotifier, BookingNotifier>()
                 .AddScoped<NotifyBookingReminderFunction>();
 
         if (userNotificationsProvider == "local")

--- a/src/api/Nhs.Appointments.Api/Notifications/template-bookingcancelled-rsv-email.txt
+++ b/src/api/Nhs.Appointments.Api/Notifications/template-bookingcancelled-rsv-email.txt
@@ -1,0 +1,23 @@
+﻿FOR INFO ONLY. THIS FILE IS NOT PART OF ANY BUILD OR DEPLOYMENT PIPELINE.
+
+This template is stored at https://www.notifications.service.gov.uk/
+
+Template name: Booking Cancelled (RSV)
+
+Template Subject: Cancellation - RSV appointment
+
+Template Body:
+
+You've cancelled your RSV (Respiratory syncytial virus) vaccination appointment.
+
+# Your cancelled appointment
+
+Booking reference: ((reference))
+((siteName))
+Date and time: ((date))
+((time))
+((address))
+
+# To rebook your appointment:
+
+* visit https://www.nhs.uk/book-rsv

--- a/src/api/Nhs.Appointments.Api/Notifications/template-bookingcancelled-rsv-sms.txt
+++ b/src/api/Nhs.Appointments.Api/Notifications/template-bookingcancelled-rsv-sms.txt
@@ -1,0 +1,5 @@
+﻿FOR INFO ONLY. THIS FILE IS NOT PART OF ANY BUILD OR DEPLOYMENT PIPELINE.
+
+This template is stored at https://www.notifications.service.gov.uk/
+
+Hello ((firstName)), you have cancelled your RSV vaccination appointment - Booking reference ((reference)). ((siteName)), ((date)), ((time)). To rebook your appointment visit https://www.nhs.uk/book-rsv

--- a/src/api/Nhs.Appointments.Api/local.settings.json
+++ b/src/api/Nhs.Appointments.Api/local.settings.json
@@ -4,6 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobs.NotifyUserRolesChanged.Disabled": true,
     "AzureWebJobs.NotifyBookingMade.Disabled": true,
+    "AzureWebJobs.NotifyBookingCancelled.Disabled": true,
     "AzureWebJobs.SendBookingReminders.Disabled": true,
     "AzureWebJobs.NotifyBookingReminder.Disabled": true,
     "AzureWebJobs.RemoveUnconfirmedProvisionalBookings.Disabled": true,

--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -10,7 +10,7 @@ public interface IBookingsService
     Task<Booking> GetBookingByReference(string bookingReference);
     Task<IEnumerable<Booking>> GetBookingByNhsNumber(string nhsNumber);
     Task<(bool Success, string Reference, bool Provisional)> MakeBooking(Booking booking);
-    Task CancelBooking(string site, string bookingReference);
+    Task<BookingCancellationResult> CancelBooking(string site, string bookingReference);
     Task<bool> SetBookingStatus(string bookingReference, string status);
     Task SendBookingReminders();
     Task<BookingConfirmationResult> ConfirmProvisionalBooking(string bookingReference, IEnumerable<ContactItem> contactDetails);
@@ -72,12 +72,24 @@ public class BookingsService(
         }            
     }
 
-    public Task CancelBooking(string site, string bookingReference)
+    public async Task<BookingCancellationResult> CancelBooking(string site, string bookingReference)
     {
-        return bookingDocumentStore
+        var booking = await bookingDocumentStore.GetByReferenceOrDefaultAsync(bookingReference);
+
+        if (booking == null)
+        {
+            return BookingCancellationResult.NotFound;
+        }
+
+        await bookingDocumentStore
             .BeginUpdate(site, bookingReference)
             .UpdateProperty(b => b.Outcome, "Cancelled")                
             .ApplyAsync();
+
+        var bookingCancelledEvent = BuildBookingCancelledEvent(booking);
+        await bus.Send (bookingCancelledEvent);
+
+        return BookingCancellationResult.Success;
     }
 
     public Task<BookingConfirmationResult> ConfirmProvisionalBooking(string bookingReference, IEnumerable<ContactItem> contactDetails)
@@ -118,6 +130,20 @@ public class BookingsService(
             Service = booking.Service,
             Site = booking.Site,
             ContactDetails = booking.ContactDetails.Select(c => new Messaging.Events.ContactItem { Type = c.Type, Value = c.Value}).ToArray()
+        };
+    }
+
+    private static BookingCancelled BuildBookingCancelledEvent(Booking booking)
+    {
+        return new BookingCancelled
+        {
+            FirstName = booking.AttendeeDetails?.FirstName,
+            From = booking.From,
+            LastName = booking.AttendeeDetails?.LastName,
+            Reference = booking.Reference,
+            Service = booking.Service,
+            Site = booking.Site,
+            ContactDetails = booking.ContactDetails?.Select(c => new Messaging.Events.ContactItem { Type = c.Type, Value = c.Value }).ToArray()
         };
     }
 

--- a/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
@@ -40,3 +40,9 @@ public enum BookingConfirmationResult
     Expired,
     NotFound
 }
+
+public enum BookingCancellationResult
+{
+    Success,
+    NotFound
+}

--- a/src/api/Nhs.Appointments.Core/Messaging/Events/BookingCancelled.cs
+++ b/src/api/Nhs.Appointments.Core/Messaging/Events/BookingCancelled.cs
@@ -1,0 +1,12 @@
+﻿namespace Nhs.Appointments.Core.Messaging.Events;
+
+public class BookingCancelled
+{
+    public string Reference { get; set; }
+    public DateTime From { get; set; }
+    public string Service { get; set; }
+    public string Site { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public ContactItem[] ContactDetails { get; set; }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/Consumers/BookingCancelledConsumerTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Consumers/BookingCancelledConsumerTests.cs
@@ -1,0 +1,108 @@
+﻿using MassTransit;
+using Moq;
+using Nhs.Appointments.Api.Consumers;
+using Nhs.Appointments.Api.Notifications;
+using Nhs.Appointments.Core.Messaging.Events;
+
+namespace Nhs.Appointments.Api.Tests.Consumers;
+
+public class BookingCancelledConsumerTests
+{
+    private BookingCancelledConsumer _sut;
+    private readonly Mock<IBookingCancelledNotifier> _notifier = new();
+
+    public BookingCancelledConsumerTests()
+    {
+        _sut = new BookingCancelledConsumer(_notifier.Object, TimeProvider.System);
+    }
+
+    [Fact]
+    public async Task NotifiesUserOnEventReceipt()
+    {
+        const string Site = "site:some-site";
+        const string Email = "test@tempuri.org";
+        const string FirstName = "joe";
+        const string PhoneNumber = "0123456789";
+        const string Reference = "booking-ref-1234";
+        const string Service = "covid-19";
+        DateOnly date = new DateOnly(DateTime.Now.AddYears(1).Year, 1, 1);
+        TimeOnly time = new TimeOnly(12, 15);
+
+        _notifier.Setup(x => x.Notify(nameof(BookingCancelled), Service, Reference, Site, FirstName, date, time, Email, PhoneNumber)).Verifiable();
+        var ctx = new Mock<ConsumeContext<BookingCancelled>>();
+        ctx.SetupGet(x => x.Message).Returns(new BookingCancelled
+        {
+            FirstName = FirstName,
+            From = new DateTime(date, time),
+            Reference = Reference,
+            Site = Site,
+            Service = Service,
+            ContactDetails = [
+                new ContactItem{Type = ContactItemType.Email, Value = Email},
+                new ContactItem{Type = ContactItemType.Phone, Value = PhoneNumber}
+                ]
+        });
+
+        await _sut.Consume(ctx.Object);
+
+        _notifier.Verify();
+    }
+
+    [Fact]
+    public async Task DoesNotNotifyUserIfNoContactDetails()
+    {
+        const string Site = "site:some-site";
+        const string FirstName = "joe";
+        const string Reference = "booking-ref-1234";
+        const string Service = "covid-19";
+        DateOnly date = new DateOnly(DateTime.Now.AddYears(1).Year, 1, 1);
+        TimeOnly time = new TimeOnly(12, 15);
+
+        _notifier.Setup(x => x.Notify(nameof(BookingCancelled), Service, Reference, Site, FirstName, date, time, It.IsAny<string>(), It.IsAny<string>())).Verifiable(Times.Never);
+        var ctx = new Mock<ConsumeContext<BookingCancelled>>();
+        ctx.SetupGet(x => x.Message).Returns(new BookingCancelled
+        {
+            FirstName = FirstName,
+            From = new DateTime(date, time),
+            Reference = Reference,
+            Site = Site,
+            Service = Service
+        });
+
+        await _sut.Consume(ctx.Object);
+
+        _notifier.Verify();
+    }
+
+    [Fact]
+    public async Task DoesNotNotifyUserIfAppointmentIsInThePast()
+    {
+        const string Site = "site:some-site";
+        const string Email = "test@tempuri.org";
+        const string FirstName = "joe";
+        const string PhoneNumber = "0123456789";
+        const string Reference = "booking-ref-1234";
+        const string Service = "covid-19";
+        DateOnly date = new DateOnly(DateTime.Now.AddYears(-1).Year, 1, 1);
+        TimeOnly time = new TimeOnly(12, 15);
+
+        _notifier.Setup(x => x.Notify(nameof(BookingCancelled), Service, Reference, Site, FirstName, date, time, Email, PhoneNumber)).Verifiable(Times.Never);
+        var ctx = new Mock<ConsumeContext<BookingCancelled>>();
+        ctx.SetupGet(x => x.Message).Returns(new BookingCancelled
+        {
+            FirstName = FirstName,
+            From = new DateTime(date, time),
+            Reference = Reference,
+            Site = Site,
+            Service = Service,
+            ContactDetails = [
+                new ContactItem{Type = ContactItemType.Email, Value = Email},
+                new ContactItem{Type = ContactItemType.Phone, Value = PhoneNumber}
+                ]
+        });
+
+        await _sut.Consume(ctx.Object);
+
+        _notifier.Verify();
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelBookingFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelBookingFunctionTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Text;
+using System.Web.Http;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Nhs.Appointments.Api.Auth;
+using Nhs.Appointments.Api.Functions;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Core;
+
+namespace Nhs.Appointments.Api.Tests.Functions;
+
+public class CancelBookingFunctionTests
+{
+    private static readonly DateOnly Date = new DateOnly(2077, 1, 1);
+    private readonly CancelBookingFunction _sut;
+    private readonly Mock<IBookingsService> _bookingService = new();
+    private readonly Mock<IUserContextProvider> _userContextProvider = new();
+    private readonly Mock<IValidator<CancelBookingRequest>> _validator = new();
+    private readonly Mock<ILogger<CancelBookingFunction>> _logger = new();
+    private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
+
+    public CancelBookingFunctionTests()
+    {
+        _sut = new CancelBookingFunction(_bookingService.Object, _validator.Object, _userContextProvider.Object, _logger.Object, _metricsRecorder.Object);
+        _validator.Setup(x => x.ValidateAsync(It.IsAny<CancelBookingRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsSuccessResponse_WhenBookingCancelled()
+    {
+        var site = "some-site";
+        var bookingRef = "some-booking";
+        _bookingService.Setup(x => x.CancelBooking(site, bookingRef)).Returns(Task.FromResult(BookingCancellationResult.Success));
+
+        var request = BuildRequest(site, bookingRef);
+
+        var response = await _sut.RunAsync(request) as ContentResult;
+
+        Assert.Equal(200, response.StatusCode.Value);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsNotFoundResponse_WhenBookingInvalid()
+    {
+        var site = "some-site";
+        var bookingRef = "some-booking";
+        _bookingService.Setup(x => x.CancelBooking(site, bookingRef)).Returns(Task.FromResult(BookingCancellationResult.NotFound));
+
+        var request = BuildRequest(site, bookingRef);
+
+        var response = await _sut.RunAsync(request) as ContentResult;
+
+        Assert.Equal(404, response.StatusCode.Value);
+    }
+
+    [Fact]
+    public async Task RunAsync_Fails_WhenServiceReturnsUnexpected()
+    {
+        var site = "some-site";
+        var bookingRef = "some-booking";
+        var invalidResultCode = 99;
+        _bookingService.Setup(x => x.CancelBooking(site, bookingRef)).Returns(Task.FromResult((BookingCancellationResult)invalidResultCode));
+
+        var request = BuildRequest(site, bookingRef);
+
+        var response = await _sut.RunAsync(request) as InternalServerErrorResult;
+
+        Assert.NotNull(response);
+        Assert.Equal(500, response.StatusCode);
+    }
+
+    private static HttpRequest BuildRequest(string site, string bookingRef)
+    {
+        var context = new DefaultHttpContext();
+        var request = context.Request;
+
+        var dto = new CancelBookingRequest(bookingRef, site);
+        var body = JsonConvert.SerializeObject(dto);
+        request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        request.Headers.Add("Authorization", "Test 123");
+        return request;
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingServiceTests.cs
@@ -156,6 +156,51 @@ namespace Nhs.Appointments.Core.UnitTests
             result.Reference.Should().Be(string.Empty);
         }
 
+        [Fact]
+        public async Task CancelBooking_ReturnsNonSuccess_WhenInvalidReference()
+        {
+            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync(It.IsAny<string>())).Returns(Task.FromResult((Booking)null));
+            var result = await _bookingsService.CancelBooking("some-site", "some-reference");
+            Assert.Equal(BookingCancellationResult.NotFound, result);
+        }
+
+        [Fact]
+        public async Task CancelBooking_CancelsBookingInDatabase()
+        {
+            var site = "some-site";
+            var bookingRef = "some-booking";
+
+            var updateMock = new Mock<IDocumentUpdate<Booking>>();
+            updateMock.Setup(x => x.UpdateProperty(b => b.Outcome, "Cancelled")).Returns(updateMock.Object).Verifiable();
+
+            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync(It.IsAny<string>())).Returns(Task.FromResult(new Booking()));
+            _bookingsDocumentStore.Setup(x => x.BeginUpdate(site, bookingRef)).Returns(updateMock.Object).Verifiable();
+
+            await _bookingsService.CancelBooking(site, bookingRef);
+
+            _bookingsDocumentStore.VerifyAll();
+            updateMock.VerifyAll();
+        }
+
+        [Fact]
+        public async Task CancelBooking_RaisesNotificationEvent()
+        {
+            var site = "some-site";
+            var bookingRef = "some-booking";
+
+            var updateMock = new Mock<IDocumentUpdate<Booking>>();
+            updateMock.Setup(x => x.UpdateProperty(b => b.Outcome, "Cancelled")).Returns(updateMock.Object);
+
+            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync(It.IsAny<string>())).Returns(Task.FromResult(new Booking { Reference = bookingRef, Site = site}));
+            _bookingsDocumentStore.Setup(x => x.BeginUpdate(site, bookingRef)).Returns(updateMock.Object);
+
+            _messageBus.Setup(x => x.Send(It.Is<BookingCancelled>(e => e.Site == site && e.Reference == bookingRef))).Verifiable();
+
+            await _bookingsService.CancelBooking(site, bookingRef);
+
+            _messageBus.VerifyAll();
+        }
+
     }
 
     public class FakeLeaseManager : ISiteLeaseManager


### PR DESCRIPTION
To enable cancellation notifications for the other service types (covid 19, flu etc):

- add the templates to Gov Notify 
- add the new template GUIDs to the notification_config item in Cosmos
- add the template text files to the solution for safekeeping