### PR TITLE
validating that json payload can be converted to request type

### DIFF
--- a/src/api/Nhs.Appointments.Api/Availability/QueryAvailabilityRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Availability/QueryAvailabilityRequest.cs
@@ -9,14 +9,9 @@ public record QueryAvailabilityRequest(
     [JsonProperty("service")]
     string Service,
     [JsonProperty("from")]
-    string From,
+    DateOnly From,
     [JsonProperty("until")]
-    string Until,
+    DateOnly Until,
     [JsonProperty("queryType")]
     QueryType QueryType
-)
-
-{
-    public DateOnly FromDate => DateOnly.ParseExact(From, "yyyy-MM-dd");
-    public DateOnly UntilDate => DateOnly.ParseExact(Until, "yyyy-MM-dd");
-}
+);

--- a/src/api/Nhs.Appointments.Api/Availability/QueryAvailabilityRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Availability/QueryAvailabilityRequestValidator.cs
@@ -15,20 +15,8 @@ public class QueryAvailabilityRequestValidator : AbstractValidator<QueryAvailabi
             .NotEmpty().WithMessage("One or more site identifiers must be provided");
         RuleForEach(x => x.Sites)
             .NotEmpty().WithMessage("All provided site identifiers must be valid");
-        RuleFor(x => x.From).Cascade(CascadeMode.Stop)
-            .NotEmpty().WithMessage("Provide a date in the format 'yyyy-MM-dd'")
-            .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _)).WithMessage("Provide a date in the format 'yyyy-MM-dd'")
-            .DependentRules(() =>
-            {
-                RuleFor(x => x.Until).Cascade(CascadeMode.Stop)
-                    .NotEmpty().WithMessage("Provide a date in the format 'yyyy-MM-dd'")
-                    .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _)).WithMessage("Provide a date in the format 'yyyy-MM-dd'")
-                    .DependentRules(() =>
-                    {
-                        RuleFor(x => x.FromDate).Cascade(CascadeMode.Stop)
-                            .LessThanOrEqualTo(x => x.UntilDate).WithMessage("From date must be on or before Until date");
-                    });
-            });
+        RuleFor(x => x.From)
+            .LessThanOrEqualTo(x => x.Until).WithMessage("From date must be on or before Until date");        
         RuleFor(x => x.Service)
             .NotEmpty().WithMessage("Provide a valid string");
         RuleFor(x => x.QueryType)

--- a/src/api/Nhs.Appointments.Api/Functions/ApplyAvailabilityTemplateFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/ApplyAvailabilityTemplateFunction.cs
@@ -32,7 +32,7 @@ public class ApplyAvailabilityTemplateFunction(IAvailabilityService availability
 
     protected override async Task<ApiResult<EmptyResponse>> HandleRequest(ApplyAvailabilityTemplateRequest request, ILogger logger)
     {
-        await availabilityService.ApplyAvailabilityTemplateAsync(request.Site, request.FromDate, request.UntilDate, request.Template);
+        await availabilityService.ApplyAvailabilityTemplateAsync(request.Site, request.From, request.Until, request.Template);
         return Success(new EmptyResponse());
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/BaseApiFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/BaseApiFunction.cs
@@ -21,9 +21,9 @@ public abstract class BaseApiFunction<TRequest, TResponse>(IValidator<TRequest> 
     {
         try
         {
-            (bool requestRead, TRequest request) = await ReadRequestAsync(req);
-            if (requestRead == false)
-                return ProblemResponse(HttpStatusCode.BadRequest, "The request was invalid");
+            (IReadOnlyCollection<ErrorMessageResponseItem> errors, TRequest request) = await ReadRequestAsync(req);
+            if (errors.Any())
+                return ProblemResponse(HttpStatusCode.BadRequest, errors);
 
             var validationErrors = await ValidateRequest(request);
             if (validationErrors.Any())
@@ -55,7 +55,7 @@ public abstract class BaseApiFunction<TRequest, TResponse>(IValidator<TRequest> 
         }
     }    
     
-    protected virtual Task<(bool requestRead, TRequest request)> ReadRequestAsync(HttpRequest req) => JsonRequestReader.TryReadRequestAsync<TRequest>(req.Body);
+    protected virtual Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, TRequest request)> ReadRequestAsync(HttpRequest req) => JsonRequestReader.ReadRequestAsync<TRequest>(req.Body);
 
     protected virtual async Task<IEnumerable<ErrorMessageResponseItem>> ValidateRequest(TRequest request)
     {

--- a/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Routing;
 using ContactItem = Nhs.Appointments.Api.Models.ContactItem;
 using Nhs.Appointments.Api.Json;
+using MassTransit.SqlTransport;
 
 namespace Nhs.Appointments.Api.Functions;
 
@@ -58,18 +59,19 @@ public class ConfirmProvisionalBookingFunction(IBookingsService bookingService,
         return Failed(HttpStatusCode.InternalServerError, "An uknown error occured when trying to confirm the appointment");
     }
 
-    protected override async Task<(bool requestRead, ConfirmBookingRequest request)> ReadRequestAsync(HttpRequest req)
+    protected override async Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, ConfirmBookingRequest request)> ReadRequestAsync(HttpRequest req)
     {
         var contactDetails = new ContactItem[] { };
         if (req.Body != null)
         {
-            var (read, payload) = await JsonRequestReader.TryReadRequestAsync<ConfirmBookingRequestPayload>(req.Body);
-            if(read && payload != null)
-                contactDetails = payload.contactDetails ?? new ContactItem[] { };
+            var (errors, payload) = await JsonRequestReader.ReadRequestAsync<ConfirmBookingRequestPayload>(req.Body);
+            if (errors.Any())
+                return (errors, null);            
+            contactDetails = payload?.contactDetails ?? new ContactItem[] { };
         }
         var bookingReference = req.HttpContext.GetRouteValue("bookingReference")?.ToString();
 
-        return (true, new ConfirmBookingRequest(bookingReference, contactDetails));
+        return (ErrorMessageResponseItem.None, new ConfirmBookingRequest(bookingReference, contactDetails));
     }
     
 }

--- a/src/api/Nhs.Appointments.Api/Functions/GetRolesFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetRolesFunction.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using FluentValidation;
@@ -35,9 +36,9 @@ public class GetRolesFunction(IRolesService rolesService, IValidator<GetRolesReq
         return ApiResult<GetRolesResponse>.Success(new GetRolesResponse(mappedRoles.ToArray()));
     }
     
-    protected override Task<(bool requestRead, GetRolesRequest request)> ReadRequestAsync(HttpRequest req)
+    protected override Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetRolesRequest request)> ReadRequestAsync(HttpRequest req)
     {
         var tag = req.Query["tag"];
-        return Task.FromResult<(bool requestRead, GetRolesRequest request)>((true, new GetRolesRequest(tag)));
+        return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem>, GetRolesRequest request)>((ErrorMessageResponseItem.None, new GetRolesRequest(tag)));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
@@ -43,15 +43,19 @@ public class GetSitesByAreaFunction(ISiteService siteService, IValidator<GetSite
         return ApiResult<IEnumerable<SiteWithDistance>>.Success(sites);
     }
     
-    protected override Task<(bool requestRead, GetSitesByAreaRequest request)> ReadRequestAsync(HttpRequest req)
+    protected override Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetSitesByAreaRequest request)> ReadRequestAsync(HttpRequest req)
     {
+        var errors = new List<ErrorMessageResponseItem>();
         var accessNeeds = req.Query.ContainsKey("accessNeeds") ? req.Query["accessNeeds"].ToString().Split(',') : Array.Empty<string>();
         if (accessNeeds.Any(string.IsNullOrEmpty))
-            return Task.FromResult<(bool requestRead, GetSitesByAreaRequest request)>((false, null));
+        {
+            errors.Add(new ErrorMessageResponseItem { Property = "accessNeeds", Message = "Access needs cannot be contain empty values" });
+            return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetSitesByAreaRequest request)>((errors.AsReadOnly(), null));
+        }
         var longitude = double.Parse(req.Query["long"]);
         var latitude = double.Parse(req.Query["lat"]);
         var searchRadius = int.Parse(req.Query["searchRadius"]);
         var maximumRecords = int.Parse(req.Query["maxRecords"]);
