### PR TITLE
Appt 448 appointment status field

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/MakeBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/MakeBookingFunction.cs
@@ -40,7 +40,6 @@ public class MakeBookingFunction(IBookingsService bookingService, IValidator<Mak
             Duration = bookingRequest.Duration,
             Service = bookingRequest.Service,
             Site = bookingRequest.Site,
-            ContactDetails = bookingRequest.ContactDetails?.Select(c => new Core.ContactItem { Type = c.Type, Value = c.Value}).ToArray(),
             Status = MapAppointmentStatus(bookingRequest.Kind),
             AttendeeDetails = bookingRequest.AttendeeDetails,
             ContactDetails = bookingRequest.ContactDetails?.ToArray(),            

--- a/src/api/Nhs.Appointments.Api/Functions/MakeBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/MakeBookingFunction.cs
@@ -11,9 +11,6 @@ using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Nhs.Appointments.Api.Auth;
-using System.Text.Json;
-using IdentityModel.Client;
-using System.Collections.Frozen;
 
 namespace Nhs.Appointments.Api.Functions;
 
@@ -39,19 +36,19 @@ public class MakeBookingFunction(IBookingsService bookingService, IValidator<Mak
     {
         var requestedBooking = new Booking
         {
-            From = bookingRequest.FromDateTime,
+            From = bookingRequest.From,
             Duration = bookingRequest.Duration,
             Service = bookingRequest.Service,
             Site = bookingRequest.Site,
             AttendeeDetails = new Core.AttendeeDetails
             {
-                DateOfBirth = bookingRequest.AttendeeDetails.BirthDate,
+                DateOfBirth = bookingRequest.AttendeeDetails.DateOfBirth,
                 FirstName = bookingRequest.AttendeeDetails.FirstName,
                 LastName = bookingRequest.AttendeeDetails.LastName,
                 NhsNumber = bookingRequest.AttendeeDetails.NhsNumber
             },
             ContactDetails = bookingRequest.ContactDetails?.Select(c => new Core.ContactItem { Type = c.Type, Value = c.Value}).ToArray(),
-            Provisional = bookingRequest.Provisional,
+            Status = MapAppointmentStatus(bookingRequest.Kind),
             AdditionalData = bookingRequest.AdditionalData
         };
 
@@ -59,7 +56,14 @@ public class MakeBookingFunction(IBookingsService bookingService, IValidator<Mak
         if (bookingResult.Success == false)
             return Failed(HttpStatusCode.NotFound, "The time slot for this booking is not available");
 
-        var response = new MakeBookingResponse(bookingResult.Reference, bookingResult.Provisional);
+        var response = new MakeBookingResponse(bookingResult.Reference);
         return Success(response);
-    }    
+    }
+
+    private AppointmentStatus MapAppointmentStatus(BookingKind kind) => kind switch
+    {
+        BookingKind.Provisional => AppointmentStatus.Provisional,
+        BookingKind.Booked => AppointmentStatus.Booked,
+        _ => throw new System.ArgumentOutOfRangeException(nameof(kind))
+    };
 }

--- a/src/api/Nhs.Appointments.Api/Json/CosmosJsonSerializer.cs
+++ b/src/api/Nhs.Appointments.Api/Json/CosmosJsonSerializer.cs
@@ -13,7 +13,7 @@ public class CosmosJsonSerializer : CosmosSerializer
         {
             var desrializerSettings = new JsonSerializerSettings
             {
-                Converters = { new ShortTimeOnlyJsonConverter(), new ShortDateOnlyJsonConverter(), new DayOfWeekJsonConverter() }
+                Converters = { new ShortTimeOnlyJsonConverter(), new ShortDateOnlyJsonConverter(), new DayOfWeekJsonConverter(), new Newtonsoft.Json.Converters.StringEnumConverter() }
             };
             var body = new StreamReader(stream).ReadToEndAsync().GetAwaiter().GetResult();
             return JsonConvert.DeserializeObject<T>(body, desrializerSettings);
@@ -24,7 +24,7 @@ public class CosmosJsonSerializer : CosmosSerializer
     {
         var serializerSettings = new JsonSerializerSettings
         {
-            Converters = { new ShortTimeOnlyJsonConverter(), new ShortDateOnlyJsonConverter(), new DayOfWeekJsonConverter() }
+            Converters = { new ShortTimeOnlyJsonConverter(), new ShortDateOnlyJsonConverter(), new DayOfWeekJsonConverter(), new Newtonsoft.Json.Converters.StringEnumConverter() }
         };
         var json = JsonConvert.SerializeObject(input, serializerSettings);
         return new MemoryStream(Encoding.UTF8.GetBytes(json));

--- a/src/api/Nhs.Appointments.Api/Models/MakeBookingRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/MakeBookingRequest.cs
@@ -1,48 +1,44 @@
 ﻿using System;
-using System.Globalization;
 using System.Text.Json;
 using Newtonsoft.Json;
 
 namespace Nhs.Appointments.Api.Models;
 
 public record MakeBookingRequest(
-    [JsonProperty("site")]
+    [property:JsonProperty("site", Required = Required.Always)]
     string Site,
-    [JsonProperty("from")]
-    string From,
-    [JsonProperty("duration")]
+    [property:JsonProperty("from", Required = Required.Always)]
+    DateTime From,
+    [property:JsonProperty("duration", Required = Required.Always)]
     int Duration,
-    [JsonProperty("service")]
+    [property:JsonProperty("service", Required = Required.Always)]
     string Service,
-    [JsonProperty("attendeeDetails")]
+    [property:JsonProperty("attendeeDetails", Required = Required.Always)]
     AttendeeDetails AttendeeDetails,
-    [JsonProperty("contactDetails")]
+    [property:JsonProperty("contactDetails")]
     ContactItem[] ContactDetails,
-    [JsonProperty("additionalData")]
-    object? AdditionalData,
-    [JsonProperty("provisional")]
-    bool Provisional = false
-)
+    [property:JsonProperty("additionalData")]
+    object AdditionalData,
+    [property:JsonProperty("kind", Required = Required.Always)]
+    BookingKind Kind
+);
 
+public enum BookingKind
 {
-    public DateTime FromDateTime => DateTime.ParseExact(From, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
-
-};
+    Booked,
+    Provisional
+}
 
 public record AttendeeDetails(
-    [JsonProperty("nhsNumber")]
+    [JsonProperty("nhsNumber", Required = Required.Always)]
     string NhsNumber,
-    [JsonProperty("firstName")]
+    [JsonProperty("firstName", Required = Required.Always)]
     string FirstName,
-    [JsonProperty("lastName")]
+    [JsonProperty("lastName", Required = Required.Always)]
     string LastName,
-    [JsonProperty("dateOfBirth")]
-    string DateOfBirth
-)
-
-{
-    public DateOnly BirthDate => DateOnly.ParseExact(DateOfBirth, "yyyy-MM-dd");
-};
+    [JsonProperty("dateOfBirth", Required = Required.Always)]
+    DateOnly DateOfBirth
+);
 
 public record ContactItem(
     [property:JsonProperty("type", Required = Required.Always)]

--- a/src/api/Nhs.Appointments.Api/Models/MakeBookingResponse.cs
+++ b/src/api/Nhs.Appointments.Api/Models/MakeBookingResponse.cs
@@ -2,4 +2,4 @@
 
 namespace Nhs.Appointments.Api.Models;
 
-public record MakeBookingResponse(string BookingReference, bool Provisional);
+public record MakeBookingResponse(string BookingReference);

--- a/src/api/Nhs.Appointments.Api/Models/SetBookingsStatusRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/SetBookingsStatusRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace Nhs.Appointments.Api.Models;
+﻿using Nhs.Appointments.Core;
 
-public record SetBookingStatusRequest(string bookingReference, string status);
-public record SetBookingStatusResponse(string bookingReference, string status);
+namespace Nhs.Appointments.Api.Models;
+
+public record SetBookingStatusRequest(string bookingReference, AppointmentStatus status);
+public record SetBookingStatusResponse(string bookingReference, AppointmentStatus status);

--- a/src/api/Nhs.Appointments.Api/Validators/AttendeeDetailsValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/AttendeeDetailsValidator.cs
@@ -19,13 +19,7 @@ public class AttendeeDetailsValidator : AbstractValidator<AttendeeDetails>
             .NotEmpty().WithMessage("Provide a first name");
         RuleFor(x => x.LastName)
             .NotEmpty().WithMessage("Provide a last name");
-        RuleFor(x => x.DateOfBirth).Cascade(CascadeMode.Stop)
-            .NotEmpty().WithMessage("Provide a date of birth in the format 'yyyy-MM-dd'")
-            .Must(x => DateOnly.TryParseExact(x.ToString(), "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var _)).WithMessage("Provide a date of birth in the format 'yyyy-MM-dd'")
-            .DependentRules(() =>
-            {
-                RuleFor(x => x.BirthDate)
-                    .LessThan(x => today).WithMessage("Date of birth must be in the past");
-            });
+        RuleFor(x => x.DateOfBirth)
+            .LessThan(x => today).WithMessage("Date of birth must be in the past");            
     }
 }

--- a/src/api/Nhs.Appointments.Api/Validators/MakeBookingRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/MakeBookingRequestValidator.cs
@@ -14,18 +14,11 @@ public class MakeBookingRequestValidator : AbstractValidator<MakeBookingRequest>
             .NotEmpty().WithMessage("A site identifier must be provided");
         RuleFor(x => x.Duration)
             .InclusiveBetween(1, 300).WithMessage("Appointment duration must be between 1 and 300");
-        RuleFor(x => x.From).Cascade(CascadeMode.Stop)
-            .NotEmpty().WithMessage("Provide a date and time in the format 'yyyy-MM-dd HH:mm'")
-            .Must(x => DateTime.TryParseExact(x, "yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var _)).WithMessage("Provide a date and time in the format 'yyyy-MM-dd HH:mm'");
         RuleFor(x => x.Service)
             .NotEmpty().WithMessage("Provide a valid service");        
         RuleFor(x => x.AttendeeDetails)
             .NotEmpty().WithMessage("Provide attendee details")
-            .SetValidator(new AttendeeDetailsValidator());
-        RuleFor(x => x.ContactDetails)
-            .NotEmpty().When(x => !x.Provisional).WithMessage("Provide contact details");
-        RuleFor(x => x.ContactDetails)
-            .Empty().When(x => x.Provisional).WithMessage("A provisional booking should not include contact details");
+            .SetValidator(new AttendeeDetailsValidator());        
     }
     
     protected override bool PreValidate(ValidationContext<MakeBookingRequest> requestBody, ValidationResult result) 

--- a/src/api/Nhs.Appointments.Core/Booking.cs
+++ b/src/api/Nhs.Appointments.Core/Booking.cs
@@ -20,8 +20,8 @@ public class Booking
     [JsonProperty("site")]
     public string Site { get; set; }
     
-    [JsonProperty("outcome")]
-    public string Outcome { get; set; }
+    [JsonProperty("status")]
+    public AppointmentStatus Status{ get; set; }
     
     [JsonProperty("attendeeDetails")]
     public AttendeeDetails AttendeeDetails { get; set; }
@@ -33,10 +33,7 @@ public class Booking
     public bool ReminderSent { get; set; }
 
     [JsonProperty("created")]
-    public DateTime Created { get; set; }
-
-    [JsonProperty("provisional")]
-    public bool Provisional { get; set; }
+    public DateTime Created { get; set; }    
     
     [JsonIgnore]
     public TimePeriod TimePeriod => new TimePeriod(From, TimeSpan.FromMinutes(Duration));
@@ -64,4 +61,12 @@ public class ContactItem
 
     [JsonProperty("value")]
     public string Value { get; set; }
+}
+
+public enum AppointmentStatus
+{
+    Unknown,
+    Provisional,
+    Booked,
+    Cancelled
 }

--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -8,9 +8,9 @@ public interface IBookingsService
     Task<IEnumerable<Booking>> GetBookings(DateTime from, DateTime to, string site);
     Task<Booking> GetBookingByReference(string bookingReference);
     Task<IEnumerable<Booking>> GetBookingByNhsNumber(string nhsNumber);
-    Task<(bool Success, string Reference, bool Provisional)> MakeBooking(Booking booking);
+    Task<(bool Success, string Reference)> MakeBooking(Booking booking);
     Task<BookingCancellationResult> CancelBooking(string bookingReference);
-    Task<bool> SetBookingStatus(string bookingReference, string status);
+    Task<bool> SetBookingStatus(string bookingReference, AppointmentStatus status);
     Task SendBookingReminders();
     Task<BookingConfirmationResult> ConfirmProvisionalBooking(string bookingReference, IEnumerable<ContactItem> contactDetails, string bookingToReschedule);
     Task<IEnumerable<string>> RemoveUnconfirmedProvisionalBookings();
@@ -32,7 +32,7 @@ public class BookingsService(
 
     protected Task<IEnumerable<Booking>> GetBookings(DateTime from, DateTime to)
     {
-        return bookingDocumentStore.GetCrossSiteAsync(from, to, false);
+        return bookingDocumentStore.GetCrossSiteAsync(from, to, AppointmentStatus.Booked);
     }
 
     public Task<Booking> GetBookingByReference(string bookingReference)
@@ -45,7 +45,7 @@ public class BookingsService(
         return bookingDocumentStore.GetByNhsNumberAsync(nhsNumber);
     }
 
-    public async Task<(bool Success, string Reference, bool Provisional)> MakeBooking(Booking booking)
+    public async Task<(bool Success, string Reference)> MakeBooking(Booking booking)
     {            
         using (var leaseContent = siteLeaseManager.Acquire(booking.Site))
         {                
@@ -59,16 +59,16 @@ public class BookingsService(
                 booking.ReminderSent = false;
                 await bookingDocumentStore.InsertAsync(booking);
 
-                if (!booking.Provisional)
+                if (booking.Status == AppointmentStatus.Booked && booking.ContactDetails?.Length > 0)
                 {
                     var bookingMadeEvent = eventFactory.BuildBookingMadeEvent(booking);
                     await bus.Send(bookingMadeEvent);
                 }
 
-                return (true, booking.Reference, booking.Provisional);
+                return (true, booking.Reference);
             }
 
-            return (false, string.Empty, booking.Provisional);
+            return (false, string.Empty);
         }            
     }
 
@@ -83,7 +83,7 @@ public class BookingsService(
 
         await bookingDocumentStore
             .BeginUpdate(booking.Site, bookingReference)
-            .UpdateProperty(b => b.Outcome, "Cancelled")                
+            .UpdateProperty(b => b.Status, AppointmentStatus.Cancelled)
             .ApplyAsync();
 
         var bookingCancelledEvent = eventFactory.BuildBookingCancelledEvent(booking);
@@ -122,7 +122,7 @@ public class BookingsService(
         return result;
     }
 
-    public Task<bool> SetBookingStatus(string bookingReference, string status)
+    public Task<bool> SetBookingStatus(string bookingReference, AppointmentStatus status)
     {
         return bookingDocumentStore.UpdateStatus(bookingReference, status);
     }

--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -81,10 +81,7 @@ public class BookingsService(
             return BookingCancellationResult.NotFound;
         }
 
-        await bookingDocumentStore
-            .BeginUpdate(booking.Site, bookingReference)
-            .UpdateProperty(b => b.Status, AppointmentStatus.Cancelled)
-            .ApplyAsync();
+        await bookingDocumentStore.UpdateStatus(bookingReference, AppointmentStatus.Cancelled);
 
         var bookingCancelledEvent = eventFactory.BuildBookingCancelledEvent(booking);
         await bus.Send (bookingCancelledEvent);

--- a/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
@@ -6,10 +6,10 @@ public interface IBookingsDocumentStore
 {
     Task InsertAsync(Booking booking);
     Task<IEnumerable<Booking>> GetInDateRangeAsync(DateTime from, DateTime to, string site);
-    Task<IEnumerable<Booking>> GetCrossSiteAsync(DateTime from, DateTime to, bool provisional = false);
+    Task<IEnumerable<Booking>> GetCrossSiteAsync(DateTime from, DateTime to, params AppointmentStatus[] statuses);
     Task<Booking> GetByReferenceOrDefaultAsync(string bookingReference);
     Task<IEnumerable<Booking>> GetByNhsNumberAsync(string nhsNumber);
-    Task<bool> UpdateStatus(string bookingReference, string status);
+    Task<bool> UpdateStatus(string bookingReference, AppointmentStatus status);
     IDocumentUpdate<Booking> BeginUpdate(string site, string reference);
     Task SetReminderSent(string bookingReference, string site);
     Task<BookingConfirmationResult> ConfirmProvisional(string bookingReference, IEnumerable<ContactItem> contactDetails, string bookingToReschedule);

--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -17,10 +17,13 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
         }
     }
 
-    public async Task<IEnumerable<Booking>> GetCrossSiteAsync(DateTime from, DateTime to, bool provisional = false)
+    public async Task<IEnumerable<Booking>> GetCrossSiteAsync(DateTime from, DateTime to, params AppointmentStatus[] statuses)
     {
-        var bookingIndexDocuments = await indexStore.RunQueryAsync<BookingIndexDocument>(i => i.From >= from && i.From <= to && i.Provisional == provisional);
-        var grouped = bookingIndexDocuments.GroupBy(i => i.Site);
+        if (statuses.Length == 0)
+            throw new ArgumentException("You must specify one or more statuses");
+
+        var bookingIndexDocuments = await indexStore.RunQueryAsync<BookingIndexDocument>(i => i.From >= from && i.From <= to);
+        var grouped = bookingIndexDocuments.Where(b => statuses.Contains(b.Status)).GroupBy(i => i.Site);
 
         var concurrentResults = new ConcurrentBag<IEnumerable<Booking>>();
 
@@ -52,7 +55,7 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
         var bookingIndexDocuments = (await indexStore.RunQueryAsync<BookingIndexDocument>(bi => bi.NhsNumber == nhsNumber)).ToList();
         var results = new List<Booking>();
 
-        var grouped = bookingIndexDocuments.Where(bi => bi.Provisional == false).GroupBy(bi => bi.Site);
+        var grouped = bookingIndexDocuments.Where(bi => bi.Status != AppointmentStatus.Provisional).GroupBy(bi => bi.Site);
         foreach (var siteBookings in grouped)
         {
             if (siteBookings.Count() > PointReadLimit)
@@ -73,7 +76,7 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
         }
         return results;
     }
-    public async Task<bool> UpdateStatus(string bookingReference, string status)
+    public async Task<bool> UpdateStatus(string bookingReference, AppointmentStatus status)
     {
         var bookingIndexDocument = await indexStore.GetDocument<BookingIndexDocument>(bookingReference);
         if(bookingIndexDocument == null)
@@ -84,9 +87,9 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
         return true;
     }
 
-    private Task UpdateStatus(BookingIndexDocument booking, string status)
+    private Task UpdateStatus(BookingIndexDocument booking, AppointmentStatus status)
     {
-        var updateStatusPatch = PatchOperation.Replace("/outcome", status);
+        var updateStatusPatch = PatchOperation.Replace("/status", status);
         return bookingStore.PatchDocument(booking.Site, booking.Reference, updateStatusPatch);
     }
 
@@ -125,14 +128,14 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
         if (bookingIndexDocument.Created.AddMinutes(5) < time.GetUtcNow())
             return BookingConfirmationResult.Expired;
 
-        var updateStatusPatch = PatchOperation.Replace("/provisional", false);
+        var updateStatusPatch = PatchOperation.Replace("/status", AppointmentStatus.Booked);
         var addContactDetailsPath = PatchOperation.Add("/contactDetails", contactDetails);
         await indexStore.PatchDocument("booking_index", bookingReference, updateStatusPatch);
         await bookingStore.PatchDocument(bookingIndexDocument.Site, bookingReference, updateStatusPatch, addContactDetailsPath);
 
         if (rescheduleDocument != null)
         {
-            await UpdateStatus(rescheduleDocument, "cancelled");
+            await UpdateStatus(rescheduleDocument, AppointmentStatus.Cancelled);
         }
         
         return BookingConfirmationResult.Success;
@@ -161,9 +164,17 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
 
     public async Task<IEnumerable<string>> RemoveUnconfirmedProvisionalBookings()
     {
-        var expiryDateTime = time.GetUtcNow().AddMinutes(-5);
-        var indexDocuments = await indexStore.RunQueryAsync<BookingIndexDocument>(i => i.Provisional && i.Created <= expiryDateTime);
-        
+        var expiryDateTime = time.GetUtcNow().AddMinutes(-5);        
+
+        var query = new QueryDefinition(
+                query: "SELECT * " +
+                       "FROM index_data d " +
+                       "WHERE d.docType = @docType AND d.status = @status AND d.created < @expiry")
+            .WithParameter("@docType", "booking_index")
+            .WithParameter("@status", AppointmentStatus.Provisional.ToString())
+            .WithParameter("@expiry", expiryDateTime);
+        var indexDocuments = await indexStore.RunSqlQueryAsync<BookingIndexDocument>(query);
+
         foreach (var indexDocument in indexDocuments)
         {
             await indexStore.DeleteDocument(indexDocument.Reference, "booking_index");

--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -87,10 +87,11 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
         return true;
     }
 
-    private Task UpdateStatus(BookingIndexDocument booking, AppointmentStatus status)
+    private async Task UpdateStatus(BookingIndexDocument booking, AppointmentStatus status)
     {
         var updateStatusPatch = PatchOperation.Replace("/status", status);
-        return bookingStore.PatchDocument(booking.Site, booking.Reference, updateStatusPatch);
+        await indexStore.PatchDocument("booking_index", booking.Reference, updateStatusPatch);
+        await bookingStore.PatchDocument(booking.Site, booking.Reference, updateStatusPatch);
     }
 
     private async Task<(BookingConfirmationResult, BookingIndexDocument)> GetBookingForReschedule(string bookingReference, string nhsNumber)

--- a/src/api/Nhs.Appointments.Persistance/Models/BookingDocument.cs
+++ b/src/api/Nhs.Appointments.Persistance/Models/BookingDocument.cs
@@ -17,16 +17,13 @@ public class BookingDocument : BookingDataCosmosDocument
     public int Duration { get; set; }
 
     [JsonProperty("service")]
-    public string Service { get; set; }
-
-    [JsonProperty("provisional")]
-    public bool Provisional { get; set; }
+    public string Service { get; set; }    
 
     [JsonProperty("created")]
     public DateTime Created { get; set; }
 
-    [JsonProperty("outcome")]
-    public string Outcome { get; set; }
+    [JsonProperty("status")]
+    public AppointmentStatus Status { get; set; }
 
     [JsonProperty("attendeeDetails")]
     public AttendeeDetails AttendeeDetails { get; set; }

--- a/src/api/Nhs.Appointments.Persistance/Models/BookingIndexDocument.cs
+++ b/src/api/Nhs.Appointments.Persistance/Models/BookingIndexDocument.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Nhs.Appointments.Core;
 
 namespace Nhs.Appointments.Persistance.Models;
 
@@ -20,6 +21,6 @@ public class BookingIndexDocument : IndexDataCosmosDocument
     [JsonProperty("created")]
     public DateTime Created { get; set; }
 
-    [JsonProperty("provisional")]
-    public bool Provisional { get; set; }
+    [JsonProperty("status")]
+    public AppointmentStatus Status { get; set; }
 }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -235,7 +235,7 @@ public abstract partial class BaseFeatureSteps : Feature
             Duration = int.Parse(row.Cells.ElementAt(2).Value),
             Service = row.Cells.ElementAt(3).Value,
             Site = GetSiteId(siteDesignation),
-            Provisional = bookingType != BookingType.Confirmed,
+            Status = MapStatus(bookingType),
             Created = bookingType == BookingType.ExpiredProvisional ? DateTime.UtcNow.AddMinutes(-10) : DateTime.UtcNow,
             AttendeeDetails = new Core.AttendeeDetails
             {
@@ -264,7 +264,7 @@ public abstract partial class BaseFeatureSteps : Feature
                 DocumentType = "booking_index",
                 Id = BookingReferences.GetBookingReference(index, bookingType),
                 NhsNumber = NhsNumber,
-                Provisional = bookingType != BookingType.Confirmed,
+                Status = MapStatus(bookingType),
                 Created = bookingType == BookingType.ExpiredProvisional ? DateTime.UtcNow.AddMinutes(-10) : DateTime.UtcNow,
                 From = DateTime.ParseExact($"{ParseNaturalLanguageDateOnly(row.Cells.ElementAt(0).Value).ToString("yyyy-MM-dd")} {row.Cells.ElementAt(1).Value}", "yyyy-MM-dd HH:mm", null),
             });
@@ -296,6 +296,14 @@ public abstract partial class BaseFeatureSteps : Feature
             randomString = string.Concat(randomString, random.Next(10).ToString());
         return randomString;
     }
+
+    protected AppointmentStatus MapStatus(BookingType bookingType) => bookingType switch
+    {
+        BookingType.Confirmed => AppointmentStatus.Booked,
+        BookingType.Provisional => AppointmentStatus.Provisional,
+        BookingType.ExpiredProvisional => AppointmentStatus.Provisional,
+        _ => throw new ArgumentOutOfRangeException(nameof(bookingType)),
+    };
     
     protected string GetTestId => $"{_testId}";
     protected string GetSiteId(string siteDesignation = "A") => $"{_testId}-{siteDesignation}";

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingAssertions.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingAssertions.cs
@@ -12,7 +12,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
             expected.ContactDetails.Should().BeEquivalentTo(actual.ContactDetails);
             expected.Duration.Should().Be(actual.Duration);
             expected.AttendeeDetails.Should().BeEquivalentTo(actual.AttendeeDetails);
-            expected.Outcome.Should().Be(actual.Outcome);
+            expected.Status.Should().Be(actual.Status);
             expected.Created.Year.Should().Be(actual.Created.Year);
             expected.Created.Month.Should().Be(actual.Created.Month);
             expected.Created.Day.Should().Be(actual.Created.Day);
@@ -28,7 +28,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
             expected.ContactDetails.Should().BeEquivalentTo(actual.ContactDetails);
             expected.Duration.Should().Be(actual.Duration);
             expected.AttendeeDetails.Should().BeEquivalentTo(actual.AttendeeDetails);
-            expected.Outcome.Should().Be(actual.Outcome);
+            expected.Status.Should().Be(actual.Status);
             expected.Created.Year.Should().Be(actual.Created.Year);
             expected.Created.Month.Should().Be(actual.Created.Month);
             expected.Created.Day.Should().Be(actual.Created.Day);

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
 using Xunit.Gherkin.Quick;
 
@@ -23,7 +24,7 @@ public abstract class BookingBaseFeatureSteps : BaseFeatureSteps
             duration = cells.ElementAt(2).Value,
             service = cells.ElementAt(3).Value,
             site = GetSiteId(),
-            provisional = true,
+            kind = "provisional",
             attendeeDetails = new
             {
                 nhsNumber = EvaluateNhsNumber(cells.ElementAt(4).Value),
@@ -37,20 +38,21 @@ public abstract class BookingBaseFeatureSteps : BaseFeatureSteps
     }
     
     [And(@"the original booking has been '(\w+)'")]
-    public Task AssertRescheduledBookingOutcome(string outcome)
+    public Task AssertRescheduledBookingStatus(string outcome)
     {
-        return AssertBookingOutcome(outcome);
+        return AssertBookingStatus(outcome);
     }
     
     [Then(@"the booking has been '(\w+)'")]
-    public async Task AssertBookingOutcome(string outcome)
-    { 
+    public async Task AssertBookingStatus(string outcome)
+    {
+        var expectedOutcome = Enum.Parse<AppointmentStatus>(outcome);
         Response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
 
         var siteId = GetSiteId();
         var bookingReference = BookingReferences.GetBookingReference(0, BookingType.Confirmed);
         var actualResult = await Client.GetContainer("appts", "booking_data").ReadItemAsync<BookingDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey(siteId));            
-        actualResult.Resource.Outcome.Should().BeEquivalentTo(outcome);
+        actualResult.Resource.Status.Should().Be(expectedOutcome);
     }
     
     [Then(@"the call should fail with (\d*)")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
@@ -44,15 +44,18 @@ public abstract class BookingBaseFeatureSteps : BaseFeatureSteps
     }
     
     [Then(@"the booking has been '(\w+)'")]
-    public async Task AssertBookingStatus(string outcome)
+    public async Task AssertBookingStatus(string status)
     {
-        var expectedOutcome = Enum.Parse<AppointmentStatus>(outcome);
+        var expectedStatus = Enum.Parse<AppointmentStatus>(status);
         Response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
 
         var siteId = GetSiteId();
         var bookingReference = BookingReferences.GetBookingReference(0, BookingType.Confirmed);
-        var actualResult = await Client.GetContainer("appts", "booking_data").ReadItemAsync<BookingDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey(siteId));            
-        actualResult.Resource.Status.Should().Be(expectedOutcome);
+        var bookingDocument = await Client.GetContainer("appts", "booking_data").ReadItemAsync<BookingDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey(siteId));            
+        bookingDocument.Resource.Status.Should().Be(expectedStatus);
+
+        var indexDocument = await Client.GetContainer("appts", "index_data").ReadItemAsync<BookingDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey("booking_index"));
+        indexDocument.Resource.Status.Should().Be(expectedStatus);
     }
     
     [Then(@"the call should fail with (\d*)")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBookingFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBookingFeatureSteps.cs
@@ -56,10 +56,10 @@ public sealed class ConfirmBookingFeatureSteps : BookingBaseFeatureSteps
         var siteId = GetSiteId();
         var bookingReference = BookingReferences.GetBookingReference(0, BookingType.Provisional);
         var actualBooking = await Client.GetContainer("appts", "booking_data").ReadItemAsync<BookingDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey(siteId));
