### PR TITLE
Fix for site not found when booking

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/MakeBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/MakeBookingFunction.cs
@@ -14,7 +14,7 @@ using Nhs.Appointments.Api.Auth;
 
 namespace Nhs.Appointments.Api.Functions;
 
-public class MakeBookingFunction(IBookingsService bookingService, IValidator<MakeBookingRequest> validator, IUserContextProvider userContextProvider, ILogger<MakeBookingFunction> logger, IMetricsRecorder metricsRecorder)
+public class MakeBookingFunction(IBookingsService bookingService, ISiteService siteService, IValidator<MakeBookingRequest> validator, IUserContextProvider userContextProvider, ILogger<MakeBookingFunction> logger, IMetricsRecorder metricsRecorder)
     : BaseApiFunction<MakeBookingRequest, MakeBookingResponse>(validator, userContextProvider, logger, metricsRecorder)
 {
     [OpenApiOperation(operationId: "MakeBooking", tags: ["Booking"], Summary = "Make a booking")]
@@ -45,6 +45,10 @@ public class MakeBookingFunction(IBookingsService bookingService, IValidator<Mak
             ContactDetails = bookingRequest.ContactDetails?.ToArray(),            
             AdditionalData = bookingRequest.AdditionalData
         };
+
+        var site = await siteService.GetSiteByIdAsync(requestedBooking.Site);
+        if(site == null)
+            return Failed(HttpStatusCode.NotFound, "Site for booking request could not be found");
 
         var bookingResult = await bookingService.MakeBooking(requestedBooking);
         if (bookingResult.Success == false)

--- a/src/api/Nhs.Appointments.Core/Metrics/InMemoryMetricsRecorder.cs
+++ b/src/api/Nhs.Appointments.Core/Metrics/InMemoryMetricsRecorder.cs
@@ -5,11 +5,14 @@
 
     public void RecordMetric(string name, double value)
     {
-        var scopedName = string.Join("/", _scopeStack.Reverse().Concat(new[] { name }));
-        _metrics.Add((scopedName, value));
+        lock (_metrics)
+        {
+            var scopedName = string.Join("/", _scopeStack.Reverse().Concat(new[] { name }));
+            _metrics.Add((scopedName, value));
+        }
     }
 
-    public IReadOnlyCollection<(string Path, double Value)> Metrics => _metrics;
+    public IReadOnlyCollection<(string Path, double Value)> Metrics => _metrics.ToList().AsReadOnly();
 
     public IDisposable BeginScope(string scopeName)
     {

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/MakeBooking.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/MakeBooking.feature
@@ -25,6 +25,7 @@
           | Tomorrow | 09:20 | 5        | COVID   | 1234678891 | Test      | One      | 2000-02-01 |       |       | Yes         | true           |             |
 
     Scenario: Cannot book an appointment that is no longer available
+        Given the site is configured for MYA
         Given the following sessions
           | Date     | From  | Until | Services | Slot Length | Capacity |
           | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
@@ -37,6 +38,7 @@
         Then I receive a message informing me that the appointment is no longer available
 
     Scenario: Cannot book an appointment that is outside the session
+        Given the site is configured for MYA
         Given the following sessions
           | Date     | From  | Until | Services | Slot Length | Capacity |
           | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |


### PR DESCRIPTION
Checks for site when processing a booking request and sends a specific error message if the site does not exist
Also fixed some thread / concurrency issues with the metrics recorder as they were causing integration test failures