-        return Task.FromResult<(bool requestRead, GetSitesByAreaRequest request)>((true, new GetSitesByAreaRequest(longitude, latitude, searchRadius, maximumRecords, accessNeeds)));
+        return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetSitesByAreaRequest request)>((errors.AsReadOnly(), new GetSitesByAreaRequest(longitude, latitude, searchRadius, maximumRecords, accessNeeds)));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/QueryAvailabilityFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/QueryAvailabilityFunction.cs
@@ -38,8 +38,8 @@ public class QueryAvailabilityFunction(IAvailabilityCalculator availabilityCalcu
     {
         var concurrentResults = new ConcurrentBag<QueryAvailabilityResponseItem>();
         var response = new QueryAvailabilityResponse();
-        var requestFrom = request.FromDate;
-        var requestUntil = request.UntilDate;
+        var requestFrom = request.From;
+        var requestUntil = request.Until;
 
         await Parallel.ForEachAsync(request.Sites, async (site, ct) =>
         {

--- a/src/api/Nhs.Appointments.Api/Functions/QueryBookingByNhsNumberFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/QueryBookingByNhsNumberFunction.cs
@@ -38,9 +38,12 @@ public class QueryBookingByNhsNumberFunction(IBookingsService bookingsService, I
         return Success(booking);
     }
 
-    protected override Task<(bool requestRead, QueryBookingByNhsNumberRequest request)> ReadRequestAsync(HttpRequest req)
+    protected override Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, QueryBookingByNhsNumberRequest request)> ReadRequestAsync(HttpRequest req)
     {
+        var errors = new List<ErrorMessageResponseItem>();
         var nhsNumber = req.Query["nhsNumber"];
-        return Task.FromResult<(bool requestRead, QueryBookingByNhsNumberRequest request)>((true, new QueryBookingByNhsNumberRequest(nhsNumber)));
+        if (string.IsNullOrEmpty(nhsNumber))
+            errors.Add(new ErrorMessageResponseItem { Property = "nhsNumber", Message = "You must provide an nhsNumber" });
+        return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, QueryBookingByNhsNumberRequest request)>((errors.AsReadOnly(), new QueryBookingByNhsNumberRequest(nhsNumber)));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/QueryBookingByReferenceFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/QueryBookingByReferenceFunction.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.OpenApi.Models;
 using Nhs.Appointments.Api.Auth;
+using System.Collections.Generic;
 
 namespace Nhs.Appointments.Api.Functions;
 
@@ -45,9 +46,9 @@ public class QueryBookingByReferenceFunction(IBookingsService bookingsService, I
         return Success(booking);
     }
 
-    protected override Task<(bool requestRead, QueryBookingByReferenceRequest request)> ReadRequestAsync(HttpRequest req)
+    protected override Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, QueryBookingByReferenceRequest request)> ReadRequestAsync(HttpRequest req)
     {
         var bookingReference = req.HttpContext.GetRouteValue("bookingReference")?.ToString();
-        return Task.FromResult((true, new QueryBookingByReferenceRequest(bookingReference)));
+        return Task.FromResult((ErrorMessageResponseItem.None, new QueryBookingByReferenceRequest(bookingReference)));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/SetSiteAttributesFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/SetSiteAttributesFunction.cs
@@ -40,10 +40,10 @@ public class SetSiteAttributesFunction(ISiteService siteService, IValidator<SetS
         return result.Success ? Success(new EmptyResponse()) : Failed(HttpStatusCode.NotFound, result.Message);
     }
 
-    protected override async Task<(bool requestRead, SetSiteAttributesRequest request)> ReadRequestAsync(HttpRequest req)
+    protected override async Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, SetSiteAttributesRequest request)> ReadRequestAsync(HttpRequest req)
     {
         var site = req.HttpContext.GetRouteValue("site")?.ToString();
-        var attributes = await JsonRequestReader.ReadRequestAsync<AttributeRequest>(req.Body);
-        return (true, new SetSiteAttributesRequest(site, attributes.Scope, attributes.AttributeValues));
+        var (errors, attributes) = await JsonRequestReader.ReadRequestAsync<AttributeRequest>(req.Body);
+        return (errors, new SetSiteAttributesRequest(site, attributes?.Scope, attributes?.AttributeValues));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/SiteBasedResourceFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/SiteBasedResourceFunction.cs
@@ -5,22 +5,23 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
+using System.Collections.Generic;
 
 namespace Nhs.Appointments.Api.Functions;
 
 public abstract class SiteBasedResourceFunction<TResponse>(IValidator<SiteBasedResourceRequest> validator, IUserContextProvider userContextProvider, ILogger logger, IMetricsRecorder metricsRecorder) : BaseApiFunction<SiteBasedResourceRequest, TResponse>(validator, userContextProvider, logger, metricsRecorder)
 {
-    protected override Task<(bool requestRead, SiteBasedResourceRequest request)> ReadRequestAsync(HttpRequest req)
+    protected override Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, SiteBasedResourceRequest request)> ReadRequestAsync(HttpRequest req)
     {
         var requestedScope = req.Query.Keys.Contains("scope") ? req.Query["scope"].ToString() : "*";
 
         if (req.Query.Keys.Contains("site"))
         {
             var site = req.Query["site"];
-            return Task.FromResult<(bool requestRead, SiteBasedResourceRequest request)>((true, new SiteBasedResourceRequest(site, requestedScope)));
+            return Task.FromResult((ErrorMessageResponseItem.None, new SiteBasedResourceRequest(site, requestedScope)));
         }
 
         var siteId = RestUriHelper.GetResourceIdFromPath(req.Path.ToUriComponent(), "sites");
-        return Task.FromResult<(bool requestRead, SiteBasedResourceRequest request)>((true, new SiteBasedResourceRequest(siteId, requestedScope)));
+        return Task.FromResult((ErrorMessageResponseItem.None, new SiteBasedResourceRequest(siteId, requestedScope)));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Json/JsonToObjectSchemaValidation.cs
+++ b/src/api/Nhs.Appointments.Api/Json/JsonToObjectSchemaValidation.cs
@@ -1,0 +1,182 @@
+﻿using Newtonsoft.Json;
+using Nhs.Appointments.Api.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+
+namespace Nhs.Appointments.Api.Json
+{
+    internal static class JsonToObjectSchemaValidation
+    {
+        public static List<ErrorMessageResponseItem> ValidateConversion<TRequest>(string json)
+        {
+            var errorList = new List<ErrorMessageResponseItem>();
+            var document = JsonDocument.Parse(json); // If this throws an exception then we have a invalid json
+
+            // First thing to check, if the root element is an array or an object
+            var requestType = typeof(TRequest);
+
+            if (requestType.IsArray)
+            {
+                if (document.RootElement.ValueKind != JsonValueKind.Array)
+                {
+                    errorList.Add(new ErrorMessageResponseItem { Property = "", Message = "Expected an array but got " + document.RootElement.ValueKind.ToString() });
+                } 
+                else
+                {
+                    errorList = CheckArray(document.RootElement, requestType.GetElementType(), "root");
+                }
+            }
+            else
+            {
+                if (document.RootElement.ValueKind != JsonValueKind.Object)
+                {
+                    errorList.Add(new ErrorMessageResponseItem { Property = "", Message = "Expected an object but got " + document.RootElement.ValueKind.ToString() });
+                }
+                else
+                {
+                    errorList = CheckObject<TRequest>(document.RootElement);
+                }
+            }
+
+            return errorList;
+        }
+
+        private static List<ErrorMessageResponseItem> CheckArray(JsonElement json, Type arrayType, string path)
+        {
+            var errors = new List<ErrorMessageResponseItem>();
+            var enumerator = json.EnumerateArray();
+            int elementIndex = 0;
+            while(enumerator.MoveNext())
+            {
+                var typeErrors = CheckType(arrayType, enumerator.Current, $"{path}[{elementIndex}]");
+                errors.AddRange(typeErrors);
+                elementIndex++;
+            }
+            return errors;
+        }
+
+        private static List<ErrorMessageResponseItem> CheckObject<TObj>(JsonElement json)
+        {
+            var objType = typeof(TObj);
+            return CheckObject(json, objType);
+        }
+
+        private static List<ErrorMessageResponseItem> CheckObject(JsonElement json, Type objType)
+        {            
+            var objectEnumerator = json.EnumerateObject();
+            var errors = new List<ErrorMessageResponseItem>();
+
+            while (objectEnumerator.MoveNext())
+            {
+                var jsonProperty = objectEnumerator.Current;
+                var objProperty = GetProperty(jsonProperty.Name, objType);
+
+                if (objProperty == null)
+                {
+                    errors.Add(new ErrorMessageResponseItem { Property = jsonProperty.Name, Message = "Does not exist on request type (over posting)" });
+                }
+                else
+                {                    
+                    var propErrors = CheckType(objProperty.PropertyType, jsonProperty);
+                    errors.AddRange(propErrors);                    
+                }
+            }
+
+            return errors;
+        }
+
+        private static List<ErrorMessageResponseItem> CheckType(Type type, JsonProperty json)
+        {
+            return CheckType(type, json.Value, json.Name);
+        }
+
+        private static List<ErrorMessageResponseItem> CheckType(Type type, JsonElement json, string path)
+        {
+            var errorMessage = "";
+            var errors = new List<ErrorMessageResponseItem>();
+
+            switch (type.Name)
+            {
+                case nameof(Int32):
+                    if (json.ValueKind != JsonValueKind.Number)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = "Expected a number but found " + json.ValueKind });
+                    else if (json.TryGetInt32(out var val) == false)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = "Expected an ineger but found a floating point number" });
+                    break;
+                case nameof(TimeOnly):
+                    errorMessage = $"Times should be provided as a string in the following format {DateTimeFormats.TimeOnly}";
+                    if (json.ValueKind != JsonValueKind.String)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = errorMessage });
+                    if (TimeOnly.TryParseExact(json.GetString(), DateTimeFormats.TimeOnly, null, System.Globalization.DateTimeStyles.None, out var _) == false)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = errorMessage });
+                    break;
+                case nameof(DateOnly):
+                    errorMessage = $"Dates should be provided as a string in the following format {DateTimeFormats.DateOnly}";
+                    if (json.ValueKind != JsonValueKind.String)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = errorMessage });
+                    if (DateOnly.TryParseExact(json.GetString(), DateTimeFormats.DateOnly, null, System.Globalization.DateTimeStyles.None, out var _) == false)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = errorMessage });
+                    break;
+                case nameof(DateTime):
+                    errorMessage = $"Date time data should be provided as a string in the following format {DateTimeFormats.DateTime}";
+                    if (json.ValueKind != JsonValueKind.String)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = errorMessage });
+                    if (DateTime.TryParseExact(json.GetString(), DateTimeFormats.DateTime, null, System.Globalization.DateTimeStyles.None, out var _) == false)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = errorMessage });
+                    break;
+                case nameof(Boolean):
+                    if (json.ValueKind != JsonValueKind.True && json.ValueKind != JsonValueKind.False)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = "Expected a boolean value but found " + json.ValueKind });
+                    break;
+                case nameof(String):
+                    if (json.ValueKind != JsonValueKind.String)
+                        errors.Add(new ErrorMessageResponseItem { Property = path, Message = "Expected a string but found " + json.ValueKind });
+                    break;
+            }
+
+            if (type.IsArray)
+            {
+                if (json.ValueKind != JsonValueKind.Array)
+                    errors.Add(new ErrorMessageResponseItem { Property = path, Message = "Expected an array but found " + json.ValueKind });
+                else
+                {
+                    var nestedErrors = CheckArray(json, type.GetElementType(), path);
+                    errors.AddRange(nestedErrors);
+                }                
+            }
+
+            if (type.IsEnum)
+            {
+                if (json.ValueKind != JsonValueKind.String)
+                    errors.Add(new ErrorMessageResponseItem { Property = path, Message = "Expected a string value but found " + json.ValueKind });
+                else if (Enum.TryParse(type, json.GetString(), out var val) == false)
+                    errors.Add(new ErrorMessageResponseItem { Property = path, Message = $"{json.GetString()} is not a valid value" });
+            }
+
+            var classesToIgnore = new[] { nameof(String) };
+
+            if (type.IsClass && !type.IsArray && classesToIgnore.Contains(type.Name) == false)
+            {
+                if(json.ValueKind != JsonValueKind.Object)
+                    errors.Add(new ErrorMessageResponseItem { Property = path, Message = "Expected an object but found " + json.ValueKind });
+                else
+                {
+                    var nestedErrors = CheckObject(json, type);
+                    errors.AddRange(nestedErrors);
+                }
+            }
+
+            return errors;
+        }
+
+        private static PropertyInfo GetProperty(string name, Type type)
+        {
+            // Look for JSON attributes first
+            var matchByJsonProp = type.GetProperties().Where(p => p.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName == name).SingleOrDefault();
+            return matchByJsonProp ?? type.GetProperties().Where(p => p.Name.ToLower() == name.ToLower()).SingleOrDefault();
+        }
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Models/ApplyAvailabilityTemplateRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/ApplyAvailabilityTemplateRequest.cs
@@ -9,13 +9,9 @@ public record ApplyAvailabilityTemplateRequest(
     [JsonProperty("site")]
     string Site,
     [JsonProperty("from")]
-    string From,
+    DateOnly From,
     [JsonProperty("until")]
-    string Until,
+    DateOnly Until,
     [JsonProperty("template")]
     Template Template
-)
-{
-    public DateOnly FromDate => DateOnly.ParseExact(From, "yyyy-MM-dd", CultureInfo.InvariantCulture);
-    public DateOnly UntilDate => DateOnly.ParseExact(Until, "yyyy-MM-dd",  CultureInfo.InvariantCulture);
-};
+);