-        actualBooking.Resource.Provisional.Should().BeFalse();
+        actualBooking.Resource.Status.Should().Be(Core.AppointmentStatus.Booked);
     
         var actualBookingIndex = await Client.GetContainer("appts", "index_data").ReadItemAsync<BookingIndexDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey("booking_index"));
-        actualBookingIndex.Resource.Provisional.Should().BeFalse();
+        actualBookingIndex.Resource.Status.Should().Be(Core.AppointmentStatus.Booked);
     }
 
     [And("the booking should have stored my contact details as follows")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/MakeBookingFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/MakeBookingFeatureSteps.cs
@@ -29,7 +29,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
                 duration = cells.ElementAt(2).Value,
                 service = cells.ElementAt(3).Value,
                 site = GetSiteId(),
-                provisional = false,
+                kind = "booked",
                 attendeeDetails = new
                 {
                     nhsNumber = cells.ElementAt(4).Value,
@@ -68,9 +68,8 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
                 From = DateTime.ParseExact($"{ParseNaturalLanguageDateOnly(cells.ElementAt(0).Value):yyyy-MM-dd} {cells.ElementAt(1).Value}", "yyyy-MM-dd HH:mm", null),
                 Duration = int.Parse(cells.ElementAt(2).Value),
                 Service = cells.ElementAt(3).Value,
-                Outcome = null,
+                Status = isProvisional ? Core.AppointmentStatus.Provisional : Core.AppointmentStatus.Booked,
                 Created = DateTime.UtcNow,
-                Provisional = isProvisional,
                 AttendeeDetails = new AttendeeDetails()
                 {
                     NhsNumber = cells.ElementAt(4).Value,

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.cs
@@ -40,7 +40,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
                     Service = row.Cells.ElementAt(3).Value,
                     Site = GetSiteId(),
                     Created = DateTime.UtcNow,
-                    Provisional = false,
+                    Status = AppointmentStatus.Booked,
                     AttendeeDetails = new AttendeeDetails
                     {
                         NhsNumber = NhsNumber,

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/RescheduleFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/RescheduleFeatureSteps.cs
@@ -38,10 +38,10 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
             var siteId = GetSiteId();
             var bookingReference = _reschduledBookingReference;
             var actualBooking = await Client.GetContainer("appts", "booking_data").ReadItemAsync<BookingDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey(siteId));
-            actualBooking.Resource.Provisional.Should().BeFalse();
+            actualBooking.Resource.Status.Should().Be(Core.AppointmentStatus.Booked);
 
             var actualBookingIndex = await Client.GetContainer("appts", "index_data").ReadItemAsync<BookingIndexDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey("booking_index"));
-            actualBookingIndex.Resource.Provisional.Should().BeFalse();
+            actualBookingIndex.Resource.Status.Should().Be(Core.AppointmentStatus.Booked);
         }
     }
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/MakeBookingFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/MakeBookingFunctionTests.cs
@@ -35,7 +35,7 @@ public class MakeBookingFunctionTests
     public async Task RunAsync_ReturnsSuccessResponse_WhenAppointmentIsRequested()
     {
         var slots = AvailabilityHelper.CreateTestSlots(Date, new TimeOnly(10,0), new TimeOnly(11,0), TimeSpan.FromMinutes(5));
-        _bookingService.Setup(x => x.MakeBooking(It.IsAny<Booking>())).ReturnsAsync((true, "TEST01", false));
+        _bookingService.Setup(x => x.MakeBooking(It.IsAny<Booking>())).ReturnsAsync((true, "TEST01"));
         
         var request = CreateRequest("1001", "2077-01-01 10:30", "COVID", "9999999999", "FirstName", "LastName", "1958-06-08", "test@tempuri.org", "0123456789", null);
 
@@ -63,7 +63,7 @@ public class MakeBookingFunctionTests
     {
         var slots = AvailabilityHelper.CreateTestSlots(Date, new TimeOnly(10, 0), new TimeOnly(11, 0), TimeSpan.FromMinutes(5));
         
-        _bookingService.Setup(x => x.MakeBooking(It.IsAny<Booking>())).ReturnsAsync((true, "TEST01", false));
+        _bookingService.Setup(x => x.MakeBooking(It.IsAny<Booking>())).ReturnsAsync((true, "TEST01"));
         
         var request = CreateRequest("1001", "2077-01-01 10:30", "COVID", "9999999999", "FirstName", "LastName", "1958-06-08", "test@tempuri.org", "0123456789", null);
         var expectedBooking = new Booking
@@ -72,6 +72,7 @@ public class MakeBookingFunctionTests
             Duration = 5,
             Service = "COVID",
             From = new DateTime(2077, 1, 1, 10, 30, 0),
+            Status = AppointmentStatus.Booked,
             AttendeeDetails = new Core.AttendeeDetails
             {
                 FirstName = "FirstName",
@@ -115,13 +116,13 @@ public class MakeBookingFunctionTests
         var context = new DefaultHttpContext();
         var request = context.Request;
 
-        var dto = new MakeBookingRequest(site, from, 5, service,
-            new Models.AttendeeDetails(nhsNumber, firstName, lastName, dateOfBirth),
+        var dto = new MakeBookingRequest(site, DateTime.ParseExact(from, "yyyy-MM-dd HH:mm", null) , 5, service,
+            new Models.AttendeeDetails(nhsNumber, firstName, lastName, DateOnly.ParseExact(dateOfBirth, "yyyy-MM-dd")),
             [
                 new Models.ContactItem ("email", email ),
                 new Models.ContactItem ("phone", phoneNumber)
             ],
-            additionalData);
+            additionalData, BookingKind.Booked);
 
         var body = JsonConvert.SerializeObject(dto);
         request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/MakeBookingFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/MakeBookingFunctionTests.cs
@@ -116,7 +116,7 @@ public class MakeBookingFunctionTests
         var context = new DefaultHttpContext();
         var request = context.Request;
 
-        var dto = new MakeBookingRequest(site, from, 5, service,
+        var dto = new MakeBookingRequest(site, DateTime.ParseExact(from, "yyyy-MM-dd HH:mm", null), 5, service,
             new AttendeeDetails
             {
                 NhsNumber = nhsNumber,

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/AttendeeDetailsValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/AttendeeDetailsValidatorTests.cs
@@ -20,7 +20,7 @@ public class AttendeeValidatorTests
             nhsNumber, 
             "FirstName", 
             "LastName", 
-            "1990-01-01");
+            new DateOnly(1990,01,01));
         
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
@@ -36,9 +36,9 @@ public class AttendeeValidatorTests
         var request = new AttendeeDetails(
             "1234567890", 
             firstName, 
-            "LastName", 
-            "1990-01-01");
-        
+            "LastName",
+            new DateOnly(1990, 01, 01));
+
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -54,33 +54,13 @@ public class AttendeeValidatorTests
             "1234567890", 
             "FirstName", 
             lastName, 
-            "1990-01-01");
+            new DateOnly(1990, 01, 01));
         
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(AttendeeDetails.LastName));
-    }
-    
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    [InlineData("01-01-2077")]
-    [InlineData("1990-99-31")]
-    [InlineData("1990-01-99")]
-    public void Validate_ReturnsError_WhenDateOfBirthIsInvalid(string dateOfBirth)
-    {
-        var request = new AttendeeDetails(
-            "1234567890", 
-            "FirstName", 
-            "LastName", 
-            dateOfBirth);
-        
-        var result = _sut.Validate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(AttendeeDetails.DateOfBirth));
-    }
+    }       
     
     [Fact]
     public void Validate_ReturnsError_WhenDateOfBirthIsInTheFuture()
