### PR TITLE
APPT-368: Ordering and filtering of Availability Created Events

### DIFF
--- a/mock-data/CosmosDbSeeder/items/booking_data/availability_created_ABC02_20200101145431233324.json
+++ b/mock-data/CosmosDbSeeder/items/booking_data/availability_created_ABC02_20200101145431233324.json
@@ -1,0 +1,19 @@
+{
+  "created": "2020-01-01T14:54:31.233324Z",
+  "by": "cc.agent@nhs.net",
+  "template": null,
+  "from": "2020-02-01",
+  "to": null,
+  "sessions": [
+    {
+      "from": "09:00",
+      "until": "12:00",
+      "services": ["RSV:Adult"],
+      "slotLength": 10,
+      "capacity": 5
+    }
+  ],
+  "site": "ABC02",
+  "id": "availability_created_ABC02_20200101145431233324",
+  "docType": "availability_created_event"
+}

--- a/src/api/Nhs.Appointments.Api/Functions/GetAvailabilityCreatedEventsFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetAvailabilityCreatedEventsFunction.cs
@@ -14,8 +14,8 @@ using Microsoft.OpenApi.Models;
 
 namespace Nhs.Appointments.Api.Functions;
 
-    public class GetAvailabilityCreatedEventsFunction(IAvailabilityService availabilityService, IValidator<SiteBasedResourceRequest> validator, IUserContextProvider userContextProvider, ILogger<GetAvailabilityCreatedEventsFunction> logger, IMetricsRecorder metricsRecorder)
-        : SiteBasedResourceFunction<IEnumerable<AvailabilityCreatedEvent>>(validator, userContextProvider, logger, metricsRecorder)
+    public class GetAvailabilityCreatedEventsFunction(IAvailabilityService availabilityService, IValidator<GetAvailabilityCreatedEventsRequest> validator, IUserContextProvider userContextProvider, ILogger<GetAvailabilityCreatedEventsFunction> logger, IMetricsRecorder metricsRecorder)
+        : BaseApiFunction<GetAvailabilityCreatedEventsRequest, IEnumerable<AvailabilityCreatedEvent>>(validator, userContextProvider, logger, metricsRecorder)
     {
         [OpenApiOperation(operationId: "Get_AvailabilityCreatedEventsFunction", tags: ["Availability"], Summary = "Get records of availability created previously")]
         [OpenApiParameter("site", In = ParameterLocation.Query, Required = true, Type = typeof(string), Description = "The id of the site from which to retrieve previously created availability")]
@@ -30,10 +30,29 @@ namespace Nhs.Appointments.Api.Functions;
             return base.RunAsync(req);
         }
 
-        protected override async Task<ApiResult<IEnumerable<AvailabilityCreatedEvent>>> HandleRequest(SiteBasedResourceRequest request, ILogger logger)
+        protected override async Task<ApiResult<IEnumerable<AvailabilityCreatedEvent>>> HandleRequest(GetAvailabilityCreatedEventsRequest request, ILogger logger)
         {
-            var availabilityCreatedEvents = await availabilityService.GetAvailabilityCreatedEventsAsync(request.Site);
+            var availabilityCreatedEvents = await availabilityService.GetAvailabilityCreatedEventsAsync(request.Site, request.FromDate);
 
             return Success(availabilityCreatedEvents);
+        }
+
+        protected override Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetAvailabilityCreatedEventsRequest request)>
+            ReadRequestAsync(HttpRequest req)
+        {
+            var errors = new List<ErrorMessageResponseItem>();
+            if (!req.Query.TryGetValue("site", out var site))
+            {
+                errors.Add(new ErrorMessageResponseItem { Message = "Error parsing site parameter from query" });
+            }
+
+            if (!req.Query.TryGetValue("from", out var from))
+            {
+                errors.Add(new ErrorMessageResponseItem { Message = "Error parsing from parameter from query" });
+            }
+
+            var parsedRequest = new GetAvailabilityCreatedEventsRequest(site, from);
+
+            return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetAvailabilityCreatedEventsRequest request)>((errors, parsedRequest));
         }
     }

