### PR TITLE
APPT-239: Capacity calculation tweaks

### DIFF
--- a/src/new-client/src/app/site/[site]/create-availability/wizard/capacity-calculation.test.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/capacity-calculation.test.tsx
@@ -23,18 +23,46 @@ describe('Capacity Calculation', () => {
     expect(
       screen.getByText(/total appointments in the session/),
     ).toBeInTheDocument();
+
+    expect(screen.getByText(/Up to/)).toBeInTheDocument();
     expect(screen.getByText('24')).toBeInTheDocument();
     expect(screen.getByText(/appointments per hour/)).toBeInTheDocument();
+  });
+
+  it('hides the appointments per hour calculation if session length is under 1 hour', () => {
+    render(
+      <CapacityCalculation
+        slotLength={5}
+        capacity={1}
+        startTime={{
+          hour: 9,
+          minute: 0,
+        }}
+        endTime={{
+          hour: 9,
+          minute: 30,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('6')).toBeInTheDocument();
+    expect(
+      screen.getByText(/total appointments in the session/),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByText(/Up to/)).not.toBeInTheDocument();
+    expect(screen.queryByText('24')).not.toBeInTheDocument();
+    expect(screen.queryByText(/appointments per hour/)).not.toBeInTheDocument();
   });
 
   it.each([
     [9, 0, 12, 0, 5, 1, 36, 12],
     [9, 0, 12, 0, 5, 2, 72, 24],
     [9, 0, 9, 0, 5, 1, 0, 0], // start time == end time
-    [9, 0, 9, 5, 5, 1, 1, 12],
+    [9, 0, 9, 5, 5, 1, 1, undefined],
     [9, 0, 9, 5, 6, 1, 0, 0], // slot length > end time
     [10, 0, 9, 0, 5, 1, 0, 0], // start time > end time
-    [9, 30, 9, 40, 5, 1, 2, 12], // time span under an hour
+    [9, 30, 9, 40, 5, 1, 2, undefined], // time span under an hour
 
     // No decimals allowed
     [9.5, 0, 12, 0, 5, 1, 0, 0],

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/capacity-calculation.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/capacity-calculation.tsx
@@ -10,7 +10,7 @@ type CapacityCalculationProps = {
 
 type CapacityCalculationResult = {
   appointmentsPerSession: number;
-  appointmentsPerHour: number;
+  appointmentsPerHour?: number;
 };
 
 const CapacityCalculation = (props: CapacityCalculationProps) => {
@@ -24,8 +24,13 @@ const CapacityCalculation = (props: CapacityCalculationProps) => {
       <p style={{ marginBottom: 0 }}>
         <strong>{capacity.appointmentsPerSession}</strong> total appointments in
         the session
-        <br />
-        <strong>{capacity.appointmentsPerHour}</strong> appointments per hour
+        {capacity.appointmentsPerHour !== undefined && (
+          <>
+            <br />
+            Up to <strong>{capacity.appointmentsPerHour}</strong> appointments
+            per hour
+          </>
+        )}
         <br />
       </p>
     </InsetText>
@@ -79,7 +84,8 @@ const calculateCapacity = ({
 
   return {
     appointmentsPerSession,
-    appointmentsPerHour,
+    appointmentsPerHour:
+      totalMinutesAvailable >= 60 ? appointmentsPerHour : undefined,
   };
 };
 

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/summary-step.test.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/summary-step.test.tsx
@@ -101,7 +101,9 @@ describe('Summary Step', () => {
     ).toBeInTheDocument;
 
     expect(
-      screen.getByRole('term', { name: 'Vaccinators or spaces available' }),
+      screen.getByRole('term', {
+        name: 'Vaccinators or vaccination spaces available',
+      }),
     ).toBeInTheDocument;
     expect(
       screen.getByRole('definition', {
@@ -171,5 +173,46 @@ describe('Summary Step', () => {
     await user.click(screen.getByRole('button', { name: 'Save session' }));
 
     expect(mockOnSubmit).toHaveBeenCalledWith(currentFormState);
+  });
+
+  it('hides the appointments per hour calculation if session length is under 1 hour', () => {
+    render(
+      <MockForm<CreateAvailabilityFormValues>
+        submitHandler={jest.fn()}
+        defaultValues={{
+          ...currentFormState,
+          session: {
+            ...currentFormState.session,
+            startTime: {
+              hour: 9,
+              minute: 0,
+            },
+            endTime: {
+              hour: 9,
+              minute: 30,
+            },
+          },
+        }}
+      >
+        <SummaryStep
+          stepNumber={1}
+          currentStep={1}
+          isActive
+          setCurrentStep={mockSetCurrentStep}
+          goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
+          goToPreviousStep={mockGoToPreviousStep}
+        />
+      </MockForm>,
+    );
+
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(
+      screen.getByText(/total appointments in the session/),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByText(/Up to/)).not.toBeInTheDocument();
+    expect(screen.queryByText('8')).not.toBeInTheDocument();
+    expect(screen.queryByText(/appointments per hour/)).not.toBeInTheDocument();
   });
 });

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/summary-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/summary-step.tsx
@@ -64,7 +64,7 @@ const SummaryStep = ({
           },
 
           {
-            title: 'Vaccinators or spaces available',
+            title: 'Vaccinators or vaccination spaces available',
             value: `${session.capacity}`,
             action: {
               renderingStrategy: 'client',
@@ -132,7 +132,7 @@ const SummaryStep = ({
             },
           },
           {
-            title: 'Vaccinators or spaces available',
+            title: 'Vaccinators or vaccination spaces available',
             value: `${session.capacity}`,
             action: {
               renderingStrategy: 'client',
@@ -195,8 +195,13 @@ const SummaryStep = ({
       <p>
         <strong>{capacity.appointmentsPerSession}</strong> total appointments in
         the session
-        <br />
-        <strong>{capacity.appointmentsPerHour}</strong> appointments per hour
+        {capacity.appointmentsPerHour !== undefined && (
+          <>
+            <br />
+            Up to <strong>{capacity.appointmentsPerHour}</strong> appointments
+            per hour
+          </>
+        )}
         <br />
       </p>
 

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.test.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.test.tsx
@@ -209,7 +209,7 @@ describe('Time and Capacity Step', () => {
     );
 
     const capacityInput = screen.getByRole('spinbutton', {
-      name: 'How many vaccinators or spaces do you have?',
+      name: 'How many vaccinators or vaccination spaces do you have?',
     });
 
     expect(capacityInput).toHaveDisplayValue('');
@@ -234,7 +234,7 @@ describe('Time and Capacity Step', () => {
     );
 
     const capacityInput = screen.getByRole('spinbutton', {
-      name: 'How many vaccinators or spaces do you have?',
+      name: 'How many vaccinators or vaccination spaces do you have?',
     });
 
     await user.clear(capacityInput);

--- a/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
+++ b/src/new-client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
@@ -309,7 +309,7 @@ const TimeAndCapacityStep = ({
           }}
           render={({ field }) => (
             <FormGroup
-              legend="How many vaccinators or spaces do you have?"
+              legend="How many vaccinators or vaccination spaces do you have?"
               error={errors.session?.capacity?.message}
             >
               <label
@@ -317,7 +317,7 @@ const TimeAndCapacityStep = ({
                 htmlFor="capacity"
                 style={{ display: 'none' }}
               >
-                How many vaccinators or spaces do you have?
+                How many vaccinators or vaccination spaces do you have?
               </label>
               <TextInput
                 id="capacity"


### PR DESCRIPTION
Out of this morning's discussion:

- The words "Up to" have been prepended to the "appointments per hour" calculation in every case.
- The entire "appointments per hour" calculation is hidden if the total session length does not exceed 60 minutes
- The copy for "Vaccinators or spaces" is now "Vaccinators or vaccination spaces"