### PR TITLE
APPT-301 - add time threshold to booking reschedule

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,9 @@ services:
     build:
       context: src/new-client/
       dockerfile: web.Dockerfile
-
     environment:
       NBS_API_BASE_URL: http://api:80
       AUTH_HOST: http://localhost:7071
-
     volumes:
       - ./src/new-client/src:/app/src
       - ./src/new-client/public:/app/public
@@ -51,6 +49,7 @@ services:
       - Notifications_Provider=local
       - BookingRemindersCronSchedule=0 0 8 * * *
       - UnconfirmedProvisionalBookingsCronSchedule=*/5 * * * *
+      - RESCHEDULE_THRESHOLD_MINUTES=60
 
   oidc-server:
     image: soluto/oidc-server-mock:latest

--- a/infrastructure/resources/api.tf
+++ b/infrastructure/resources/api.tf
@@ -48,6 +48,7 @@ resource "azurerm_windows_function_app" "nbs_mya_func_app" {
     ServiceBusConnectionString                 = azurerm_servicebus_namespace.nbs_mya_service_bus.default_primary_connection_string
     BookingRemindersCronSchedule               = var.booking_reminders_cron_schedule
     UnconfirmedProvisionalBookingsCronSchedule = var.unconfirmed_provisional_bookings_cron_schedule
+    RESCHEDULE_THRESHOLD_MINUTES               = 60
   }
 
   identity {

--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -47,6 +47,7 @@ public static class FunctionConfigurationExtensions
         builder.Services
             .Configure<CosmosDataStoreOptions>(opts => opts.DatabaseName = "appts")
             .Configure<ReferenceGroupOptions>(opts => opts.InitialGroupCount = 100)
+            .Configure<BookingCosmosDocumentStore.Options>(opts => opts.RescheduleThreshold = TimeSpan.FromMinutes(int.Parse(Environment.GetEnvironmentVariable("RESCHEDULE_THRESHOLD_MINUTES"))))
             .AddTransient<IAvailabilityStore, AvailabilityDocumentStore>()
             .AddTransient<IBookingsDocumentStore, BookingCosmosDocumentStore>()
             .AddTransient<IReferenceNumberDocumentStore, ReferenceGroupCosmosDocumentStore>()

--- a/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
@@ -54,7 +54,9 @@ public class ConfirmProvisionalBookingFunction(IBookingsService bookingService,
             case BookingConfirmationResult.RescheduleNotFound:
                 return Failed(HttpStatusCode.NotFound, "The booking to reschedule was not found");
             case BookingConfirmationResult.RescheduleMismatch:
-                return Failed(HttpStatusCode.PreconditionFailed, "The nhs number for the provisional booking and the booking tobe rescheduled do not match");
+                return Failed(HttpStatusCode.PreconditionFailed, "The nhs number for the provisional booking and the booking to be rescheduled do not match");
+            case BookingConfirmationResult.RescheduleTooSoon:
+                return Failed(HttpStatusCode.PreconditionFailed, "The booking to reschedule could not be rescheduled as it is too soon.");
             case BookingConfirmationResult.Success:
                 return Success();
         }

--- a/src/api/Nhs.Appointments.Api/local.settings.json
+++ b/src/api/Nhs.Appointments.Api/local.settings.json
@@ -23,7 +23,8 @@
     "Notifications_Provider": "local",
     "GovNotifyApiKey": "test",
     "BookingRemindersCronSchedule": "0 0 8 * * *",
-    "UnconfirmedProvisionalBookingsCronSchedule": "*/5 * * * *"
+    "UnconfirmedProvisionalBookingsCronSchedule": "*/5 * * * *",
+    "RESCHEDULE_THRESHOLD_MINUTES": 60
   },
   "Host": { "CORS": "*" }
 }

--- a/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
@@ -40,7 +40,8 @@ public enum BookingConfirmationResult
     Expired,
     NotFound,
     RescheduleNotFound,
-    RescheduleMismatch
+    RescheduleMismatch,
+    RescheduleTooSoon
 }
 
 public enum BookingCancellationResult

--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -106,7 +106,7 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
                 return (BookingConfirmationResult.RescheduleMismatch, null);
             }
             
-            if (rescheduleDocument.From.Add(options.Value.RescheduleThreshold) > time.GetLocalNow())
+            if (rescheduleDocument.From < time.GetLocalNow().Add(options.Value.RescheduleThreshold))
             {
                 return (BookingConfirmationResult.RescheduleTooSoon, null);
             }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Reschedule.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Reschedule.feature
@@ -15,6 +15,21 @@
         And I confirm the rescheduled booking
         Then the rescheduled booking is no longer marked as provisional
         And  the original booking has been 'Cancelled'
+
+    Scenario: Cannot reschedule an appointment that is less than 60 minutes away 
+        Given the site is configured for MYA
+        And a citizen with the NHS Number '9999999999'
+        And the following sessions
+            | Date     | From  | Until | Services | Slot Length | Capacity |
+            | Tomorrow | 09:00 | 17:00 | COVID    | 5           | 1        |
+        And I have an existing appointment less than 60 minutes from now
+            | Date     | Duration | Service |
+            | Today    | 5        | COVID   |
+        When I make a provisional appointment with the following details
+            | Date     | Time  | Duration | Service | NhsNumber  | FirstName | LastName | DOB        |
+            | Tomorrow | 09:30 | 5        | COVID   | *          | Test      | One      | 2000-02-01 |
+        And I confirm the rescheduled booking
+        Then the call should fail with 412
         
     Scenario: Cannot reschedule an appointment if the nhs number for both bookings does not match
         Given the site is configured for MYA

--- a/tests/Nhs.Appointments.Persistance.UnitTests/BookingCosmosDocumentStoreTests.cs
+++ b/tests/Nhs.Appointments.Persistance.UnitTests/BookingCosmosDocumentStoreTests.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Microsoft.Extensions.Options;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
 
@@ -10,11 +11,12 @@ public class BookingCosmosDocumentStoreTests
     private readonly Mock<ITypedDocumentCosmosStore<BookingDocument>> _bookingStore = new();
     private readonly Mock<ITypedDocumentCosmosStore<BookingIndexDocument>> _indexStore = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
+    private readonly Mock<IOptions<BookingCosmosDocumentStore.Options>> _options = new();
     private readonly Mock<TimeProvider> _timeProvider = new();
 
     public BookingCosmosDocumentStoreTests()
     {
-        _sut = new BookingCosmosDocumentStore(_bookingStore.Object, _indexStore.Object, _metricsRecorder.Object, _timeProvider.Object);
+        _sut = new BookingCosmosDocumentStore(_bookingStore.Object, _indexStore.Object, _metricsRecorder.Object, _timeProvider.Object, _options.Object);
     }
     
     [Fact]


### PR DESCRIPTION
- Add rule that prevents a booking being rescheduled if it is less than 60 minutes away
- Add configurable option for reschedule time threshold
- Integration test to check condition