--- a/src/api/Nhs.Appointments.Api/Models/ErrorMessageResponseItem.cs
+++ b/src/api/Nhs.Appointments.Api/Models/ErrorMessageResponseItem.cs
@@ -1,7 +1,12 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Nhs.Appointments.Api.Models;
 
 public class ErrorMessageResponseItem
 {
     public string Message { get; set; }
     public string Property { get; set; }
+
+    public static IReadOnlyCollection<ErrorMessageResponseItem> None => Enumerable.Empty<ErrorMessageResponseItem>().ToList().AsReadOnly();
 }

--- a/src/api/Nhs.Appointments.Api/Validators/ApplyAvailabilityTemplateRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/ApplyAvailabilityTemplateRequestValidator.cs
@@ -12,25 +12,9 @@ public class ApplyAvailabilityTemplateRequestValidator : AbstractValidator<Apply
         RuleFor(x => x.Site)            
             .NotEmpty()
             .WithMessage("Provide a valid site");
-        RuleFor(x => x.From).Cascade(CascadeMode.Stop)
-            .NotEmpty()
-            .Must(x => DateOnly.TryParseExact(x.ToString(), "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var _))
-            .WithMessage("Provide a from date in the format 'yyyy-MM-dd'")
-            .DependentRules(
-                () =>
-                {
-                    RuleFor(x => x.Until).Cascade(CascadeMode.Stop)
-                        .NotEmpty()
-                        .Must(x => DateOnly.TryParseExact(x.ToString(), "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var _))
-                        .WithMessage("Provide a from date in the format 'yyyy-MM-dd'")
-                        .DependentRules(
-                        () =>
-                        {
-                            RuleFor(x => x.FromDate).Cascade(CascadeMode.Stop)
-                                .LessThanOrEqualTo(x => x.UntilDate)
+        RuleFor(x => x.From)
+                                .LessThanOrEqualTo(x => x.Until)
                                 .WithMessage("'until' date must be after 'from' date");
-                        });
-                });
         RuleFor(x => x.Template)
             .NotEmpty()
             .WithMessage("Please provide a valid template")

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/AttributeDefinitions/AttributeDefinitionsFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/AttributeDefinitions/AttributeDefinitionsFeatureSteps.cs
@@ -40,7 +40,7 @@ public sealed class AttributeDefinitionsFeatureSteps : BaseFeatureSteps
     {
         _response = await Http.GetAsync("http://localhost:7071/api/attributeDefinitions");
         _statusCode = _response.StatusCode;
-        _actualResponse = await JsonRequestReader.ReadRequestAsync<IEnumerable<AttributeDefinition>>(await _response.Content.ReadAsStreamAsync());
+        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<IEnumerable<AttributeDefinition>>(await _response.Content.ReadAsStreamAsync());
     }
     
     [Then("the following attribute definitions are returned")] 

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/AvailabilityBaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/AvailabilityBaseFeatureSteps.cs
@@ -42,7 +42,7 @@ public abstract class AvailabilityBaseFeatureSteps : BaseFeatureSteps
             
         _response = await Http.PostAsJsonAsync($"http://localhost:7071/api/availability/query", payload);
         _statusCode = _response.StatusCode;
-        _actualResponse = await JsonRequestReader.ReadRequestAsync<QueryAvailabilityResponse>(await _response.Content.ReadAsStreamAsync());
+        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<QueryAvailabilityResponse>(await _response.Content.ReadAsStreamAsync());
     }
         
     [Then(@"the following availability is returned for '(\d{4}-\d{2}-\d{2})'")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.cs
@@ -24,7 +24,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
         {
             _response = await Http.GetAsync($"http://localhost:7071/api/booking?nhsNumber={NhsNumber}");
             _statusCode = _response.StatusCode;
-            _actualResponse = await JsonRequestReader.ReadRequestAsync<List<Core.Booking>>(await _response.Content.ReadAsStreamAsync());
+            (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<List<Core.Booking>>(await _response.Content.ReadAsStreamAsync());
         }
         
         [Then(@"the following bookings are returned")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/ApplyAvailabilityTemplateFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/ApplyAvailabilityTemplateFeatureSteps.cs
@@ -46,11 +46,11 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.CreateAvailability
                 }
             };
             
-            var request = new ApplyAvailabilityTemplateRequest(site, cells.ElementAt(0).Value, cells.ElementAt(1).Value, template);
+            var request = new ApplyAvailabilityTemplateRequest(site, DateOnly.ParseExact(cells.ElementAt(0).Value, DateTimeFormats.DateOnly) , DateOnly.ParseExact(cells.ElementAt(1).Value, DateTimeFormats.DateOnly), template);
             var payload = JsonResponseWriter.Serialize(request);
             _response = await Http.PostAsync($"http://localhost:7071/api/availability/apply-template", new StringContent(payload));
             _statusCode = _response.StatusCode;
-            _actualResponse = await JsonRequestReader.ReadRequestAsync<EmptyResponse>(await _response.Content.ReadAsStreamAsync());
+            (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<EmptyResponse>(await _response.Content.ReadAsStreamAsync());
         }
             
         [Then("the request is successful and the following daily availability is created")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/RoleManagement/RoleManagementFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/RoleManagement/RoleManagementFeatureSteps.cs
@@ -28,7 +28,7 @@ public sealed class RoleManagementFeatureSteps : BaseFeatureSteps
     {
         _response = await Http.GetAsync($"http://localhost:7071/api/roles?tag={tag}");
         _statusCode = _response.StatusCode;
-        _actualResponse = await JsonRequestReader.ReadRequestAsync<GetRolesResponse>(await _response.Content.ReadAsStreamAsync());
+        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<GetRolesResponse>(await _response.Content.ReadAsStreamAsync());
     }
 
     [Then("The following roles are returned")] 

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteByIdFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteByIdFeatureSteps.cs
@@ -32,7 +32,7 @@ public sealed class GetSiteByIdFeatureSteps : SiteManagementBaseFeatureSteps
                 Coordinates: [double.Parse(row.Cells.ElementAt(4).Value), double.Parse(row.Cells.ElementAt(5).Value)])
         );
         Response.StatusCode.Should().Be(HttpStatusCode.OK);
-        ActualResponse = await JsonRequestReader.ReadRequestAsync<Site>(await Response.Content.ReadAsStreamAsync());
+        (_, ActualResponse) = await JsonRequestReader.ReadRequestAsync<Site>(await Response.Content.ReadAsStreamAsync());
         ActualResponse.Should().BeEquivalentTo(expectedSite);
     }
 }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteMetaDataFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteMetaDataFeatureSteps.cs
@@ -29,7 +29,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement
                 AdditionalInformation: row.Cells.ElementAt(1).Value);
 
             Response.StatusCode.Should().Be(HttpStatusCode.OK);