@@ -90,7 +70,7 @@ public class AttendeeValidatorTests
             "1234567890",
             "FirstName",
             "LastName",
-            today);
+            DateOnly.FromDateTime(DateTime.Now.AddDays(5)));
         
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
@@ -105,7 +85,7 @@ public class AttendeeValidatorTests
             "1234567890",
             "FirstName",
             "LastName",
-            "2000-01-01"
+            new DateOnly(2000, 01,01)
         );
         var result = _sut.Validate(request);
         result.IsValid.Should().BeTrue();

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/MakeBookingRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/MakeBookingRequestValidatorTests.cs
@@ -15,12 +15,13 @@ public class MakeBookingRequestValidatorTests
     {
         var request = new MakeBookingRequest(
             site,
-            "2077-01-01 09:00",
+            new DateTime(2077, 01, 01, 09, 0, 0),
             5,
             "COVID",
             GetAttendeeDetails(),
             GetContactDetails(),
-            null
+            null,
+            BookingKind.Booked
         );
         
         var result = _sut.Validate(request);
@@ -37,46 +38,20 @@ public class MakeBookingRequestValidatorTests
     {
         var request = new MakeBookingRequest(
             "1000",
-            "2077-01-01 09:00",
+            new DateTime(2077, 01, 01, 09, 0, 0),
             duration,
             "COVID",
             GetAttendeeDetails(),
             GetContactDetails(),
-            null
+            null,
+            BookingKind.Booked
         );
 
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.Duration));
-    }
-    
-    [Theory]
-    [InlineData("")]
-    [InlineData("01-01-2077 09:00")]
-    [InlineData("2077-99-31 09:00")]
-    [InlineData("2077-01-99 09:00")]
-    [InlineData("Not a date 09:00")]
-    [InlineData("2077-01-01 :00")]
-    [InlineData("2077-01-01 09")]
-    [InlineData(null)]
-    public void Validate_ReturnsError_WhenFromDateIsInvalid(string from)
-    {
-        var request = new MakeBookingRequest(
-            "1000",
-            from,
-            5,
-            "COVID",
-            GetAttendeeDetails(),
-            GetContactDetails(),
-            null
-        );
-        
-        var result = _sut.Validate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.From));
-    }
+    }       
     
     [Theory]
     [InlineData("")]
