### PR TITLE
improved validation for some additional cases

### DIFF
--- a/src/api/Nhs.Appointments.Api/Json/JsonRequestReader.cs
+++ b/src/api/Nhs.Appointments.Api/Json/JsonRequestReader.cs
@@ -2,10 +2,8 @@
 using Newtonsoft.Json;
 using System.IO;
 using System.Threading.Tasks;
-using System.Reflection;
 using System.Linq;
 using System.Collections.Generic;
-using System.Text.Json;
 using Nhs.Appointments.Api.Models;
 
 namespace Nhs.Appointments.Api.Json;
@@ -25,7 +23,11 @@ public static class JsonRequestReader
         {
             Converters =
                 {
-                    new ShortTimeOnlyJsonConverter(), new ShortDateOnlyJsonConverter(), new DayOfWeekJsonConverter(), new NullableShortDateOnlyJsonConverter()
+                    new ShortTimeOnlyJsonConverter(), 
+                    new ShortDateOnlyJsonConverter(), 
+                    new DayOfWeekJsonConverter(), 
+                    new NullableShortDateOnlyJsonConverter(),
+                    new StrictBooleanJsonConverter()
                 },
 
         };

--- a/src/api/Nhs.Appointments.Api/Json/StrictBooleanJsonConverter.cs
+++ b/src/api/Nhs.Appointments.Api/Json/StrictBooleanJsonConverter.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Nhs.Appointments.Api.Json;
+
+public class StrictBooleanJsonConverter : JsonConverter<Boolean>
+{
+    public override void WriteJson(JsonWriter writer, Boolean value, JsonSerializer serializer)
+    {
+        writer.WriteValue(value);
+    }
+
+    public override Boolean ReadJson(JsonReader reader, Type objectType, Boolean existingValue, bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        return Boolean.Parse(reader.Value.ToString());            
+    }
+}    

--- a/src/api/Nhs.Appointments.Api/Validators/MakeBookingRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/MakeBookingRequestValidator.cs
@@ -12,6 +12,8 @@ public class MakeBookingRequestValidator : AbstractValidator<MakeBookingRequest>
     {
         RuleFor(x => x.Site)
             .NotEmpty().WithMessage("A site identifier must be provided");
+        RuleFor(x => x.Duration)
+            .InclusiveBetween(1, 300).WithMessage("Appointment duration must be between 1 and 300");
         RuleFor(x => x.From).Cascade(CascadeMode.Stop)
             .NotEmpty().WithMessage("Provide a date and time in the format 'yyyy-MM-dd HH:mm'")
             .Must(x => DateTime.TryParseExact(x, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var _)).WithMessage("Provide a date and time in the format 'yyyy-MM-dd HH:mm'");

--- a/tests/Nhs.Appointments.Api.UnitTests/Json/JsonToObjectSchemaValidationTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Json/JsonToObjectSchemaValidationTests.cs
@@ -6,6 +6,15 @@ namespace Nhs.Appointments.Api.Tests.Json
 {
     public class JsonToObjectSchemaValidationTests
     {
+        [Fact]
+        public void ValidateConversion_ReturnsError_WhenJsonIsImproperlyFormatted()
+        {
+            var results = JsonToObjectSchemaValidation.ValidateConversion<Object[]>("{\"prop\": }");
+            results.Count.Should().Be(1);
+            results[0].Property.Should().Be("document");
+            results[0].Message.Should().Be("The json is not properly formatted");
+        }
+
         [Theory]
         [InlineData("\"string\"", JsonValueKind.String)]
         [InlineData("32", JsonValueKind.Number)]
@@ -351,6 +360,13 @@ namespace Nhs.Appointments.Api.Tests.Json
             results[0].Message.Should().Be("The property does not exist on the request type");
         }
 
+        [Fact]
+        public void ValidateConversion_DoesNotValidateNestedObjects_WhenDynamicDataIsExpected()
+        {
+            var results = JsonToObjectSchemaValidation.ValidateConversion<ClassWithDyamicProperty>("{\"DynamicProp\": {\"Prop\": 2} }");
+            results.Count.Should().Be(0);            
+        }
+
         public class ClassWithDateTimeProperty
         {
             public DateTime MyProp { get; set; }
@@ -401,6 +417,11 @@ namespace Nhs.Appointments.Api.Tests.Json
         public class ClassWithEnumProperty
         {
             public TestEnum MyProp { get; set; }
+        }
+
+        public class ClassWithDyamicProperty
+        {
+            public Object DynamicProp { get; set; }
         }
     }
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/MakeBookingRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/MakeBookingRequestValidatorTests.cs
@@ -28,6 +28,28 @@ public class MakeBookingRequestValidatorTests
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.Site));
     }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(301)]
+    public void Validate_ReturnsError_WhenDurationIsOutOfRange(int duration)
+    {
+        var request = new MakeBookingRequest(
+            "1000",
+            "2077-01-01 09:00",
+            duration,
+            "COVID",
+            GetAttendeeDetails(),
+            GetContactDetails(),
+            null
+        );
+
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.Duration));
+    }
     
     [Theory]
     [InlineData("")]


### PR DESCRIPTION
Prevents integers being parsed as boolean
Detects incorrectly formatted json
Won't report errors for schema-less properties 
Added range validation to duration on make booking endpoint