-            var actualResponse = await JsonRequestReader.ReadRequestAsync<GetSiteMetaDataResponse>(await Response.Content.ReadAsStreamAsync());
+            var (_, actualResponse) = await JsonRequestReader.ReadRequestAsync<GetSiteMetaDataResponse>(await Response.Content.ReadAsStreamAsync());
             actualResponse.Should().BeEquivalentTo(expectedSite);
         }
 
@@ -37,7 +37,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement
         public async Task AssertEmpty()
         {
             Response.StatusCode.Should().Be(HttpStatusCode.OK);
-            var actualResponse = await JsonRequestReader.ReadRequestAsync<GetSiteMetaDataResponse>(await Response.Content.ReadAsStreamAsync());
+            var (_, actualResponse) = await JsonRequestReader.ReadRequestAsync<GetSiteMetaDataResponse>(await Response.Content.ReadAsStreamAsync());
             actualResponse.AdditionalInformation.Should().BeEmpty();
         }
     }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteManagementBaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteManagementBaseFeatureSteps.cs
@@ -48,7 +48,7 @@ public abstract class SiteManagementBaseFeatureSteps : BaseFeatureSteps
     public async Task Assert()
     {
         Response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        ErrorResponse = await JsonRequestReader.ReadRequestAsync<ErrorMessageResponseItem>(await Response.Content.ReadAsStreamAsync());
+        (_, ErrorResponse) = await JsonRequestReader.ReadRequestAsync<ErrorMessageResponseItem>(await Response.Content.ReadAsStreamAsync());
         ErrorResponse.Message.Should().Be("The specified site was not found.");
     }
     

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
@@ -32,7 +32,7 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         var accessNeeds = row.Cells.ElementAt(4).Value;
         _response = await Http.GetAsync($"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&accessNeeds={accessNeeds}");
         _statusCode = _response.StatusCode;