@@ -85,12 +60,13 @@ public class MakeBookingRequestValidatorTests
     {
         var request = new MakeBookingRequest(
             "1000",
-            "2077-01-01 09:00",
+            new DateTime(2077, 01, 01, 09, 0, 0),
             5,
             service,
             GetAttendeeDetails(),
             GetContactDetails(),
-            null
+            null,
+            BookingKind.Booked
         );
         
         var result = _sut.Validate(request);
@@ -104,76 +80,20 @@ public class MakeBookingRequestValidatorTests
     {
         var request = new MakeBookingRequest(
             "1000",
-            "2077-01-01 09:00",
+            new DateTime(2077, 01, 01, 09, 0, 0),
             5,
             "COVID",
             null,
             GetContactDetails(),
-            null
+            null,
+            BookingKind.Booked
         );
         
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.AttendeeDetails));
-    }
-
-    [Fact]
-    public void Validate_ReturnsError_WhenContactDetailsIsNull()
-    {
-        var request = new MakeBookingRequest(
-            "1000",
-            "2077-01-01 09:00",
-            5,
-            "COVID",
-            GetAttendeeDetails(),
-            null,
-            null
-        );
-
-        var result = _sut.Validate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.ContactDetails));
-    }
-
-    [Fact]
-    public void Validate_ContactDetailsCanBeNull_IfProvisional()
-    {
-        var request = new MakeBookingRequest(
-            "1000",
-            "2077-01-01 09:00",
-            5,
-            "COVID",
-            GetAttendeeDetails(),
-            null,
-            null,
-            true
-        );
-
-        var result = _sut.Validate(request);
-        result.IsValid.Should().BeTrue();
-    }
-
-    [Fact]
-    public void Validate_ProvisionalBooking_ShouldNotHaveContactDetails()
-    {
-        var request = new MakeBookingRequest(
-            "1000",
-            "2077-01-01 09:00",
-            5,
-            "COVID",
-            GetAttendeeDetails(),
-            [new ContactItem("email", "test@tempuri.org")],
-            null,
-            true
-        );
-
-        var result = _sut.Validate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.ContactDetails));
-    }
+    }    
 
     [Fact]
     public void Validate_ReturnsError_WhenRequestIsEmpty()