--- a/src/api/Nhs.Appointments.Api/Functions/GetAvailabilityCreatedEventsFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetAvailabilityCreatedEventsFunction.cs
@@ -43,12 +43,12 @@ namespace Nhs.Appointments.Api.Functions;
             var errors = new List<ErrorMessageResponseItem>();
             if (!req.Query.TryGetValue("site", out var site))
             {
-                errors.Add(new ErrorMessageResponseItem { Message = "Error parsing site parameter from query" });
+                errors.Add(new ErrorMessageResponseItem { Message = "Error parsing site parameter from query", Property = nameof(GetAvailabilityCreatedEventsRequest.Site)});
             }
 
             if (!req.Query.TryGetValue("from", out var from))
             {
-                errors.Add(new ErrorMessageResponseItem { Message = "Error parsing from parameter from query" });
+                errors.Add(new ErrorMessageResponseItem { Message = "Error parsing from parameter from query", Property = nameof(GetAvailabilityCreatedEventsRequest.From) });
             }
 
             var parsedRequest = new GetAvailabilityCreatedEventsRequest(site, from);

--- a/src/api/Nhs.Appointments.Api/Models/GetAvailabilityCreatedEventsRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/GetAvailabilityCreatedEventsRequest.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Nhs.Appointments.Api.Models;
+public record GetAvailabilityCreatedEventsRequest(
+    [JsonProperty("site")]
+    string Site,
+    [JsonProperty("from")]
+    string From
+)
+
+{
+    public DateOnly FromDate => DateOnly.ParseExact(From, "yyyy-MM-dd");
+};

--- a/src/api/Nhs.Appointments.Api/Validators/GetAvailabilityCreatedEventsRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetAvailabilityCreatedEventsRequestValidator.cs
@@ -13,6 +13,7 @@ public class GetAvailabilityCreatedEventsRequestValidator : AbstractValidator<Ge
             .WithMessage("Provide a valid site");
 
         RuleFor(x => x.From)
+            .Cascade(CascadeMode.Stop)
             .NotEmpty().WithMessage("Provide a date in 'yyyy-MM-dd'")
             .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))
             .WithMessage("Provide a date in the format 'yyyy-MM-dd'");

--- a/src/api/Nhs.Appointments.Api/Validators/GetAvailabilityCreatedEventsRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetAvailabilityCreatedEventsRequestValidator.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using FluentValidation;
+using Nhs.Appointments.Api.Models;
+
+namespace Nhs.Appointments.Api.Validators;
+
+public class GetAvailabilityCreatedEventsRequestValidator : AbstractValidator<GetAvailabilityCreatedEventsRequest>
+{
+    public GetAvailabilityCreatedEventsRequestValidator()
+    {
+        RuleFor(x => x.Site)
+            .NotEmpty()
+            .WithMessage("Provide a valid site");
+
+        RuleFor(x => x.From)
+            .NotEmpty().WithMessage("Provide a date in 'yyyy-MM-dd'")
+            .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))
+            .WithMessage("Provide a date in the format 'yyyy-MM-dd'");
+    }
+}