-        _actualResponse = await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(await _response.Content.ReadAsStreamAsync());
+        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(await _response.Content.ReadAsStreamAsync());
     }
 
     [When("I make the following request without access needs")]
@@ -45,7 +45,7 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         var latitude = row.Cells.ElementAt(3).Value;
         _response = await Http.GetAsync($"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}");
         _statusCode = _response.StatusCode;
-        _actualResponse = await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(await _response.Content.ReadAsStreamAsync());
+        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(await _response.Content.ReadAsStreamAsync());
     }
 
     [Then("the following sites and distances are returned")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/UserManagement/GetUserRoleAssignmentsSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/UserManagement/GetUserRoleAssignmentsSteps.cs
@@ -23,7 +23,7 @@ public sealed class GetUserRoleAssignmentsSteps : UserManagementBaseFeatureSteps
         var siteId = GetSiteId(site);
         _response = await Http.GetAsync($"http://localhost:7071/api/users?site={siteId}");
         _statusCode = _response.StatusCode;
-        _actualResponse = await JsonRequestReader.ReadRequestAsync<IEnumerable<User>>(await _response.Content.ReadAsStreamAsync());
+        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<IEnumerable<User>>(await _response.Content.ReadAsStreamAsync());
     }
     
     [Then(@"the following list of user role assignments is returned")] 

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/UserManagement/RemoveUserRoleAssignmentsSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/UserManagement/RemoveUserRoleAssignmentsSteps.cs
@@ -40,7 +40,7 @@ public sealed class RemoveUserRoleAssignmentsSteps : UserManagementBaseFeatureSt
 
         _response = await Http.PostAsync($"http://localhost:7071/api/user/remove", new StringContent(JsonResponseWriter.Serialize(requestBody), Encoding.UTF8, "application/json"));
         _statusCode = _response.StatusCode;