@@ -190,12 +110,13 @@ public class MakeBookingRequestValidatorTests
     {
         var request = new MakeBookingRequest(
             "1000",
-            "2077-01-01 09:00",
+            new DateTime(2077, 01, 01, 09, 0, 0),
             5,
             "COVID",
             GetAttendeeDetails(),
             GetContactDetails(),
-            null
+            null,
+            BookingKind.Booked
         );
         var result = _sut.Validate(request);
         result.IsValid.Should().BeTrue();
@@ -208,7 +129,7 @@ public class MakeBookingRequestValidatorTests
             "1234567890",
             "FirstName",
             "LastName",
-            "1980-01-01"
+            new DateOnly(1980, 01, 01)
         );
         return attendeeDetails;
     }

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/MakeBookingRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/MakeBookingRequestValidatorTests.cs
@@ -94,64 +94,7 @@ public class MakeBookingRequestValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.AttendeeDetails));
-    }    
-
-    [Fact]
-    public void Validate_ReturnsError_WhenContactDetailsIsNull()
-    {
-        var request = new MakeBookingRequest(
-            "1000",
-            "2077-01-01 09:00",
-            5,
-            "COVID",
-            GetAttendeeDetails(),
-            null,
-            null
-        );
-
-        var result = _sut.Validate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.ContactDetails));
-    }
-
-    [Fact]
-    public void Validate_ContactDetailsCanBeNull_IfProvisional()
-    {
-        var request = new MakeBookingRequest(
-            "1000",
-            "2077-01-01 09:00",
-            5,
-            "COVID",
-            GetAttendeeDetails(),
-            null,
-            null,
-            true
-        );
-
-        var result = _sut.Validate(request);
-        result.IsValid.Should().BeTrue();
-    }
-
-    [Fact]
-    public void Validate_ProvisionalBooking_ShouldNotHaveContactDetails()
-    {
-        var request = new MakeBookingRequest(
-            "1000",
-            "2077-01-01 09:00",
-            5,
-            "COVID",
-            GetAttendeeDetails(),
-            [new ContactItem { Type = ContactItemType.Email, Value = "test@tempuri.org" }],
-            null,
-            true
-        );
-
-        var result = _sut.Validate(request);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.ContactDetails));
-    }
+    }            
 
     [Fact]
     public void Validate_ReturnsError_WhenRequestIsEmpty()