--- a/src/api/Nhs.Appointments.Core/AvailabilityService.cs
+++ b/src/api/Nhs.Appointments.Core/AvailabilityService.cs
@@ -38,7 +38,7 @@ public class AvailabilityService(IAvailabilityStore availabilityStore, IAvailabi
     {
         var events = await availabilityCreatedEventStore.GetAvailabilityCreatedEvents(site);
 
-        return events;
+        return events.OrderBy(e => e.From).ThenBy(e => e.To);
     }
 
     public async Task SetAvailabilityAsync(DateOnly date, string site, Session[] sessions)

--- a/src/api/Nhs.Appointments.Core/AvailabilityService.cs
+++ b/src/api/Nhs.Appointments.Core/AvailabilityService.cs
@@ -34,11 +34,14 @@ public class AvailabilityService(IAvailabilityStore availabilityStore, IAvailabi
         await availabilityCreatedEventStore.LogSingleDateSessionCreated(site, date, sessions, user);
     }
 
-    public async Task<IEnumerable<AvailabilityCreatedEvent>> GetAvailabilityCreatedEventsAsync(string site)
+    public async Task<IEnumerable<AvailabilityCreatedEvent>> GetAvailabilityCreatedEventsAsync(string site, DateOnly from)
     {
         var events = await availabilityCreatedEventStore.GetAvailabilityCreatedEvents(site);
 
-        return events.OrderBy(e => e.From).ThenBy(e => e.To);
+        return events
+            .Where(acEvent => (acEvent.To ?? acEvent.From) >= from)
+            .OrderBy(e => e.From)
+            .ThenBy(e => e.To);
     }
 
     public async Task SetAvailabilityAsync(DateOnly date, string site, Session[] sessions)

--- a/src/api/Nhs.Appointments.Core/IAvailabilityService.cs
+++ b/src/api/Nhs.Appointments.Core/IAvailabilityService.cs
@@ -4,5 +4,5 @@ public interface IAvailabilityService
 {
     Task ApplyAvailabilityTemplateAsync(string site, DateOnly from, DateOnly until, Template template, string user);
     Task ApplySingleDateSessionAsync(DateOnly date, string site, Session[] sessions, string user);
-    Task<IEnumerable<AvailabilityCreatedEvent>> GetAvailabilityCreatedEventsAsync(string site);
+    Task<IEnumerable<AvailabilityCreatedEvent>> GetAvailabilityCreatedEventsAsync(string site, DateOnly from);
 }

--- a/src/new-client/src/app/lib/services/appointmentsService.ts
+++ b/src/new-client/src/app/lib/services/appointmentsService.ts
@@ -16,6 +16,7 @@ import { appointmentsApi } from '@services/api/appointmentsApi';
 import { ApiResponse } from '@types';
 import { raiseNotification } from '@services/notificationService';
 import { notAuthenticated, notAuthorized } from '@services/authService';
+import { now } from '@services/timeService';
 
 export const fetchAccessToken = async (code: string) => {
   const response = await appointmentsApi.post<{ token: string }>('token', code);
@@ -87,7 +88,7 @@ export async function fetchPermissions(site: string) {
 
 export async function fetchAvailabilityCreatedEvents(site: string) {
   const response = await appointmentsApi.get<AvailabilityCreatedEvent[]>(
-    `availability-created?site=${site}`,
+    `availability-created?site=${site}&from=${now().format('YYYY-MM-DD')}`,
     {
       next: { tags: ['availability-created'] },
     },

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/GetAvailabilityCreatedEventsFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/GetAvailabilityCreatedEventsFeatureSteps.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Nhs.Appointments.Api.Json;
 using Xunit.Gherkin.Quick;
-using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
 
 namespace Nhs.Appointments.Api.Integration.Scenarios.CreateAvailability
@@ -21,8 +20,9 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.CreateAvailability
         public async Task ThenIRequestAvailabilityCreatedEventsForTheCurrentSite()
         {
             var siteId = GetSiteId();
+            var dateFrom = ParseNaturalLanguageDateOnly("Yesterday");
 
-            _response = await Http.GetAsync($"http://localhost:7071/api/availability-created?site={siteId}");
+            _response = await Http.GetAsync($"http://localhost:7071/api/availability-created?site={siteId}&from={dateFrom:yyyy-MM-dd}");
             _statusCode = _response.StatusCode;
             var content = await _response.Content.ReadAsStreamAsync();
 

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetAvailabilityCreatedEventsFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetAvailabilityCreatedEventsFunctionTests.cs
@@ -16,7 +16,7 @@ namespace Nhs.Appointments.Api.Tests.Functions;
 public class GetAvailabilityCreatedEventsFunctionTests
 {
     private readonly Mock<IAvailabilityService> availabilityService = new();
-    private readonly Mock<IValidator<SiteBasedResourceRequest>> _validator = new();
+    private readonly Mock<IValidator<GetAvailabilityCreatedEventsRequest>> _validator = new();
     private readonly Mock<IUserContextProvider> _userContextProvider = new();
     private readonly Mock<ILogger<GetAvailabilityCreatedEventsFunction>> _logger = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
@@ -31,7 +31,7 @@ public class GetAvailabilityCreatedEventsFunctionTests
             _logger.Object,
             _metricsRecorder.Object);
         _validator
-            .Setup(x => x.ValidateAsync(It.IsAny<SiteBasedResourceRequest>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.ValidateAsync(It.IsAny<GetAvailabilityCreatedEventsRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
     }
 
@@ -39,7 +39,7 @@ public class GetAvailabilityCreatedEventsFunctionTests
     {
         var context = new DefaultHttpContext();
         var request = context.Request;
-        request.QueryString = new QueryString($"?site=1000");
+        request.QueryString = new QueryString($"?site=1000&from=2000-01-01");
         return request;
     }
 
@@ -47,7 +47,7 @@ public class GetAvailabilityCreatedEventsFunctionTests
     public async Task RunsAsync_Gets_Availability_Created_Events()
     {
         availabilityService.Setup(
-            x => x.GetAvailabilityCreatedEventsAsync("1000"))
+            x => x.GetAvailabilityCreatedEventsAsync("1000", DateOnly.FromDateTime(new DateTime(2000, 1, 1))))
             .ReturnsAsync([new AvailabilityCreatedEvent()
             {
                 Created = DateTime.UtcNow,
@@ -67,7 +67,7 @@ public class GetAvailabilityCreatedEventsFunctionTests
 
         response.Single().By.Should().Be("test@test.com");
         availabilityService.Verify(
-            x => x.GetAvailabilityCreatedEventsAsync("1000"),
+            x => x.GetAvailabilityCreatedEventsAsync("1000", DateOnly.FromDateTime(new DateTime(2000, 1, 1))),
             Times.Once);
     }
 

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetAvailabilityCreatedEventsRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetAvailabilityCreatedEventsRequestValidatorTests.cs
@@ -1,0 +1,70 @@
+﻿using FluentAssertions;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Api.Validators;
+
+namespace Nhs.Appointments.Api.Tests.Validators;
+
+public class GetAvailabilityCreatedEventsRequestValidatorTests
+{
+    private readonly GetAvailabilityCreatedEventsRequestValidator _sut = new();
+
+    [Fact]
+    public void Validate_ReturnsError_WhenSiteIsBlank()
+    {
+        var testRequest = new GetAvailabilityCreatedEventsRequest(string.Empty, "2020-01-01");
+        var result = _sut.Validate(testRequest);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().PropertyName.Should().Be(nameof(GetAvailabilityCreatedEventsRequest.Site));
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenSiteIsNull()
+    {
+        var testRequest = new GetAvailabilityCreatedEventsRequest(null, "2020-01-01");
+        var result = _sut.Validate(testRequest);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().PropertyName.Should().Be(nameof(GetAvailabilityCreatedEventsRequest.Site));
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenFromIsBlank()
+    {
+        var testRequest = new GetAvailabilityCreatedEventsRequest("ABC02", "");
+        var result = _sut.Validate(testRequest);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().PropertyName.Should().Be(nameof(GetAvailabilityCreatedEventsRequest.From));
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenFromIsNull()
+    {
+        var testRequest = new GetAvailabilityCreatedEventsRequest("ABC02", null);
+        var result = _sut.Validate(testRequest);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().PropertyName.Should().Be(nameof(GetAvailabilityCreatedEventsRequest.From));
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenFromIsInWrongFormat()
+    {
+        var testRequest = new GetAvailabilityCreatedEventsRequest("ABC02", "20:01:2031");
+        var result = _sut.Validate(testRequest);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().PropertyName.Should().Be(nameof(GetAvailabilityCreatedEventsRequest.From));
+    }
+
+    [Fact]
+    public void Validate_ReturnsSuccess_WhenRequestIsValid()
+    {
+        var testRequest = new GetAvailabilityCreatedEventsRequest("ABC02", "2020-01-01");
+        var result = _sut.Validate(testRequest);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().HaveCount(0);
+    }
+}
+

--- a/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
@@ -225,4 +225,51 @@ public class AvailabilityServiceTests
 
         _availabilityStore.Verify(x => x.ApplyAvailabilityTemplate(site, date, sessions), Times.Once);
     }
+
+    [Fact]
+    public async Task GetAvailabilityCreatedEvents_OrdersEventsByFromThenByTo()
+    {
+        var availabilityCreatedEvents = new List<AvailabilityCreatedEvent>()
+        {
+            new()
+            {
+                Created = DateTime.UtcNow,
+                By = "some.user@nhs.net",
+                Site = "some-site",
+                From = DateOnly.FromDateTime(new DateTime(2025, 4, 3)),
+            },
+            new()
+            {
+                Created = DateTime.UtcNow,
+                By = "some.user@nhs.net",
+                Site = "some-site",
+                From = DateOnly.FromDateTime(new DateTime(2024, 10, 10)),
+                To = DateOnly.FromDateTime(new DateTime(2024, 10, 20)),
+            },
+            new()
+            {
+                Created = DateTime.UtcNow,
+                By = "some.user@nhs.net",
+                Site = "some-site",
+                From = DateOnly.FromDateTime(new DateTime(2024, 10, 10)),
+                To = DateOnly.FromDateTime(new DateTime(2024, 10, 15)),
+            }
+        };
+
+        _availabilityCreatedEventStore.Setup(x => x.GetAvailabilityCreatedEvents(It.IsAny<string>()))
+            .ReturnsAsync(availabilityCreatedEvents);
+
+        var result = (await _sut.GetAvailabilityCreatedEventsAsync("some-site")).ToList();
+
+        result.Should().HaveCount(3);
+
+        result[0].From.Should().Be(DateOnly.FromDateTime(new DateTime(2024, 10, 10)));
+        result[0].To.Should().Be(DateOnly.FromDateTime(new DateTime(2024, 10, 15)));
+
+        result[1].From.Should().Be(DateOnly.FromDateTime(new DateTime(2024, 10, 10)));
+        result[1].To.Should().Be(DateOnly.FromDateTime(new DateTime(2024, 10, 20)));
+
+        result[2].From.Should().Be(DateOnly.FromDateTime(new DateTime(2025, 4, 3)));
+        result[2].To.Should().BeNull();
+    }
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
@@ -259,7 +259,8 @@ public class AvailabilityServiceTests
         _availabilityCreatedEventStore.Setup(x => x.GetAvailabilityCreatedEvents(It.IsAny<string>()))
             .ReturnsAsync(availabilityCreatedEvents);
 
-        var result = (await _sut.GetAvailabilityCreatedEventsAsync("some-site")).ToList();
+        var fromDate = DateOnly.FromDateTime(DateTime.MinValue);
+        var result = (await _sut.GetAvailabilityCreatedEventsAsync("some-site", fromDate)).ToList();
 
         result.Should().HaveCount(3);
 
@@ -271,5 +272,50 @@ public class AvailabilityServiceTests
 
         result[2].From.Should().Be(DateOnly.FromDateTime(new DateTime(2025, 4, 3)));
         result[2].To.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAvailabilityCreatedEvents_FiltersEventsAfterDate()
+    {
+        var availabilityCreatedEvents = new List<AvailabilityCreatedEvent>()
+        {
+            new()
+            {
+                Created = DateTime.UtcNow,
+                By = "some.user@nhs.net",
+                Site = "some-site",
+                From = DateOnly.FromDateTime(new DateTime(2025, 4, 3)),
+            },
+            new()
+            {
+                Created = DateTime.UtcNow,
+                By = "some.user@nhs.net",
+                Site = "some-site",
+                From = DateOnly.FromDateTime(new DateTime(2024, 10, 10)),
+                To = DateOnly.FromDateTime(new DateTime(2024, 10, 20)),
+            },
+            new()
+            {
+                Created = DateTime.UtcNow,
+                By = "some.user@nhs.net",
+                Site = "some-site",
+                From = DateOnly.FromDateTime(new DateTime(2024, 10, 10)),
+                To = DateOnly.FromDateTime(new DateTime(2024, 10, 15)),
+            }
+        };
+
+        _availabilityCreatedEventStore.Setup(x => x.GetAvailabilityCreatedEvents(It.IsAny<string>()))
+            .ReturnsAsync(availabilityCreatedEvents);
+
+        var fromDate = DateOnly.FromDateTime(new DateTime(2024, 10, 17));
+        var result = (await _sut.GetAvailabilityCreatedEventsAsync("some-site", fromDate)).ToList();
+
+        result.Should().HaveCount(2);
+
+        result[0].From.Should().Be(DateOnly.FromDateTime(new DateTime(2024, 10, 10)));
+        result[0].To.Should().Be(DateOnly.FromDateTime(new DateTime(2024, 10, 20)));
+
+        result[1].From.Should().Be(DateOnly.FromDateTime(new DateTime(2025, 4, 3)));
+        result[1].To.Should().BeNull();
     }
 }


### PR DESCRIPTION
Satisfies two more acceptance criteria of the Create Availability page: 

- Created availability should be ordered by date ascending. For templates, this ordering should be done on FROM first then on TO in the case of a tie. 
- If ALL dates within a period described by an Availability Created Event are in the past, that entry should not appear in the table 