-        _actualResponse = await JsonRequestReader.ReadRequestAsync<RemoveUserResponse>(await _response.Content.ReadAsStreamAsync());
+        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<RemoveUserResponse>(await _response.Content.ReadAsStreamAsync());
     }
 
     [Then(@"'(.+)' is no longer in the system")]

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/BaseApiFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/BaseApiFunctionTests.cs
@@ -73,8 +73,9 @@ public class BaseApiFunctionTests
     {
         var exception = new SystemException("Test Exception");
         var request = GetDefaultRequest();
+        var errors = new List<ErrorMessageResponseItem>() { new ErrorMessageResponseItem { } };
 
-        _sut.ReadRequestDelegate = (req) => (false, "");
+        _sut.ReadRequestDelegate = (req) => (errors.AsReadOnly(), "");
 
         var result = await _sut.RunAsync(request) as ContentResult;
 
@@ -183,10 +184,10 @@ internal class TestableBaseApiFunction : BaseApiFunction<string, string>
         return Task.FromResult(HandleDelegate(request, logger));
     }
 
-    protected override Task<(bool requestRead, string request)> ReadRequestAsync(HttpRequest req)
+    protected override Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, string request)> ReadRequestAsync(HttpRequest req)
     {
         if (ReadRequestDelegate is null)
-            return Task.FromResult((true, ""));
+            return Task.FromResult((ErrorMessageResponseItem.None, ""));
         return Task.FromResult(ReadRequestDelegate(req));
     }
 
@@ -199,7 +200,7 @@ internal class TestableBaseApiFunction : BaseApiFunction<string, string>
 
     public Func<string, ILogger, ApiResult<string>> HandleDelegate { get; set; }
 
-    public Func<HttpRequest, (bool requestRead, string request)> ReadRequestDelegate { get; set; }
+    public Func<HttpRequest, (IReadOnlyCollection<ErrorMessageResponseItem> errors, string request)> ReadRequestDelegate { get; set; }
 
     public Func<string, IEnumerable<ErrorMessageResponseItem>> ValidateRequestDelegate { get; set; }
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/QueryAvailabilityFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/QueryAvailabilityFunctionTests.cs
@@ -12,7 +12,6 @@ using Nhs.Appointments.Api.Availability;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Json;
 using Nhs.Appointments.Core;
-using Nhs.Appointments.Persistance;
 
 namespace Nhs.Appointments.Api.Tests.Functions;
 