--- a/tests/Nhs.Appointments.Core.UnitTests/AvailabilityCalculatorTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/AvailabilityCalculatorTests.cs
@@ -132,7 +132,7 @@ public class AvailabilityCalculatorTests
 
         var bookings = new[]
         {
-            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01", "cancelled")
+            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01", AppointmentStatus.Cancelled)
         };
 
         _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
@@ -163,7 +163,7 @@ public class AvailabilityCalculatorTests
 
         var bookings = new[]
         {
-            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01", null, true, DateTime.Now.AddMinutes(-6))
+            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01", AppointmentStatus.Provisional, DateTime.Now.AddMinutes(-6))
         };
 
         _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
@@ -258,7 +258,7 @@ public class AvailabilityCalculatorTests
         return sessionInstance;
     }
     
-    private static Booking CreateTestBooking(DateTime appointmentDateAndTime, int appointmentDuration, string service, string site, string outcome = null, bool provisional = false, DateTime? created = null)
+    private static Booking CreateTestBooking(DateTime appointmentDateAndTime, int appointmentDuration, string service, string site, AppointmentStatus status = AppointmentStatus.Booked, DateTime? created = null)
     {
         created = created ?? DateTime.Now;
         var testBooking = new Booking
@@ -268,7 +268,7 @@ public class AvailabilityCalculatorTests
             Duration = appointmentDuration,
             Service = service,
             Site = site,            
-            Outcome = outcome,
+            Status = status,
             AttendeeDetails = new AttendeeDetails()
             {
                 NhsNumber = "999999999",
@@ -276,7 +276,6 @@ public class AvailabilityCalculatorTests
                 FirstName = "FirstName",
                 LastName = "LastName"
             },
-            Provisional = provisional,
             Created = created.Value
         };
         return testBooking;

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingServiceTests.cs
@@ -72,7 +72,7 @@ namespace Nhs.Appointments.Core.UnitTests
             var expectedUntil = expectedFrom.AddDays(1);
             var availability = new[] { new SessionInstance(new DateTime(2077, 1, 1, 10, 0, 0, 0), new DateTime(2077, 1, 1, 10, 10, 0, 0)) { Services = new[] { "TSERV" } } };
 
