### PR TITLE
APPT-309: Create availability updates

### DIFF
--- a/src/new-client/src/app/lib/components/nhsuk-frontend/text-input.tsx
+++ b/src/new-client/src/app/lib/components/nhsuk-frontend/text-input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, HTMLProps } from 'react';
+import { DetailedHTMLProps, forwardRef, InputHTMLAttributes } from 'react';
 
 type Props = {
   label?: string;
@@ -6,7 +6,7 @@ type Props = {
   width?: 2 | 3 | 4 | 5 | 10 | 20;
   prefix?: string;
   suffix?: string;
-} & HTMLProps<HTMLInputElement>;
+} & DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 type Ref = HTMLInputElement;
 
 /**

--- a/src/new-client/src/app/lib/components/wizard.tsx
+++ b/src/new-client/src/app/lib/components/wizard.tsx
@@ -14,6 +14,7 @@ export interface InjectedWizardProps {
   setCurrentStep(step: number): void;
   goToNextStep(): void;
   goToPreviousStep(): void;
+  goToLastStep(): void;
   returnRouteUponCancellation?: string;
 }
 
@@ -68,6 +69,9 @@ const Wizard = ({
             await setActiveStep(
               stepNumber + 1 > lastStep ? lastStep : stepNumber + 1,
             );
+          },
+          async goToLastStep() {
+            await setActiveStep(lastStep);
           },
         });
       })}

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/availability-template-wizard.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/availability-template-wizard.tsx
@@ -33,17 +33,7 @@ const AvailabilityTemplateWizard = ({ site }: Props) => {
       days: [],
       sessionType: 'single',
       session: {
-        startTime: {
-          hour: 9,
-          minute: 0,
-        },
-        endTime: {
-          hour: 17,
-          minute: 0,
-        },
         break: 'no',
-        capacity: 1,
-        slotLength: 5,
         services: [],
       },
     },

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/availability-template-wizard.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/availability-template-wizard.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation';
 import TimeAndCapacityStep from './time-and-capacity-step';
 import DaysOfWeekStep from './days-of-week-step';
 import SelectServicesStep from './select-services-step';
+import { ChangeEvent } from 'react';
 
 export type CreateAvailabilityFormValues = {
   startDate: DateComponents;
@@ -26,6 +27,22 @@ type Props = {
 
 // TODO: Decide where this info should live and move it there
 export const services = [{ label: 'RSV (Adult)', value: 'RSV:Adult' }];
+
+export const handlePositiveBoundedNumberInput = (
+  e: ChangeEvent<HTMLInputElement>,
+  upperBound: number,
+) => {
+  const asNumber = Number(e.currentTarget.value);
+  if (asNumber < 1 || Number.isNaN(asNumber) || !Number.isInteger(asNumber)) {
+    return undefined;
+  }
+
+  if (asNumber > upperBound) {
+    return upperBound;
+  }
+
+  return asNumber;
+};
 
 const AvailabilityTemplateWizard = ({ site }: Props) => {
   const methods = useForm<CreateAvailabilityFormValues>({

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/days-of-week-step.test.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/days-of-week-step.test.tsx
@@ -6,6 +6,7 @@ import DaysOfWeekStep from './days-of-week-step';
 
 const mockGoToNextStep = jest.fn();
 const mockGoToPreviousStep = jest.fn();
+const mockGoToLastStep = jest.fn();
 const mockSetCurrentStep = jest.fn();
 
 describe('Days of Week Step', () => {
@@ -21,6 +22,7 @@ describe('Days of Week Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -45,6 +47,7 @@ describe('Days of Week Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -74,6 +77,7 @@ describe('Days of Week Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -99,6 +103,7 @@ describe('Days of Week Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/days-of-week-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/days-of-week-step.tsx
@@ -85,7 +85,10 @@ const DaysOfWeekStep = ({
                 } else {
                   setValue('days', [dayOfWeek, ...(daysWatch ?? [])]);
                 }
-                trigger('days');
+
+                if (errors.days) {
+                  trigger('days');
+                }
               }}
             />
           ))}
@@ -103,7 +106,9 @@ const DaysOfWeekStep = ({
                   daysOfTheWeek.map(_ => _),
                 );
               }
-              trigger('days');
+              if (errors.days) {
+                trigger('days');
+              }
             }}
           />
         </CheckBoxes>

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/days-of-week-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/days-of-week-step.tsx
@@ -15,15 +15,19 @@ import { daysOfTheWeek } from '@types';
 
 const DaysOfWeekStep = ({
   goToNextStep,
+  goToLastStep,
   stepNumber,
   returnRouteUponCancellation,
   goToPreviousStep,
 }: InjectedWizardProps) => {
   const { register, setValue, watch, formState, trigger } =
     useFormContext<CreateAvailabilityFormValues>();
-  const { errors } = formState;
+  const { errors, isValid: allStepsAreValid, touchedFields } = formState;
 
   const daysWatch = watch('days');
+
+  const shouldSkipToSummaryStep =
+    touchedFields.session?.services && allStepsAreValid;
 
   const onContinue = async () => {
     const formIsValid = await trigger(['days']);
@@ -31,7 +35,11 @@ const DaysOfWeekStep = ({
       return;
     }
 
-    goToNextStep();
+    if (shouldSkipToSummaryStep) {
+      goToLastStep();
+    } else {
+      goToNextStep();
+    }
   };
 
   return (

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/select-services-step.test.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/select-services-step.test.tsx
@@ -6,6 +6,7 @@ import SelectServicesStep from './select-services-step';
 
 const mockGoToNextStep = jest.fn();
 const mockGoToPreviousStep = jest.fn();
+const mockGoToLastStep = jest.fn();
 const mockSetCurrentStep = jest.fn();
 
 describe('Select Services Step', () => {
@@ -21,6 +22,7 @@ describe('Select Services Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -45,6 +47,7 @@ describe('Select Services Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -78,6 +81,7 @@ describe('Select Services Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -108,6 +112,7 @@ describe('Select Services Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/select-services-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/select-services-step.tsx
@@ -16,15 +16,19 @@ import NhsHeading from '@components/nhs-heading';
 
 const SelectServicesStep = ({
   goToNextStep,
+  goToLastStep,
   stepNumber,
   returnRouteUponCancellation,
   goToPreviousStep,
 }: InjectedWizardProps) => {
   const { register, watch, trigger, formState, setValue } =
     useFormContext<CreateAvailabilityFormValues>();
-  const { errors } = formState;
+  const { errors, isValid: allStepsAreValid, touchedFields } = formState;
 
   const servicesWatch = watch('session.services');
+
+  const shouldSkipToSummaryStep =
+    touchedFields.session?.services && allStepsAreValid;
 
   const onContinue = async () => {
     const formIsValid = await trigger(['session.services']);
@@ -32,7 +36,11 @@ const SelectServicesStep = ({
       return;
     }
 
-    goToNextStep();
+    if (shouldSkipToSummaryStep) {
+      goToLastStep();
+    } else {
+      goToNextStep();
+    }
   };
 
   return (

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/select-services-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/select-services-step.tsx
@@ -87,7 +87,9 @@ const SelectServicesStep = ({
                     ...(servicesWatch ?? []),
                   ]);
                 }
-                trigger('session.services');
+                if (errors.session?.services) {
+                  trigger('session.services');
+                }
               }}
             />
           ))}

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/single-or-repeating-session-step.test.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/single-or-repeating-session-step.test.tsx
@@ -6,6 +6,7 @@ import SingleOrRepeatingSessionStep from './single-or-repeating-session-step';
 
 const mockGoToNextStep = jest.fn();
 const mockGoToPreviousStep = jest.fn();
+const mockGoToLastStep = jest.fn();
 const mockSetCurrentStep = jest.fn();
 
 describe('Single or Repeating Session Step', () => {
@@ -18,6 +19,7 @@ describe('Single or Repeating Session Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -39,6 +41,7 @@ describe('Single or Repeating Session Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/single-or-repeating-session-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/single-or-repeating-session-step.tsx
@@ -18,11 +18,13 @@ const SingleOrRepeatingSessionStep = ({
   returnRouteUponCancellation,
   goToPreviousStep,
 }: InjectedWizardProps) => {
-  const { register } = useFormContext<CreateAvailabilityFormValues>();
+  const { register, reset } = useFormContext<CreateAvailabilityFormValues>();
 
   const onContinue = async () => {
     goToNextStep();
   };
+
+  const sessionType = { ...register('sessionType') };
 
   return (
     <>
@@ -43,14 +45,40 @@ const SingleOrRepeatingSessionStep = ({
           <Radio
             label="Repeat session"
             hint="Create sessions that repeat on a weekly basis"
-            {...register('sessionType')}
+            {...{
+              ...sessionType,
+              onChange: e => {
+                reset({
+                  days: [],
+                  sessionType: 'repeating',
+                  session: {
+                    break: 'no',
+                    services: [],
+                  },
+                });
+                sessionType.onChange(e);
+              },
+            }}
             id="sessionType-repeating"
             value="repeating"
           />
           <Radio
             label="Single session"
             hint="Create a session on a single date"
-            {...register('sessionType')}
+            {...{
+              ...sessionType,
+              onChange: e => {
+                reset({
+                  days: [],
+                  sessionType: 'single',
+                  session: {
+                    break: 'no',
+                    services: [],
+                  },
+                });
+                sessionType.onChange(e);
+              },
+            }}
             id="sessionType-single"
             value="single"
           />

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/single-or-repeating-session-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/single-or-repeating-session-step.tsx
@@ -15,13 +15,23 @@ import { useFormContext } from 'react-hook-form';
 const SingleOrRepeatingSessionStep = ({
   stepNumber,
   goToNextStep,
+  goToLastStep,
   returnRouteUponCancellation,
   goToPreviousStep,
 }: InjectedWizardProps) => {
-  const { register, reset } = useFormContext<CreateAvailabilityFormValues>();
+  const { register, reset, formState } =
+    useFormContext<CreateAvailabilityFormValues>();
+  const { isValid: allStepsAreValid, touchedFields } = formState;
+
+  const shouldSkipToSummaryStep =
+    touchedFields.session?.services && allStepsAreValid;
 
   const onContinue = async () => {
-    goToNextStep();
+    if (shouldSkipToSummaryStep) {
+      goToLastStep();
+    } else {
+      goToNextStep();
+    }
   };
 
   const sessionType = { ...register('sessionType') };

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/start-and-end-date-step.test.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/start-and-end-date-step.test.tsx
@@ -16,6 +16,7 @@ jest.mock('@services/timeService', () => {
 
 const mockGoToNextStep = jest.fn();
 const mockGoToPreviousStep = jest.fn();
+const mockGoToLastStep = jest.fn();
 const mockSetCurrentStep = jest.fn();
 
 const defaultValues: DefaultValues<CreateAvailabilityFormValues> = {
@@ -49,6 +50,7 @@ describe('Start and End Date Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -76,6 +78,7 @@ describe('Start and End Date Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -114,6 +117,7 @@ describe('Start and End Date Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -170,6 +174,7 @@ describe('Start and End Date Step', () => {
             isActive
             setCurrentStep={mockSetCurrentStep}
             goToNextStep={mockGoToNextStep}
+            goToLastStep={mockGoToLastStep}
             goToPreviousStep={mockGoToPreviousStep}
           />
         </MockForm>,
@@ -212,6 +217,7 @@ describe('Start and End Date Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -247,6 +253,7 @@ describe('Start and End Date Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -274,6 +281,7 @@ describe('Start and End Date Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
           returnRouteUponCancellation={'some-back-link'}
         />
@@ -298,6 +306,7 @@ describe('Start and End Date Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/start-and-end-date-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/start-and-end-date-step.tsx
@@ -7,7 +7,10 @@ import {
   TextInput,
 } from '@components/nhsuk-frontend';
 import { Controller, useFormContext } from 'react-hook-form';
-import { CreateAvailabilityFormValues } from './availability-template-wizard';
+import {
+  CreateAvailabilityFormValues,
+  handlePositiveBoundedNumberInput,
+} from './availability-template-wizard';
 import { InjectedWizardProps } from '@components/wizard';
 import {
   isSameDayOrBefore,
@@ -104,33 +107,61 @@ const StartAndEndDateStep = ({
               hint="For example, 15 3 1984"
               id="start-date-input"
             >
-              <TextInput
-                label="Day"
-                type="number"
-                id="start-date-input-day"
-                inputType="date"
-                {...register('startDate.day', {
-                  valueAsNumber: true,
-                })}
+              <Controller
+                control={control}
+                name="startDate.day"
+                render={({ field }) => (
+                  <TextInput
+                    label="Day"
+                    type="number"
+                    id="start-date-input-day"
+                    inputType="date"
+                    onChange={e =>
+                      field.onChange(handlePositiveBoundedNumberInput(e, 31))
+                    }
+                    value={field.value ?? ''}
+                  />
+                )}
               />
-              <TextInput
-                label="Month"
-                type="number"
-                id="start-date-input-month"
-                inputType="date"
-                {...register('startDate.month', {
-                  valueAsNumber: true,
-                })}
+
+              <Controller
+                control={control}
+                name="startDate.month"
+                render={({ field }) => (
+                  <TextInput
+                    label="Month"
+                    type="number"
+                    id="start-date-input-month"
+                    inputType="date"
+                    onChange={e =>
+                      field.onChange(handlePositiveBoundedNumberInput(e, 12))
+                    }
+                    value={field.value ?? ''}
+                  />
+                )}
               />
-              <TextInput
-                label="Year"
-                type="number"
-                id="start-date-input-year"
-                inputType="date"
-                width={3}
-                {...register('startDate.year', {
-                  valueAsNumber: true,
-                })}
+
+              <Controller
+                control={control}
+                name="startDate.year"
+                render={({ field }) => (
+                  <TextInput
+                    label="Year"
+                    type="number"
+                    id="start-date-input-year"
+                    inputType="date"
+                    width={3}
+                    onChange={e =>
+                      field.onChange(
+                        handlePositiveBoundedNumberInput(
+                          e,
+                          now().add(1, 'year').year(),
+                        ),
+                      )
+                    }
+                    value={field.value ?? ''}
+                  />
+                )}
               />
             </DateInput>
           )}
@@ -167,33 +198,65 @@ const StartAndEndDateStep = ({
                   hint="For example, 15 3 1984"
                   id="end-date-input"
                 >
-                  <TextInput
-                    label="Day"
-                    type="number"
-                    id="end-date-input-day"
-                    inputType="date"
-                    {...register('endDate.day', {
-                      valueAsNumber: true,
-                    })}
+                  <Controller
+                    control={control}
+                    name="endDate.day"
+                    render={({ field }) => (
+                      <TextInput
+                        label="Day"
+                        type="number"
+                        id="end-date-input-day"
+                        inputType="date"
+                        onChange={e =>
+                          field.onChange(
+                            handlePositiveBoundedNumberInput(e, 31),
+                          )
+                        }
+                        value={field.value ?? ''}
+                      />
+                    )}
                   />
-                  <TextInput
-                    label="Month"
-                    type="number"
-                    id="end-date-input-month"
-                    inputType="date"
-                    width={3}
-                    {...register('endDate.month', {
-                      valueAsNumber: true,
-                    })}
+
+                  <Controller
+                    control={control}
+                    name="endDate.month"
+                    render={({ field }) => (
+                      <TextInput
+                        label="Month"
+                        type="number"
+                        id="end-date-input-month"
+                        inputType="date"
+                        onChange={e =>
+                          field.onChange(
+                            handlePositiveBoundedNumberInput(e, 12),
+                          )
+                        }
+                        value={field.value ?? ''}
+                      />
+                    )}
                   />
-                  <TextInput
-                    label="Year"
-                    type="number"
-                    id="end-date-input-year"
-                    inputType="date"
-                    {...register('endDate.year', {
-                      valueAsNumber: true,
-                    })}
+
+                  <Controller
+                    control={control}
+                    name="endDate.year"
+                    render={({ field }) => (
+                      <TextInput
+                        label="Year"
+                        type="number"
+                        id="end-date-input-year"
+                        inputType="date"
+                        width={3}
+                        onChange={e =>
+                          field.onChange(
+                            handlePositiveBoundedNumberInput(
+                              e,
+                              now().add(1, 'year').year(),
+                            ),
+                          )
+                        }
+                        value={field.value ?? ''}
+                      />
+                    )}
                   />
                 </DateInput>
               </FormGroup>

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/start-and-end-date-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/start-and-end-date-step.tsx
@@ -27,7 +27,7 @@ const StartAndEndDateStep = ({
   returnRouteUponCancellation,
   goToPreviousStep,
 }: InjectedWizardProps) => {
-  const { register, formState, trigger, getValues, control } =
+  const { formState, trigger, getValues, control } =
     useFormContext<CreateAvailabilityFormValues>();
   const { errors, isValid: allStepsAreValid, touchedFields } = formState;
 

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/start-and-end-date-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/start-and-end-date-step.tsx
@@ -19,13 +19,14 @@ import NhsHeading from '@components/nhs-heading';
 const StartAndEndDateStep = ({
   stepNumber,
   goToNextStep,
+  goToLastStep,
   setCurrentStep,
   returnRouteUponCancellation,
   goToPreviousStep,
 }: InjectedWizardProps) => {
   const { register, formState, trigger, getValues, control } =
     useFormContext<CreateAvailabilityFormValues>();
-  const { errors } = formState;
+  const { errors, isValid: allStepsAreValid, touchedFields } = formState;
 
   const sessionType = getValues('sessionType');
 
@@ -37,9 +38,17 @@ const StartAndEndDateStep = ({
     }
   };
 
+  const shouldSkipToSummaryStep =
+    touchedFields.session?.services && allStepsAreValid;
+
   const onContinue = async () => {
     const formIsValid = await validateFields();
     if (!formIsValid) {
+      return;
+    }
+
+    if (shouldSkipToSummaryStep) {
+      goToLastStep();
       return;
     }
 

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/summary-step.test.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/summary-step.test.tsx
@@ -6,6 +6,7 @@ import SummaryStep from './summary-step';
 
 const mockGoToNextStep = jest.fn();
 const mockGoToPreviousStep = jest.fn();
+const mockGoToLastStep = jest.fn();
 const mockSetCurrentStep = jest.fn();
 
 const currentFormState: CreateAvailabilityFormValues = {
@@ -50,6 +51,7 @@ describe('Summary Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -74,6 +76,7 @@ describe('Summary Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -131,6 +134,7 @@ describe('Summary Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -158,6 +162,7 @@ describe('Summary Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.test.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.test.tsx
@@ -6,6 +6,7 @@ import TimeAndCapacityStep from './time-and-capacity-step';
 
 const mockGoToNextStep = jest.fn();
 const mockGoToPreviousStep = jest.fn();
+const mockGoToLastStep = jest.fn();
 const mockSetCurrentStep = jest.fn();
 
 describe('Time and Capacity Step', () => {
@@ -32,6 +33,7 @@ describe('Time and Capacity Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -67,6 +69,7 @@ describe('Time and Capacity Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
@@ -98,7 +101,7 @@ describe('Time and Capacity Step', () => {
     expect(endTimeHourInput).toHaveDisplayValue('17');
     await user.clear(endTimeHourInput);
     await user.type(endTimeHourInput, '6');
-    expect(endTimeHourInput).toHaveDisplayValue('6');
+    expect(endTimeHourInput).toHaveDisplayValue('06');
 
     expect(endTimeMinuteInput).toHaveDisplayValue('45');
     await user.clear(endTimeMinuteInput);
@@ -132,6 +135,7 @@ describe('Time and Capacity Step', () => {
             isActive
             setCurrentStep={mockSetCurrentStep}
             goToNextStep={mockGoToNextStep}
+            goToLastStep={mockGoToLastStep}
             goToPreviousStep={mockGoToPreviousStep}
           />
         </MockForm>,
@@ -189,7 +193,6 @@ describe('Time and Capacity Step', () => {
               hour: 17,
               minute: 45,
             },
-            capacity: 1,
           },
         }}
       >
@@ -199,56 +202,46 @@ describe('Time and Capacity Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
     );
 
-    const capacityInput = screen.getByRole('textbox', {
+    const capacityInput = screen.getByRole('spinbutton', {
       name: 'How many vaccinators or spaces do you have?',
     });
 
-    expect(capacityInput).toHaveDisplayValue('1');
+    expect(capacityInput).toHaveDisplayValue('');
     await user.clear(capacityInput);
     await user.type(capacityInput, '5');
     expect(capacityInput).toHaveDisplayValue('5');
   });
 
-  it.each([
-    [undefined, 'Capacity is required'],
-    ['0', 'Capacity must be at least 1'],
-    ['-1', 'Capacity must be at least 1'],
-    ['0.5', 'Capacity must be at least 1'],
-    ['4.5', 'Capacity must be a whole number'],
-  ])(
-    'validates capacity entry',
-    async (capacity: string | undefined, expectedMessage: string) => {
-      const { user } = render(
-        <MockForm<CreateAvailabilityFormValues> submitHandler={jest.fn()}>
-          <TimeAndCapacityStep
-            stepNumber={1}
-            currentStep={1}
-            isActive
-            setCurrentStep={mockSetCurrentStep}
-            goToNextStep={mockGoToNextStep}
-            goToPreviousStep={mockGoToPreviousStep}
-          />
-        </MockForm>,
-      );
+  it('validates capacity entry', async () => {
+    const { user } = render(
+      <MockForm<CreateAvailabilityFormValues> submitHandler={jest.fn()}>
+        <TimeAndCapacityStep
+          stepNumber={1}
+          currentStep={1}
+          isActive
+          setCurrentStep={mockSetCurrentStep}
+          goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
+          goToPreviousStep={mockGoToPreviousStep}
+        />
+      </MockForm>,
+    );
 
-      const capacityInput = screen.getByRole('textbox', {
-        name: 'How many vaccinators or spaces do you have?',
-      });
+    const capacityInput = screen.getByRole('spinbutton', {
+      name: 'How many vaccinators or spaces do you have?',
+    });
 
-      await user.clear(capacityInput);
-      if (capacity) {
-        await user.type(capacityInput, capacity);
-      }
+    await user.clear(capacityInput);
 
-      await user.click(screen.getByRole('button', { name: 'Continue' }));
-      expect(screen.getByText(expectedMessage)).toBeInTheDocument();
-    },
-  );
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(screen.getByText('Capacity is required')).toBeInTheDocument();
+  });
 
   it('permits slot length data entry', async () => {
     const { user } = render(
@@ -265,6 +258,46 @@ describe('Time and Capacity Step', () => {
               minute: 45,
             },
             capacity: 1,
+          },
+        }}
+      >
+        <TimeAndCapacityStep
+          stepNumber={1}
+          currentStep={1}
+          isActive
+          setCurrentStep={mockSetCurrentStep}
+          goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
+          goToPreviousStep={mockGoToPreviousStep}
+        />
+      </MockForm>,
+    );
+
+    const slotLengthInput = screen.getByRole('spinbutton', {
+      name: 'How long are your appointments?',
+    });
+
+    expect(slotLengthInput).toHaveDisplayValue('');
+    await user.clear(slotLengthInput);
+    await user.type(slotLengthInput, '3');
+    expect(slotLengthInput).toHaveDisplayValue('3');
+  });
+
+  it('validates slot length entry', async () => {
+    const { user } = render(
+      <MockForm<CreateAvailabilityFormValues>
+        submitHandler={jest.fn()}
+        defaultValues={{
+          session: {
+            startTime: {
+              hour: 9,
+              minute: 30,
+            },
+            endTime: {
+              hour: 17,
+              minute: 30,
+            },
+            capacity: 1,
             slotLength: 7,
           },
         }}
@@ -275,73 +308,23 @@ describe('Time and Capacity Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
     );
 
-    const slotLengthInput = screen.getByRole('textbox', {
+    const slotLengthInput = screen.getByRole('spinbutton', {
       name: 'How long are your appointments?',
     });
 
-    expect(slotLengthInput).toHaveDisplayValue('7');
     await user.clear(slotLengthInput);
-    await user.type(slotLengthInput, '3');
-    expect(slotLengthInput).toHaveDisplayValue('3');
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(
+      screen.getByText('Appointment length is required'),
+    ).toBeInTheDocument();
   });
-
-  it.each([
-    [undefined, 'Appointment length is required'],
-    ['0', 'Appointment length must be at least 1 minute'],
-    ['-1', 'Appointment length must be at least 1 minute'],
-    ['0.5', 'Appointment length must be at least 1 minute'],
-    ['4.5', 'Appointment length must be a whole number'],
-    ['61', 'Appointment length cannot exceed 1 hour'],
-  ])(
-    'validates slot length entry',
-    async (slotLength: string | undefined, expectedMessage: string) => {
-      const { user } = render(
-        <MockForm<CreateAvailabilityFormValues>
-          submitHandler={jest.fn()}
-          defaultValues={{
-            session: {
-              startTime: {
-                hour: 9,
-                minute: 30,
-              },
-              endTime: {
-                hour: 17,
-                minute: 30,
-              },
-              capacity: 1,
-              slotLength: 7,
-            },
-          }}
-        >
-          <TimeAndCapacityStep
-            stepNumber={1}
-            currentStep={1}
-            isActive
-            setCurrentStep={mockSetCurrentStep}
-            goToNextStep={mockGoToNextStep}
-            goToPreviousStep={mockGoToPreviousStep}
-          />
-        </MockForm>,
-      );
-
-      const slotLengthInput = screen.getByRole('textbox', {
-        name: 'How long are your appointments?',
-      });
-
-      await user.clear(slotLengthInput);
-      if (slotLength) {
-        await user.type(slotLengthInput, slotLength);
-      }
-
-      await user.click(screen.getByRole('button', { name: 'Continue' }));
-      expect(screen.getByText(expectedMessage)).toBeInTheDocument();
-    },
-  );
 
   it('validates slot length is shorter than session length', async () => {
     const { user } = render(
@@ -368,12 +351,13 @@ describe('Time and Capacity Step', () => {
           isActive
           setCurrentStep={mockSetCurrentStep}
           goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
           goToPreviousStep={mockGoToPreviousStep}
         />
       </MockForm>,
     );
 
-    const slotLengthInput = screen.getByRole('textbox', {
+    const slotLengthInput = screen.getByRole('spinbutton', {
       name: 'How long are your appointments?',
     });
 

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
@@ -18,6 +18,7 @@ import { ChangeEvent } from 'react';
 
 const TimeAndCapacityStep = ({
   goToNextStep,
+  goToLastStep,
   stepNumber,
   returnRouteUponCancellation,
   goToPreviousStep,
@@ -25,7 +26,7 @@ const TimeAndCapacityStep = ({
 }: InjectedWizardProps) => {
   const { watch, formState, trigger, control, getValues } =
     useFormContext<CreateAvailabilityFormValues>();
-  const { errors } = formState;
+  const { errors, isValid: allStepsAreValid, touchedFields } = formState;
 
   const [startTimeWatch, endTimeWatch, slotLengthWatch, capacityWatch] = watch([
     'session.startTime',
@@ -43,13 +44,20 @@ const TimeAndCapacityStep = ({
     ]);
   };
 
+  const shouldSkipToSummaryStep =
+    touchedFields.session?.services && allStepsAreValid;
+
   const onContinue = async () => {
     const formIsValid = await validateFields();
     if (!formIsValid) {
       return;
     }
 
-    goToNextStep();
+    if (shouldSkipToSummaryStep) {
+      goToLastStep();
+    } else {
+      goToNextStep();
+    }
   };
 
   const onBack = async () => {

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
@@ -8,7 +8,10 @@ import {
   TextInput,
 } from '@components/nhsuk-frontend';
 import { InjectedWizardProps } from '@components/wizard';
-import { CreateAvailabilityFormValues } from './availability-template-wizard';
+import {
+  CreateAvailabilityFormValues,
+  handlePositiveBoundedNumberInput,
+} from './availability-template-wizard';
 import { Controller, useFormContext } from 'react-hook-form';
 import CapacityCalculation, {
   sessionLengthInMinutes,
@@ -66,22 +69,6 @@ const TimeAndCapacityStep = ({
     } else {
       setCurrentStep(stepNumber - 2);
     }
-  };
-
-  const handlePositiveBoundedNumberInput = (
-    e: ChangeEvent<HTMLInputElement>,
-    upperBound: number,
-  ) => {
-    const asNumber = Number(e.currentTarget.value);
-    if (asNumber < 1 || Number.isNaN(asNumber) || !Number.isInteger(asNumber)) {
-      return undefined;
-    }
-
-    if (asNumber > upperBound) {
-      return upperBound;
-    }
-
-    return asNumber;
   };
 
   const handleTwoDigitPositiveBoundedNumberInput = (
@@ -333,6 +320,7 @@ const TimeAndCapacityStep = ({
                 id="capacity"
                 aria-labelledby="capacity"
                 inputMode="numeric"
+                type="number"
                 width={2}
                 onChange={e =>
                   field.onChange(handlePositiveBoundedNumberInput(e, 99))
@@ -391,6 +379,7 @@ const TimeAndCapacityStep = ({
                 id="slot-length"
                 aria-labelledby="slot-length"
                 inputMode="numeric"
+                type="number"
                 width={2}
                 suffix="minutes"
                 onChange={e => {

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
@@ -14,6 +14,7 @@ import CapacityCalculation, {
   sessionLengthInMinutes,
 } from './capacity-calculation';
 import { formatTimeString } from '@services/timeService';
+import { ChangeEvent } from 'react';
 
 const TimeAndCapacityStep = ({
   goToNextStep,
@@ -59,6 +60,29 @@ const TimeAndCapacityStep = ({
     }
   };
 
+  const handlePositiveBoundedInput = (
+    e: ChangeEvent<HTMLInputElement>,
+    upperBound: number,
+  ) => {
+    const asNumber = Number(e.target.value);
+    if (asNumber < 0 || Number.isNaN(asNumber) || !Number.isInteger(asNumber)) {
+      return '00';
+    }
+
+    if (asNumber > upperBound) {
+      return `0${e.target.value.slice(-1)}`;
+    }
+
+    switch (e.target.value.length) {
+      case 1:
+        return `0${e.target.value}`;
+      case 2:
+        return e.target.value;
+      default:
+        return e.target.value.slice(-2);
+    }
+  };
+
   return (
     <>
       {stepNumber === 1 ? (
@@ -101,43 +125,59 @@ const TimeAndCapacityStep = ({
             <>
               <div className="nhsuk-label">Start time</div>
               <div className="nhsuk-time-input-custom">
-                <div className="nhsuk-time-input-custom__item">
-                  <label
-                    id="start-time-accessibility-label-hour"
-                    htmlFor="start-time-hour"
-                  >
-                    Session start time - hour
-                  </label>
-                  <input
-                    aria-labelledby="start-time-accessibility-label-hour"
-                    id="start-time-hour"
-                    className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
-                    {...register('session.startTime.hour', {
-                      valueAsNumber: true,
-                    })}
-                  ></input>
-                </div>
+                <Controller
+                  control={control}
+                  name="session.startTime.hour"
+                  render={({ field }) => (
+                    <div className="nhsuk-time-input-custom__item">
+                      <label
+                        id="start-time-accessibility-label-hour"
+                        htmlFor="start-time-hour"
+                      >
+                        Session start time - hour
+                      </label>
+                      <input
+                        aria-labelledby="start-time-accessibility-label-hour"
+                        id="start-time-hour"
+                        className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
+                        onChange={e =>
+                          field.onChange(handlePositiveBoundedInput(e, 23))
+                        }
+                        value={field.value ?? ''}
+                      ></input>
+                    </div>
+                  )}
+                />
+
                 <div className="nhsuk-time-input-custom__item">
                   <div style={{ display: 'inline-block', fontSize: 'x-large' }}>
                     :
                   </div>
                 </div>
 
-                <div className="nhsuk-time-input-custom__item">
-                  <label
-                    id="start-time-accessibility-label-minute"
-                    htmlFor="start-time-minute"
-                  >
-                    Session start time - minute
-                  </label>
-                  <input
-                    aria-labelledby="start-time-accessibility-label-minute"
-                    className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
-                    {...register('session.startTime.minute', {
-                      valueAsNumber: true,
-                    })}
-                  ></input>
-                </div>
+                <Controller
+                  control={control}
+                  name="session.startTime.minute"
+                  render={({ field }) => (
+                    <div className="nhsuk-time-input-custom__item">
+                      <label
+                        id="start-time-accessibility-label-minute"
+                        htmlFor="start-time-minute"
+                      >
+                        Session start time - minute
+                      </label>
+                      <input
+                        aria-labelledby="start-time-accessibility-label-minute"
+                        className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
+                        id="start-time-minute"
+                        onChange={e =>
+                          field.onChange(handlePositiveBoundedInput(e, 59))
+                        }
+                        value={field.value ?? ''}
+                      ></input>
+                    </div>
+                  )}
+                />
               </div>
             </>
           )}
@@ -171,42 +211,58 @@ const TimeAndCapacityStep = ({
             <>
               <div className="nhsuk-label">End time</div>
               <div className="nhsuk-time-input-custom">
-                <div className="nhsuk-time-input-custom__item">
-                  <label
-                    id="end-time-accessibility-label-hour"
-                    htmlFor="end-time-hour"
-                  >
-                    Session end time - hour
-                  </label>
-                  <input
-                    aria-labelledby="end-time-accessibility-label-hour"
-                    className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
-                    {...register('session.endTime.hour', {
-                      valueAsNumber: true,
-                    })}
-                  ></input>
-                </div>
+                <Controller
+                  control={control}
+                  name="session.endTime.hour"
+                  render={({ field }) => (
+                    <div className="nhsuk-time-input-custom__item">
+                      <label
+                        id="end-time-accessibility-label-hour"
+                        htmlFor="end-time-hour"
+                      >
+                        Session end time - hour
+                      </label>
+                      <input
+                        aria-labelledby="end-time-accessibility-label-hour"
+                        className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
+                        id="end-time-hour"
+                        onChange={e =>
+                          field.onChange(handlePositiveBoundedInput(e, 23))
+                        }
+                        value={field.value ?? ''}
+                      ></input>
+                    </div>
+                  )}
+                />
+
                 <div className="nhsuk-time-input-custom__item">
                   <div style={{ display: 'inline-block', fontSize: 'x-large' }}>
                     :
                   </div>
                 </div>
 
-                <div className="nhsuk-time-input-custom__item">
-                  <label
-                    id="end-time-accessibility-label-minute"
-                    htmlFor="end-time-minute"
-                  >
-                    Session end time - minute
-                  </label>
-                  <input
-                    aria-labelledby="end-time-accessibility-label-minute"
-                    className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
-                    {...register('session.endTime.minute', {
-                      valueAsNumber: true,
-                    })}
-                  ></input>
-                </div>
+                <Controller
+                  control={control}
+                  name="session.endTime.minute"
+                  render={({ field }) => (
+                    <div className="nhsuk-time-input-custom__item">
+                      <label
+                        id="end-time-accessibility-label-minute"
+                        htmlFor="end-time-minute"
+                      >
+                        Session end time - minute
+                      </label>
+                      <input
+                        aria-labelledby="end-time-accessibility-label-minute"
+                        className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
+                        onChange={e =>
+                          field.onChange(handlePositiveBoundedInput(e, 59))
+                        }
+                        value={field.value ?? ''}
+                      ></input>
+                    </div>
+                  )}
+                />
               </div>
             </>
           )}

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
@@ -23,7 +23,7 @@ const TimeAndCapacityStep = ({
   goToPreviousStep,
   setCurrentStep,
 }: InjectedWizardProps) => {
-  const { register, watch, formState, trigger, control, getValues } =
+  const { watch, formState, trigger, control, getValues } =
     useFormContext<CreateAvailabilityFormValues>();
   const { errors } = formState;
 
@@ -60,7 +60,23 @@ const TimeAndCapacityStep = ({
     }
   };
 
-  const handlePositiveBoundedInput = (
+  const handlePositiveBoundedNumberInput = (
+    e: ChangeEvent<HTMLInputElement>,
+    upperBound: number,
+  ) => {
+    const asNumber = Number(e.currentTarget.value);
+    if (asNumber < 1 || Number.isNaN(asNumber) || !Number.isInteger(asNumber)) {
+      return undefined;
+    }
+
+    if (asNumber > upperBound) {
+      return upperBound;
+    }
+
+    return asNumber;
+  };
+
+  const handleTwoDigitPositiveBoundedNumberInput = (
     e: ChangeEvent<HTMLInputElement>,
     upperBound: number,
   ) => {
@@ -81,22 +97,6 @@ const TimeAndCapacityStep = ({
       default:
         return e.target.value.slice(-2);
     }
-  };
-
-  const handlePositiveBoundedNumberInput = (
-    e: ChangeEvent<HTMLInputElement>,
-    upperBound: number,
-  ) => {
-    const asNumber = Number(e.currentTarget.value);
-    if (asNumber < 1 || Number.isNaN(asNumber) || !Number.isInteger(asNumber)) {
-      return undefined;
-    }
-
-    if (asNumber > upperBound) {
-      return upperBound;
-    }
-
-    return asNumber;
   };
 
   return (
@@ -157,7 +157,9 @@ const TimeAndCapacityStep = ({
                         id="start-time-hour"
                         className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
                         onChange={e =>
-                          field.onChange(handlePositiveBoundedInput(e, 23))
+                          field.onChange(
+                            handleTwoDigitPositiveBoundedNumberInput(e, 23),
+                          )
                         }
                         value={field.value ?? ''}
                       ></input>
@@ -187,7 +189,9 @@ const TimeAndCapacityStep = ({
                         className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
                         id="start-time-minute"
                         onChange={e =>
-                          field.onChange(handlePositiveBoundedInput(e, 59))
+                          field.onChange(
+                            handleTwoDigitPositiveBoundedNumberInput(e, 59),
+                          )
                         }
                         value={field.value ?? ''}
                       ></input>
@@ -243,7 +247,9 @@ const TimeAndCapacityStep = ({
                         className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
                         id="end-time-hour"
                         onChange={e =>
-                          field.onChange(handlePositiveBoundedInput(e, 23))
+                          field.onChange(
+                            handleTwoDigitPositiveBoundedNumberInput(e, 23),
+                          )
                         }
                         value={field.value ?? ''}
                       ></input>
@@ -272,7 +278,9 @@ const TimeAndCapacityStep = ({
                         aria-labelledby="end-time-accessibility-label-minute"
                         className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
                         onChange={e =>
-                          field.onChange(handlePositiveBoundedInput(e, 59))
+                          field.onChange(
+                            handleTwoDigitPositiveBoundedNumberInput(e, 59),
+                          )
                         }
                         value={field.value ?? ''}
                       ></input>
@@ -377,9 +385,9 @@ const TimeAndCapacityStep = ({
                 inputMode="numeric"
                 width={2}
                 suffix="minutes"
-                onChange={e =>
-                  field.onChange(handlePositiveBoundedNumberInput(e, 60))
-                }
+                onChange={e => {
+                  field.onChange(handlePositiveBoundedNumberInput(e, 60));
+                }}
                 value={field.value ?? ''}
               />
             </FormGroup>


### PR DESCRIPTION
Contains a series of requested changes to the Create Availability Wizard. Namely: 

- APPT-406: If the user has previously reached the final step of the wizard, then clicked "Change" or "Go back" to visit and change a prior step, the `Continue` buttons on that step will now take them straight back to the summary screen rather than the next step.
- APPT-40?: If the user changes between Single Date Session and Weekly Repeating Session, the remaining form entries will be wiped clean and reset. 
- APPT-401: Inputs are now controlled as well as validated. Users can no longer enter whatever they want (i.e. no minuses, no text, etc.). This was always being validated but now is being enforced on input change. 
- APPT-403: All default values have been removed. Users do not get anything pre-populated. 
- APPT-404: Leaving certain fields blank then clicking "Go back" -> "Continue" no longer erroneously sets the value to NaN. This was caused by improper use of `ValueAsNumber`.
- APPT-402: Steps with checkboxes (services, days) now only validate when Continue is clicked, and will not pre-emptively validate upon checkbox change. 