@@ -57,9 +56,9 @@ public class QueryAvailabilityFunctionTests
         
         var request = new QueryAvailabilityRequest(
             new[] { "1000", "1001" },
-            "COVID", 
-            "2077-01-01",
-            "2077-01-01",
+            "COVID",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2077, 01, 01),
             QueryType.Days);
 
         var httpRequest = CreateRequest(request);
@@ -88,9 +87,9 @@ public class QueryAvailabilityFunctionTests
         
         var request = new QueryAvailabilityRequest(
             new[] { "1000" },
-            "COVID", 
-            "2077-01-01",
-            "2077-01-01",
+            "COVID",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2077, 01, 03),
             queryType);
 
         var httpRequest = CreateRequest(request);
@@ -113,8 +112,8 @@ public class QueryAvailabilityFunctionTests
         var request = new QueryAvailabilityRequest(
             new[] { "1000" },
             "COVID",
-            "2077-01-01",
-            "2077-01-03",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2077, 01, 03),
             QueryType.Days);
 
         var httpRequest = CreateRequest(request);
@@ -147,8 +146,8 @@ public class QueryAvailabilityFunctionTests
         var request = new QueryAvailabilityRequest(
             new[] { "1000" },
             "COVID",
-            "2077-01-01",
-            "2077-01-03",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2077, 01, 03),
             QueryType.Days);
 
         var httpRequest = CreateRequest(request);
@@ -163,13 +162,13 @@ public class QueryAvailabilityFunctionTests
         return CreateRequest(request.Sites, request.From, request.Until, request.Service, request.QueryType);
     }
     
-    private static HttpRequest CreateRequest(string[] sites, string from, string until, string service, QueryType queryType)
+    private static HttpRequest CreateRequest(string[] sites, DateOnly from, DateOnly until, string service, QueryType queryType)
     {
         var sitesArray = String.Join(",", sites.Select(x => $"\"{x}\""));
 
         var context = new DefaultHttpContext();
         var request = context.Request;
-        var body = $"{{ sites:[{sitesArray}], \"service\": \"{service}\", \"from\":  \"{from}\", \"until\": \"{until}\", \"queryType\": \"{queryType}\" }} ";
+        var body = $"{{ sites:[{sitesArray}], \"service\": \"{service}\", \"from\":  \"{from.ToString(DateTimeFormats.DateOnly)}\", \"until\": \"{until.ToString(DateTimeFormats.DateOnly)}\", \"queryType\": \"{queryType}\" }} ";
         request.Body =  new MemoryStream(Encoding.UTF8.GetBytes(body));
         request.Headers.Add("Authorization", "Test 123");
         return request;

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/ApplyAvailabilityTemplateValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/ApplyAvailabilityTemplateValidatorTests.cs
@@ -16,8 +16,8 @@ public class ApplyAvailabilityTemplateValidatorTests
     {
         var request = new ApplyAvailabilityTemplateRequest(
             Site: "ABC01",
-            From: "2077-01-01",
-            Until: "2077-01-01",
+            From: new DateOnly(2077, 01, 01),
+            Until: new DateOnly(2077, 01, 01),
             Template: new Template()
             {
                 Days = [DayOfWeek.Monday],
@@ -45,8 +45,8 @@ public class ApplyAvailabilityTemplateValidatorTests
     {
         var request = new ApplyAvailabilityTemplateRequest(
             Site: siteId,
-            From: "2077-01-01",
-            Until: "2077-01-01",
+            From: new DateOnly(2077, 01, 01),
+            Until: new DateOnly(2077, 01, 01),
             Template: new Template()
                 {
                     Days = [DayOfWeek.Monday],
@@ -68,87 +68,14 @@ public class ApplyAvailabilityTemplateValidatorTests
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Contain(nameof(ApplyAvailabilityTemplateRequest.Site));
     }
-    
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("2077-02-01")]
-    [InlineData("01-01-2077")]
-    [InlineData("2077/01/01")]
-    [InlineData("2077-99-31")]
-    [InlineData("2077-01-99")]
-    [InlineData("Not a date")]
-    public void Validate_ReturnsError_WhenFromDateIsInvalid(string? fromDate)
-    {
-        var request = new ApplyAvailabilityTemplateRequest(
-            Site: "ABC01",
-            From: fromDate,
-            Until: "2077-01-01",
-            Template: new Template()
-            {
-                Days = [DayOfWeek.Monday],
-                Sessions =
-                [
-                    new Session()
-                    {
-                        Capacity = 1,
-                        From = new TimeOnly(09, 00),
-                        Until = new TimeOnly(10, 00),
-                        SlotLength = 5,
-                        Services = ["Service 1"]
-                    }
-                ]
-            }
-        );
-        var result = _sut.TestValidate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Contain(nameof(ApplyAvailabilityTemplateRequest.From));
-    }
-    
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("2077/01/01")]
-    [InlineData("01-01-2077")]
-    [InlineData("2077-99-31")]
-    [InlineData("2077-01-99")]
-    [InlineData("Not a date")]
-    public void Validate_ReturnsError_WhenUntilDateIsInvalid(string? untilDate)
-    {
-        var request = new ApplyAvailabilityTemplateRequest(
-            Site: "ABC01",
-            From: "2077-01-01",
-            Until: untilDate,
-            Template: new Template()
-            {
-                Days = [DayOfWeek.Monday],
-                Sessions =
-                [
-                    new Session()
-                    {
-                        Capacity = 1,
-                        From = new TimeOnly(09, 00),
-                        Until = new TimeOnly(10, 00),
-                        SlotLength = 5,
-                        Services = ["Service 1"]
-                    }
-                ]
-            }
-        );
-        var result = _sut.TestValidate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Contain(nameof(ApplyAvailabilityTemplateRequest.Until));
-    }
-    
+
     [Fact]
     public void Validate_ReturnsError_WhenTemplateIsInvalid()
     {
         var request = new ApplyAvailabilityTemplateRequest(
             Site: "ABC01",
-            From: "2077-01-01",
-            Until: "2077-01-01",
+            From: new DateOnly(2077, 01, 01),
+            Until: new DateOnly(2077, 01, 01),
             Template: new Template()
             {
                 Days = [],
@@ -175,8 +102,8 @@ public class ApplyAvailabilityTemplateValidatorTests
     {
         var request = new ApplyAvailabilityTemplateRequest(
             Site: "ABC01",
-            From: "2077-01-01",
-            Until: "2077-01-01",
+            From: new DateOnly(2077, 01, 01),
+            Until: new DateOnly(2077, 01, 01),
             Template: null
         );
         var result = _sut.TestValidate(request);

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/QueryAvailabilityRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/QueryAvailabilityRequestValidatorTests.cs
@@ -21,8 +21,8 @@ public class QueryAvailabilityRequestValidatorTests
         var request = new QueryAvailabilityRequest(
             new [] {"1000", "1001"},
             "COVID",
-            "2077-01-01",
-            "2077-01-01",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2077, 01, 01),
             QueryType.Days
         );
         var result = _sut.TestValidate(request);
@@ -41,8 +41,8 @@ public class QueryAvailabilityRequestValidatorTests
         var request = new QueryAvailabilityRequest(
             sites,
             "SERVICE",
-            "2077-01-01",
-            "2077-01-01",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2077, 01, 01),
             QueryType.Days
         );
         var result = _sut.TestValidate(request);
@@ -60,8 +60,8 @@ public class QueryAvailabilityRequestValidatorTests
         var request = new QueryAvailabilityRequest(
             new [] {"1000", "1001"},
             service,
-            "2077-01-01",
-            "2077-01-01",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2077, 01, 01),
             QueryType.Days
         );
         var result = _sut.TestValidate(request);
@@ -69,53 +69,7 @@ public class QueryAvailabilityRequestValidatorTests
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(QueryAvailabilityRequest.Service));
         result.Errors.Single().ErrorMessage.Should().Be(InvalidStringErrorMessage);
-    }
-    
-    [Theory]
-    [InlineData("")]
-    [InlineData("01-01-2077")]
-    [InlineData("2077-99-31")]
-    [InlineData("2077-01-99")]
-    [InlineData("Not a date")]
-    [InlineData(null)]
-    public void Validate_ReturnsError_WhenFromDateIsNotValid(string fromDate)
-    {
-        var request = new QueryAvailabilityRequest(
-            new [] {"1000", "1001"},
-            "COVID",
-            fromDate,
-            "2077-01-01",
-            QueryType.Days
-        );
-        var result = _sut.TestValidate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(QueryAvailabilityRequest.From));
-        result.Errors.Single().ErrorMessage.Should().Be(InvalidDateErrorMessage);
-    }
-    
-    [Theory]
-    [InlineData("")]
-    [InlineData("01-01-2077")]
-    [InlineData("2077-99-31")]
-    [InlineData("2077-01-99")]
-    [InlineData("Not a date")]
-    [InlineData(null)]
-    public void Validate_ReturnsError_WhenUntilDateIsNotValid(string untilDate)
-    {
-        var request = new QueryAvailabilityRequest(
-            new [] {"1000", "1001"},
-            "COVID",
-            "2077-01-01",
-            untilDate,
-            QueryType.Days
-        );
-        var result = _sut.TestValidate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(QueryAvailabilityRequest.Until));
-        result.Errors.Single().ErrorMessage.Should().Be(InvalidDateErrorMessage);
-    }
+    }              
     
     [Fact]
     public void Validate_ReturnsError_WhenUntilDateIsBeforeFrom()