-            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = [new ContactItem()], AttendeeDetails = new AttendeeDetails() };
+            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = [new ContactItem()], AttendeeDetails = new AttendeeDetails(), Status = AppointmentStatus.Booked };
 
             _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
             _availabilityCalculator.Setup(x => x.CalculateAvailability("TEST", "TSERV", expectedFrom, expectedUntil)).ReturnsAsync(availability);
@@ -90,7 +90,7 @@ namespace Nhs.Appointments.Core.UnitTests
             var expectedUntil = expectedFrom.AddDays(1);
             var availability = new[] { new SessionInstance(new DateTime(2077, 1, 1, 10, 0, 0, 0), new DateTime(2077, 1, 1, 10, 10, 0, 0)) { Services = new[] { "TSERV" } } };
 
-            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = null, Provisional = true };
+            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = null, Status = AppointmentStatus.Provisional };
 
             _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
             _availabilityCalculator.Setup(x => x.CalculateAvailability("TEST", "TSERV", expectedFrom, expectedUntil)).ReturnsAsync(availability);
@@ -172,7 +172,7 @@ namespace Nhs.Appointments.Core.UnitTests
             var bookingRef = "some-booking";
 
             var updateMock = new Mock<IDocumentUpdate<Booking>>();
-            updateMock.Setup(x => x.UpdateProperty(b => b.Outcome, "Cancelled")).Returns(updateMock.Object).Verifiable();
+            updateMock.Setup(x => x.UpdateProperty(b => b.Status, AppointmentStatus.Cancelled)).Returns(updateMock.Object).Verifiable();
 
             _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync(It.IsAny<string>())).Returns(Task.FromResult(new Booking() { Site = site }));
             _bookingsDocumentStore.Setup(x => x.BeginUpdate(site, bookingRef)).Returns(updateMock.Object).Verifiable();
@@ -190,7 +190,7 @@ namespace Nhs.Appointments.Core.UnitTests
             var bookingRef = "some-booking";
 
             var updateMock = new Mock<IDocumentUpdate<Booking>>();
-            updateMock.Setup(x => x.UpdateProperty(b => b.Outcome, "Cancelled")).Returns(updateMock.Object);
+            updateMock.Setup(x => x.UpdateProperty(b => b.Status, AppointmentStatus.Cancelled)).Returns(updateMock.Object);
 
             _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync(It.IsAny<string>())).Returns(Task.FromResult(new Booking { Reference = bookingRef, Site = site}));
             _bookingsDocumentStore.Setup(x => x.BeginUpdate(site, bookingRef)).Returns(updateMock.Object);

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingServiceTests.cs
@@ -115,20 +115,20 @@ namespace Nhs.Appointments.Core.UnitTests
 
             ContactItem[] contactDetails = [new ContactItem { Type = ContactItemType.Email, Value = "test@tempuri.org" }];
 