@@ -123,14 +77,14 @@ public class QueryAvailabilityRequestValidatorTests
         var request = new QueryAvailabilityRequest(
             new [] {"1000", "1001"},
             "COVID",
-            "2077-01-01",
-            "2076-01-01",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2076, 01, 01),
             QueryType.Days
         );
         var result = _sut.TestValidate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(QueryAvailabilityRequest.FromDate));
+        result.Errors.Single().PropertyName.Should().Be(nameof(QueryAvailabilityRequest.From));
         result.Errors.Single().ErrorMessage.Should().Be(InvalidFromDateRangeErrorMessage);
     }
     
@@ -143,8 +97,8 @@ public class QueryAvailabilityRequestValidatorTests
         var request = new QueryAvailabilityRequest(
             new [] {"1000", "1001"},
             "COVID",
-            "2077-01-01",
-            "2077-01-01",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2077, 01, 01),
             queryType
         );
         var result = _sut.TestValidate(request);
@@ -160,8 +114,8 @@ public class QueryAvailabilityRequestValidatorTests
         var request = new QueryAvailabilityRequest(
             new [] {"1000", "1001"},
             "COVID",
-            "2077-01-01",
-            "2077-01-01",
+            new DateOnly(2077, 01, 01),
+            new DateOnly(2077, 01, 01),
             queryType
         );
         var result = _sut.TestValidate(request);


### PR DESCRIPTION
This is the first pass at creating a mechanism for ensuring that json payloads can be mapped to request types. It is required because fluent validation can only operate on serialized data so cannot detect or manage serialization issues. This approach allows very in depth checking of elements that seemed difficult to achieve with serialization frameworks. It also covers over posting (sending more properties than the request type has). Validation issues this addresses are

Over posting
Sending number for enums when we want string
Sending string for enums that don't match values
Validating dates and times as strings
Sending floats when integers are expected

These would previously have resulted in a 500 or a 400 without a decent error message

The current implementation only triggers if validation fails, this causes some problems that mean some issues that don't cause 400s are still allowed. (i.e. over posting and ints for enums). We could run this check on every request but that would mean running "expensive code on every request"