-            var initialBooking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = null, Provisional = true };
+            var initialBooking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = null, Status = AppointmentStatus.Provisional };
 
             _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
             _availabilityCalculator.Setup(x => x.CalculateAvailability("TEST", "TSERV", expectedFrom, expectedUntil)).ReturnsAsync(availability);
             _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync("TEST1");
             _bookingsDocumentStore.Setup(x => x.ConfirmProvisional(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>())).ReturnsAsync(BookingConfirmationResult.Success);
-            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync("TEST1")).ReturnsAsync(new Booking { Reference = "TEST1", Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = contactDetails, Provisional = false, AttendeeDetails = new AttendeeDetails() });
-            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync("TEST2")).ReturnsAsync(new Booking { Reference = "TEST2", Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 11, 0, 0, 0), Duration = 10, ContactDetails = contactDetails, Provisional = false, AttendeeDetails = new AttendeeDetails() });
+            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync("TEST1")).ReturnsAsync(new Booking { Reference = "TEST1", Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = contactDetails, Status = AppointmentStatus.Booked, AttendeeDetails = new AttendeeDetails() });
+            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync("TEST2")).ReturnsAsync(new Booking { Reference = "TEST2", Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 11, 0, 0, 0), Duration = 10, ContactDetails = contactDetails, Status = AppointmentStatus.Booked, AttendeeDetails = new AttendeeDetails() });
             var initialBookingResult = await _bookingsService.MakeBooking(initialBooking);
             await _bookingsService.ConfirmProvisionalBooking(initialBookingResult.Reference, contactDetails, "");
 
             _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync("TEST2");
 
-            var rescheduledBooking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 11, 0, 0, 0), Duration = 10, ContactDetails = null, Provisional = true };
+            var rescheduledBooking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 11, 0, 0, 0), Duration = 10, ContactDetails = null, Status = AppointmentStatus.Provisional };
             var rescheduledBookingResult = await _bookingsService.MakeBooking(rescheduledBooking);
 
             var rescheduleResult = await _bookingsService.ConfirmProvisionalBooking(rescheduledBooking.Reference, contactDetails, initialBookingResult.Reference);
@@ -150,20 +150,20 @@ namespace Nhs.Appointments.Core.UnitTests
 
             ContactItem[] contactDetails = [new ContactItem { Type = ContactItemType.Email, Value = "test@tempuri.org" }];
 
-            var initialBooking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = null, Provisional = true };
+            var initialBooking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = null, Status = AppointmentStatus.Provisional };
 
             _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
             _availabilityCalculator.Setup(x => x.CalculateAvailability("TEST", "TSERV", expectedFrom, expectedUntil)).ReturnsAsync(availability);
             _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync("TEST1");
             _bookingsDocumentStore.Setup(x => x.ConfirmProvisional(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>())).ReturnsAsync(BookingConfirmationResult.Success);
-            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync("TEST1")).ReturnsAsync(new Booking { Reference = "TEST1", Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = contactDetails, Provisional = false, AttendeeDetails = new AttendeeDetails() });
-            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync("TEST2")).ReturnsAsync(new Booking { Reference = "TEST2", Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 11, 0, 0, 0), Duration = 10, ContactDetails = contactDetails, Provisional = false, AttendeeDetails = new AttendeeDetails() });
+            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync("TEST1")).ReturnsAsync(new Booking { Reference = "TEST1", Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = contactDetails, Status = AppointmentStatus.Booked, AttendeeDetails = new AttendeeDetails() });
+            _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync("TEST2")).ReturnsAsync(new Booking { Reference = "TEST2", Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 11, 0, 0, 0), Duration = 10, ContactDetails = contactDetails, Status = AppointmentStatus.Booked, AttendeeDetails = new AttendeeDetails() });
             var initialBookingResult = await _bookingsService.MakeBooking(initialBooking);
             await _bookingsService.ConfirmProvisionalBooking(initialBookingResult.Reference, contactDetails, "");
 
             _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync("TEST2");
 
-            var rescheduledBooking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 11, 0, 0, 0), Duration = 10, ContactDetails = null, Provisional = true };
+            var rescheduledBooking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 11, 0, 0, 0), Duration = 10, ContactDetails = null, Status = AppointmentStatus.Provisional };
             var rescheduledBookingResult = await _bookingsService.MakeBooking(rescheduledBooking);
 
             var rescheduleResult = await _bookingsService.ConfirmProvisionalBooking(rescheduledBooking.Reference, contactDetails, initialBookingResult.Reference);
@@ -178,7 +178,7 @@ namespace Nhs.Appointments.Core.UnitTests
             var expectedUntil = expectedFrom.AddDays(1);
             var availability = new[] { new SessionInstance(new DateTime(2077, 1, 1, 10, 0, 0, 0), new DateTime(2077, 1, 1, 10, 10, 0, 0)) { Services = new[] { "TSERV" } } };
 
-            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = [new ContactItem()], AttendeeDetails = new AttendeeDetails() };
+            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = [new ContactItem()], AttendeeDetails = new AttendeeDetails(), Status = AppointmentStatus.Booked };
 
             _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
             _availabilityCalculator.Setup(x => x.CalculateAvailability("TEST", "TSERV", expectedFrom, expectedUntil)).ReturnsAsync(availability);
@@ -198,7 +198,7 @@ namespace Nhs.Appointments.Core.UnitTests
             var expectedUntil = expectedFrom.AddDays(1);
             var availability = new[] { new SessionInstance(new DateTime(2077, 1, 1, 10, 0, 0, 0), new DateTime(2077, 1, 1, 10, 10, 0, 0)) { Services = new[] { "TSERV" } } };
 
-            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = [new ContactItem()], AttendeeDetails = new AttendeeDetails()  };
+            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10, ContactDetails = [new ContactItem()], AttendeeDetails = new AttendeeDetails(), Status = AppointmentStatus.Booked };
 
             _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
             _availabilityCalculator.Setup(x => x.CalculateAvailability("TEST", "TSERV", expectedFrom, expectedUntil)).ReturnsAsync(availability);
@@ -216,7 +216,7 @@ namespace Nhs.Appointments.Core.UnitTests
             var expectedUntil = expectedFrom.AddDays(1);
             var availability = new[] { new SessionInstance(new DateTime(2077, 1, 1, 9, 0, 0, 0), new DateTime(2077, 1, 1, 12, 0, 0, 0)) };
 
-            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 13, 0, 0, 0), Duration = 10 };
+            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 13, 0, 0, 0), Duration = 10, Status = AppointmentStatus.Booked };
 
             _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
             _availabilityCalculator.Setup(x => x.CalculateAvailability("TEST", "TSERV", expectedFrom, expectedUntil)).ReturnsAsync(availability);


### PR DESCRIPTION
Remove the provisional field from booking, instead use the status field (renamed from outcome) - this can now store the status of an appointment as either Provisional, Booked, or Cancelled. This data is stored in the booking document and booking_index document. Changes also made to the Make Booking endpoint - now accepts "kind" instead of "provisional" - kind can be "booked" or "provisional"