### PR TITLE
Appt 338/get daily availability endpoint - PART 1

### DIFF
--- a/postman-collection/Appointment Service.postman_collection.json
+++ b/postman-collection/Appointment Service.postman_collection.json
@@ -1119,7 +1119,7 @@
 					}
 				],
 				"url": {
-					"raw": "{{baseUrl}}/api/daily-availability?site=ABC02&from=2024-12-03&to=2024-12-08",
+					"raw": "{{baseUrl}}/api/daily-availability?site=ABC02&from=2024-12-03&until=2024-12-08",
 					"host": [
 						"{{baseUrl}}"
 					],
@@ -1137,7 +1137,7 @@
 							"value": "2024-12-03"
 						},
 						{
-							"key": "to",
+							"key": "until",
 							"value": "2024-12-08"
 						}
 					]

--- a/postman-collection/Appointment Service.postman_collection.json
+++ b/postman-collection/Appointment Service.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "6ddb1181-33d2-4bbb-a631-fad3492086f0",
+		"_postman_id": "2a5010aa-37c4-4257-8b79-80665db57d50",
 		"name": "Appointment Service",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "27520445"
+		"_exporter_id": "39091838"
 	},
 	"item": [
 		{
@@ -1101,6 +1101,44 @@
 						{
 							"key": "site",
 							"value": "{{site}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "daily-availability",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "ClientId",
+						"value": "{{clientId}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/api/daily-availability?site=ABC02&from=2024-12-03&to=2024-12-08",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"api",
+						"daily-availability"
+					],
+					"query": [
+						{
+							"key": "site",
+							"value": "ABC02"
+						},
+						{
+							"key": "from",
+							"value": "2024-12-03"
+						},
+						{
+							"key": "to",
+							"value": "2024-12-08"
 						}
 					]
 				}

--- a/src/api/Nhs.Appointments.Api/Functions/GetDailyAvailabilityFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetDailyAvailabilityFunction.cs
@@ -1,0 +1,52 @@
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Nhs.Appointments.Api.Auth;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Core;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.OpenApi.Models;
+
+namespace Nhs.Appointments.Api.Functions;
+
+public class GetDailyAvailabilityFunction(IAvailabilityService availabilityService, IValidator<GetDailyAvailabilityRequest> validator, IUserContextProvider userContextProvider, ILogger<GetDailyAvailabilityFunction> logger, IMetricsRecorder metricsRecorder)
+    : BaseApiFunction<GetDailyAvailabilityRequest, IEnumerable<DailyAvailability>>(validator, userContextProvider, logger, metricsRecorder)
+{
+    [OpenApiOperation(operationId: "Get_DailyAvailabilityFunction", tags: ["Availability"], Summary = "Get daily availability within a date range previously")]
+    [OpenApiParameter("site", In = ParameterLocation.Query, Required = true, Type = typeof(double), Description = "The id of them site where to get daily availability from")]
+    [OpenApiParameter("from", In = ParameterLocation.Query, Required = true, Type = typeof(double), Description = "The start of the date range to get daily availability")]
+    [OpenApiParameter("to", In = ParameterLocation.Query, Required = true, Type = typeof(double), Description = "The end of the date range to get daily availability")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, "application/json", typeof(IEnumerable<DailyAvailability>), Description = "List of daily availability within a date range")]
+    [OpenApiResponseWithBody(statusCode:HttpStatusCode.Unauthorized, "application/json", typeof(ErrorMessageResponseItem), Description = "Unauthorized request to a protected API")]
+    [OpenApiResponseWithBody(statusCode:HttpStatusCode.Forbidden, "application/json", typeof(ErrorMessageResponseItem), Description = "Request failed due to insufficient permissions")]
+    [RequiresPermission("availability:query", typeof(SiteFromQueryStringInspector))]
+    [Function("GetDailyAvailabilityFunction")]
+    public override Task<IActionResult> RunAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "daily-availabiltiy")] HttpRequest req)
+    {
+        return base.RunAsync(req);
+    }
+
+    protected override async Task<ApiResult<IEnumerable<DailyAvailability>>> HandleRequest(GetDailyAvailabilityRequest request, ILogger logger)
+    {
+        var availability = await availabilityService.GetDailyAvailability(request.Site, request.FromDate, request.ToDate);
+
+        return Success(availability);
+    }
+
+    protected override Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetDailyAvailabilityRequest request)> ReadRequestAsync(HttpRequest req)
+    {
+        var errors = new List<ErrorMessageResponseItem>();
+
+        var site = req.Query["site"];
+        var from = req.Query["from"];
+        var to = req.Query["to"];
+
+        return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetDailyAvailabilityRequest request)>
+            ((errors.AsReadOnly(), new GetDailyAvailabilityRequest(site, from, to)));
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Functions/GetDailyAvailabilityFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetDailyAvailabilityFunction.cs
@@ -26,7 +26,7 @@ public class GetDailyAvailabilityFunction(IAvailabilityService availabilityServi
     [OpenApiResponseWithBody(statusCode:HttpStatusCode.Forbidden, "application/json", typeof(ErrorMessageResponseItem), Description = "Request failed due to insufficient permissions")]
     [RequiresPermission("availability:query", typeof(SiteFromQueryStringInspector))]
     [Function("GetDailyAvailabilityFunction")]
-    public override Task<IActionResult> RunAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "daily-availabiltiy")] HttpRequest req)
+    public override Task<IActionResult> RunAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "daily-availability")] HttpRequest req)
     {
         return base.RunAsync(req);
     }

--- a/src/api/Nhs.Appointments.Api/Functions/GetDailyAvailabilityFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetDailyAvailabilityFunction.cs
@@ -33,7 +33,7 @@ public class GetDailyAvailabilityFunction(IAvailabilityService availabilityServi
 
     protected override async Task<ApiResult<IEnumerable<DailyAvailability>>> HandleRequest(GetDailyAvailabilityRequest request, ILogger logger)
     {
-        var availability = await availabilityService.GetDailyAvailability(request.Site, request.FromDate, request.ToDate);
+        var availability = await availabilityService.GetDailyAvailability(request.Site, request.FromDate, request.UntilDate);
 
         return Success(availability);
     }
@@ -44,9 +44,9 @@ public class GetDailyAvailabilityFunction(IAvailabilityService availabilityServi
 
         var site = req.Query["site"];
         var from = req.Query["from"];
-        var to = req.Query["to"];
+        var until = req.Query["until"];
 
         return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetDailyAvailabilityRequest request)>
-            ((errors.AsReadOnly(), new GetDailyAvailabilityRequest(site, from, to)));
+            ((errors.AsReadOnly(), new GetDailyAvailabilityRequest(site, from, until)));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Models/GetDailyAvailabilityRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/GetDailyAvailabilityRequest.cs
@@ -5,9 +5,9 @@ namespace Nhs.Appointments.Api.Models
     public record GetDailyAvailabilityRequest(
         string Site,
         string From,
-        string To)
+        string Until)
     {
         public DateOnly FromDate => DateOnly.ParseExact(From, "yyyy-MM-dd");
-        public DateOnly ToDate => DateOnly.ParseExact(To, "yyyy-MM-dd");
+        public DateOnly UntilDate => DateOnly.ParseExact(Until, "yyyy-MM-dd");
     }
 }

--- a/src/api/Nhs.Appointments.Api/Models/GetDailyAvailabilityRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/GetDailyAvailabilityRequest.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Nhs.Appointments.Api.Models
+{
+    public record GetDailyAvailabilityRequest(
+        string Site,
+        string From,
+        string To)
+    {
+        public DateOnly FromDate => DateOnly.ParseExact(From, "yyyy-MM-dd");
+        public DateOnly ToDate => DateOnly.ParseExact(To, "yyyy-MM-dd");
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Validators/GetDailyAvailabilityRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetDailyAvailabilityRequestValidator.cs
@@ -18,10 +18,10 @@ namespace Nhs.Appointments.Api.Validators
                 .WithMessage("Provide a date in 'yyyy-MM-dd'")
                 .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))
                 .WithMessage("Provide a date in the format 'yyyy-MM-dd'")
-                .LessThanOrEqualTo(x => x.To)
+                .LessThanOrEqualTo(x => x.Until)
                 .WithMessage("'from' date must be before 'to' date");
 
-            RuleFor(x => x.To)
+            RuleFor(x => x.Until)
                 .Cascade(CascadeMode.Stop)
                 .NotEmpty().WithMessage("Provide a date in 'yyyy-MM-dd'")
                 .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))

--- a/src/api/Nhs.Appointments.Api/Validators/GetDailyAvailabilityRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetDailyAvailabilityRequestValidator.cs
@@ -1,0 +1,31 @@
+﻿using FluentValidation;
+using Nhs.Appointments.Api.Models;
+using System;
+
+namespace Nhs.Appointments.Api.Validators
+{
+    public class GetDailyAvailabilityRequestValidator : AbstractValidator<GetDailyAvailabilityRequest>
+    {
+        public GetDailyAvailabilityRequestValidator()
+        {
+            RuleFor(x => x.Site)
+            .NotEmpty()
+            .WithMessage("Provide a valid site");
+
+            RuleFor(x => x.From)
+                .Cascade(CascadeMode.Stop)
+                .NotEmpty()
+                .WithMessage("Provide a date in 'yyyy-MM-dd'")
+                .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))
+                .WithMessage("Provide a date in the format 'yyyy-MM-dd'")
+                .LessThanOrEqualTo(x => x.To)
+                .WithMessage("'from' date must be before 'to' date");
+
+            RuleFor(x => x.To)
+                .Cascade(CascadeMode.Stop)
+                .NotEmpty().WithMessage("Provide a date in 'yyyy-MM-dd'")
+                .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))
+                .WithMessage("Provide a date in the format 'yyyy-MM-dd'");
+        }
+    }
+}

--- a/src/api/Nhs.Appointments.Core/AvailabilityService.cs
+++ b/src/api/Nhs.Appointments.Core/AvailabilityService.cs
@@ -55,6 +55,17 @@ public class AvailabilityService(IAvailabilityStore availabilityStore, IAvailabi
         await availabilityStore.ApplyAvailabilityTemplate(site, date, sessions, mode);
     }
 
+    public async Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to)
+    {
+        if (string.IsNullOrEmpty(site))
+            throw new ArgumentException("Site must have a value.");
+
+        if (from > to)
+            throw new ArgumentException("From date must be before to date.");
+
+        return await availabilityStore.GetDailyAvailability(site, from, to);
+    }
+
     private static IEnumerable<DateOnly> GetDatesBetween(DateOnly start, DateOnly end, params DayOfWeek[] weekdays)
     {
         var cursor = start;

--- a/src/api/Nhs.Appointments.Core/AvailabilityService.cs
+++ b/src/api/Nhs.Appointments.Core/AvailabilityService.cs
@@ -57,12 +57,6 @@ public class AvailabilityService(IAvailabilityStore availabilityStore, IAvailabi
 
     public async Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to)
     {
-        if (string.IsNullOrEmpty(site))
-            throw new ArgumentException("Site must have a value.");
-
-        if (from > to)
-            throw new ArgumentException("From date must be before to date.");
-
         return await availabilityStore.GetDailyAvailability(site, from, to);
     }
 

--- a/src/api/Nhs.Appointments.Core/DailyAvailability.cs
+++ b/src/api/Nhs.Appointments.Core/DailyAvailability.cs
@@ -1,0 +1,8 @@
+﻿namespace Nhs.Appointments.Core
+{
+    public class DailyAvailability
+    {
+        public DateOnly Date { get; set; }
+        public Session[] Sessions { get; set; }
+    }
+}

--- a/src/api/Nhs.Appointments.Core/IAvailabilityService.cs
+++ b/src/api/Nhs.Appointments.Core/IAvailabilityService.cs
@@ -5,4 +5,5 @@ public interface IAvailabilityService
     Task ApplyAvailabilityTemplateAsync(string site, DateOnly from, DateOnly until, Template template, ApplyAvailabilityMode mode, string user);
     Task ApplySingleDateSessionAsync(DateOnly date, string site, Session[] sessions, ApplyAvailabilityMode mode, string user);
     Task<IEnumerable<AvailabilityCreatedEvent>> GetAvailabilityCreatedEventsAsync(string site, DateOnly from);
+    Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to);
 }

--- a/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
+++ b/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
@@ -4,4 +4,5 @@ public interface IAvailabilityStore
 {
     Task<IEnumerable<SessionInstance>> GetSessions(string site, DateOnly notBefore, DateOnly notAfter);
     Task ApplyAvailabilityTemplate(string site, DateOnly date, Session[] sessions, ApplyAvailabilityMode mode);
+    Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to);
 }

--- a/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
@@ -54,9 +54,7 @@ public class AvailabilityDocumentStore(ITypedDocumentCosmosStore<DailyAvailabili
     public async Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to)
     {
         var docType = documentStore.GetDocumentType();
-        var documents = await documentStore.RunQueryAsync<DailyAvailabilityDocument>(b => b.DocumentType == docType && b.Site == site && b.Date >= from && b.Date <= to);
-
-        return mapper.Map<IEnumerable<DailyAvailability>>(documents);
+        return await documentStore.RunQueryAsync<DailyAvailability>(b => b.DocumentType == docType && b.Site == site && b.Date >= from && b.Date <= to);
     }
 
     private async Task WriteDocument(DateOnly date, string documentType, string documentId, Session[] sessions, string site)

--- a/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.Azure.Cosmos;
 using Nhs.Appointments.Persistance.Models;
 using Nhs.Appointments.Core;
+using AutoMapper;
 
 namespace Nhs.Appointments.Persistance;
 
-public class AvailabilityDocumentStore(ITypedDocumentCosmosStore<DailyAvailabilityDocument> documentStore, IMetricsRecorder metricsRecorder) : IAvailabilityStore
+public class AvailabilityDocumentStore(ITypedDocumentCosmosStore<DailyAvailabilityDocument> documentStore, IMetricsRecorder metricsRecorder, IMapper mapper) : IAvailabilityStore
 {
     public async Task<IEnumerable<SessionInstance>> GetSessions(string site, DateOnly from, DateOnly to)
     {
@@ -48,6 +49,14 @@ public class AvailabilityDocumentStore(ITypedDocumentCosmosStore<DailyAvailabili
             default:
                 throw new NotSupportedException();
         }
+    }
+
+    public async Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to)
+    {
+        var docType = documentStore.GetDocumentType();
+        var documents = await documentStore.RunQueryAsync<DailyAvailabilityDocument>(b => b.DocumentType == docType && b.Site == site && b.Date >= from && b.Date <= to);
+
+        return mapper.Map<IEnumerable<DailyAvailability>>(documents);
     }
 
     private async Task WriteDocument(DateOnly date, string documentType, string documentId, Session[] sessions, string site)

--- a/src/api/Nhs.Appointments.Persistance/CosmosAutoMapperProfile.cs
+++ b/src/api/Nhs.Appointments.Persistance/CosmosAutoMapperProfile.cs
@@ -29,5 +29,7 @@ public class CosmosAutoMapperProfile : Profile
         CreateMap<SiteDocument, Site>();
 
         CreateMap<NotificationConfigurationItem, NotificationConfiguration>();
+
+        CreateMap<DailyAvailabilityDocument, DailyAvailability>();
     }
 }

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -15,6 +15,7 @@ import {
   AvailabilityResponse,
   FetchBookingsRequest,
   Booking,
+  DailyAvailability,
 } from '@types';
 import { appointmentsApi } from '@services/api/appointmentsApi';
 import { ApiResponse } from '@types';
@@ -317,6 +318,18 @@ export const fetchBookings = async (payload: FetchBookingsRequest) => {
   const response = await appointmentsApi.post<Booking[]>(
     'booking/query',
     JSON.stringify(payload),
+  );
+
+  return handleBodyResponse(response);
+};
+
+export const fetchDailyAvailability = async (
+  site: string,
+  from: string,
+  to: string,
+) => {
+  const response = await appointmentsApi.get<DailyAvailability[]>(
+    `daily-availability?site=${site}&from=${from}&to=${to}`,
   );
 
   return handleBodyResponse(response);

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -326,10 +326,10 @@ export const fetchBookings = async (payload: FetchBookingsRequest) => {
 export const fetchDailyAvailability = async (
   site: string,
   from: string,
-  to: string,
+  until: string,
 ) => {
   const response = await appointmentsApi.get<DailyAvailability[]>(
-    `daily-availability?site=${site}&from=${from}&to=${to}`,
+    `daily-availability?site=${site}&from=${from}&until=${until}`,
   );
 
   return handleBodyResponse(response);

--- a/src/client/src/app/lib/services/timeService.ts
+++ b/src/client/src/app/lib/services/timeService.ts
@@ -2,11 +2,13 @@ import { DateComponents, TimeComponents } from '@types';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import utc from 'dayjs/plugin/utc';
+import isoWeek from 'dayjs/plugin/isoWeek';
 
 dayjs.extend(customParseFormat);
 // Our times are treated as zone agnostic, but if we don't
 // specify this then midnight 2020-09-16 will get formatted as 23:00 2020-09-15
 dayjs.extend(utc);
+dayjs.extend(isoWeek);
 
 export const now = () => dayjs.utc();
 
@@ -86,4 +88,12 @@ export const toTwoDigitFormat = (
 
 export const parseDateString = (dateString: string, format = 'YYYY-MM-DD') => {
   return dayjs.utc(dateString, format, true);
+};
+
+export const startOfWeek = (dateString: string) => {
+  return dayjs(dateString).startOf('isoWeek');
+};
+
+export const endOfWeek = (dateString: string) => {
+  return dayjs(dateString).endOf('isoWeek');
 };

--- a/src/client/src/app/lib/types/index.tsx
+++ b/src/client/src/app/lib/types/index.tsx
@@ -215,7 +215,7 @@ type ClinicalService = {
 };
 
 type DailyAvailability = {
-  date: Date;
+  date: string;
   sessions: AvailabilitySession[];
 };
 

--- a/src/client/src/app/lib/types/index.tsx
+++ b/src/client/src/app/lib/types/index.tsx
@@ -214,6 +214,11 @@ type ClinicalService = {
   value: string;
 };
 
+type DailyAvailability = {
+  date: Date;
+  sessions: AvailabilitySession[];
+};
+
 // TODO: Decide where this info should live and move it there
 const clinicalServices: ClinicalService[] = [
   { label: 'RSV (Adult)', value: 'RSV:Adult' },
@@ -233,6 +238,7 @@ export type {
   AvailabilitySession,
   AvailabilityTemplate,
   Booking,
+  DailyAvailability,
   DateComponents,
   ErrorType,
   FetchAvailabilityRequest,

--- a/src/client/src/app/site/[site]/view-availability/view-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/view-availability-page.tsx
@@ -46,7 +46,7 @@ export const ViewAvailabilityPage = ({ weeks, searchMonth }: Props) => {
           <br />
           <Link
             className="nhsuk-link"
-            href={`view-availability/week?from=${week.startDate.format('YYYY-MM-DD')}&until=${week.endDate.format('YYYY-MM-DD')}`}
+            href={`view-availability/week?date=${week.startDate.format('YYYY-MM-DD')}`}
           >
             View week
           </Link>

--- a/src/client/src/app/site/[site]/view-availability/week/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/page.tsx
@@ -4,15 +4,8 @@ import {
   fetchDailyAvailability,
   fetchSite,
 } from '@services/appointmentsService';
-import dayjs from 'dayjs';
-import isoWeek from 'dayjs/plugin/isoWeek';
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import { ViewWeekAvailabilityPage } from './view-week-availability-page';
-
-dayjs.extend(isoWeek);
-dayjs.extend(isSameOrAfter);
-dayjs.extend(isSameOrBefore);
+import { endOfWeek, startOfWeek } from '@services/timeService';
 
 // TODO: Include site in props
 type PageProps = {
@@ -28,8 +21,8 @@ const Page = async ({ searchParams, params }: PageProps) => {
   const site = await fetchSite(params.site);
   await assertPermission(site.id, 'availability:query');
 
-  const weekStart = dayjs(searchParams.date).startOf('isoWeek');
-  const weekEnd = dayjs(searchParams.date).endOf('isoWeek');
+  const weekStart = startOfWeek(searchParams.date);
+  const weekEnd = endOfWeek(searchParams.date);
 
   const availability = await fetchDailyAvailability(
     params.site,

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.test.tsx
@@ -3,7 +3,7 @@ import { ViewWeekAvailabilityPage } from './view-week-availability-page';
 import { mockDailyAvailability } from '@testing/data';
 
 describe('View Week Availability Page', () => {
-  it('renders', async () => {
+  it('renders', () => {
     render(<ViewWeekAvailabilityPage availability={mockDailyAvailability} />);
 
     expect(

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { ViewWeekAvailabilityPage } from './view-week-availability-page';
+import { mockDailyAvailability } from '@testing/data';
+
+describe('View Week Availability Page', () => {
+  it('renders', async () => {
+    render(<ViewWeekAvailabilityPage availability={mockDailyAvailability} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Monday 2 December' }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('table')).toHaveLength(6);
+  });
+
+  // TODO: Add tests for correct information (booked, unbooked etc.)
+});

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
@@ -1,0 +1,38 @@
+import { Card, Table } from '@components/nhsuk-frontend';
+import { DailyAvailability } from '@types';
+import dayjs from 'dayjs';
+
+type Props = {
+  availability: DailyAvailability[];
+};
+
+export const ViewWeekAvailabilityPage = ({ availability }: Props) => {
+  return (
+    <>
+      {availability.map((day, i) => (
+        <Card title={dayjs(day.date).format('dddd D MMMM')} key={i}>
+          <Table
+            headers={['Time', 'Services', 'Booked', 'Unbooked', 'Action']}
+            rows={day.sessions.map(session => {
+              return [
+                `${session.from} - ${session.until}`,
+                `${session.services.join(',')}`,
+                '0 booked',
+                '0 unbooked',
+                'Change', // TODO: This should be a link
+              ];
+            })}
+          ></Table>
+          <br />
+          {/* TODO: Add link for add session */}
+          <Table
+            headers={['Total appointments: 0', 'Booked: 0', 'Unbooked: 0']}
+            rows={[]}
+          ></Table>
+          <br />
+          {/* TODO: Add link to view daily appointments */}
+        </Card>
+      ))}
+    </>
+  );
+};

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
@@ -12,14 +12,13 @@ export const ViewWeekAvailabilityPage = ({ availability }: Props) => {
       {availability.map((day, i) => (
         <Card title={dayjs(day.date).format('dddd D MMMM')} key={i}>
           <Table
-            headers={['Time', 'Services', 'Booked', 'Unbooked', 'Action']}
+            headers={['Time', 'Services', 'Booked', 'Unbooked']}
             rows={day.sessions.map(session => {
               return [
                 `${session.from} - ${session.until}`,
                 `${session.services.join(',')}`,
                 '0 booked',
                 '0 unbooked',
-                'Change', // TODO: This should be a link
               ];
             })}
           ></Table>

--- a/src/client/src/app/testing/data.ts
+++ b/src/client/src/app/testing/data.ts
@@ -6,6 +6,7 @@ import {
   AvailabilitySession,
   AvailabilityTemplate,
   Booking,
+  DailyAvailability,
   Role,
   Site,
   SiteWithAttributes,
@@ -356,6 +357,66 @@ const mockDetailedWeeks: Week[] = [
   },
 ];
 
+const mockDailyAvailability: DailyAvailability[] = [
+  {
+    date: '2024/12/02',
+    sessions: [
+      {
+        from: '09:00',
+        until: '12:00',
+        services: ['RSV (Adult)'],
+        capacity: 2,
+        slotLength: 5,
+      },
+      {
+        from: '13:00',
+        until: '17:00',
+        services: ['RSV (Adult)'],
+        capacity: 2,
+        slotLength: 5,
+      },
+    ],
+  },
+  {
+    date: '2024/12/03',
+    sessions: [
+      {
+        from: '09:00',
+        until: '12:00',
+        services: ['RSV (Adult)'],
+        capacity: 2,
+        slotLength: 5,
+      },
+      {
+        from: '13:00',
+        until: '17:00',
+        services: ['RSV (Adult)'],
+        capacity: 2,
+        slotLength: 5,
+      },
+    ],
+  },
+  {
+    date: '2024/12/04',
+    sessions: [
+      {
+        from: '09:00',
+        until: '12:00',
+        services: ['RSV (Adult)'],
+        capacity: 2,
+        slotLength: 5,
+      },
+      {
+        from: '13:00',
+        until: '17:00',
+        services: ['RSV (Adult)'],
+        capacity: 2,
+        slotLength: 5,
+      },
+    ],
+  },
+];
+
 export {
   getMockUserAssignments,
   mockAvailabilityCreatedEvents,
@@ -372,4 +433,5 @@ export {
   mockAvailability,
   mockBookings,
   mockDetailedWeeks,
+  mockDailyAvailability,
 };

--- a/tests/Nhs.Appointments.Api.Integration/Nhs.Appointments.Api.Integration.csproj
+++ b/tests/Nhs.Appointments.Api.Integration/Nhs.Appointments.Api.Integration.csproj
@@ -41,4 +41,8 @@
 	  <None Remove="Nhs.Appointments.Api.Integration\**" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <None Remove="Scenarios\Availability\DailyAvailability.feature" />
+	</ItemGroup>
+
 </Project>

--- a/tests/Nhs.Appointments.Api.Integration/Nhs.Appointments.Api.Integration.csproj
+++ b/tests/Nhs.Appointments.Api.Integration/Nhs.Appointments.Api.Integration.csproj
@@ -41,8 +41,4 @@
 	  <None Remove="Nhs.Appointments.Api.Integration\**" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <None Remove="Scenarios\Availability\DailyAvailability.feature" />
-	</ItemGroup>
-
 </Project>

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/DailyAvailability.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/DailyAvailability.feature
@@ -1,0 +1,13 @@
+﻿Feature: Get daily availability
+
+    Scenario: Dates and sessions are returned within date range
+        Given the following sessions
+          | Date              | From  | Until | Services | Slot Length | Capacity |
+          | Tomorrow          | 09:00 | 17:00 | COVID    | 5           | 1        |
+          | 2 days from today | 09:00 | 17:00 | COVID    | 5           | 1        |
+          | 5 days from today | 09:00 | 17:00 | COVID    | 5           | 1        |
+        When I check daily availability for the current site between 'Tomorrow' and '3 days from now'
+        Then the following daily availability is returned
+          | Date              | From  | Until | Services | Slot Length | Capacity |
+          | Tomorrow          | 09:00 | 17:00 | COVID    | 5           | 1        |
+          | 2 days from today | 09:00 | 17:00 | COVID    | 5           | 1        |

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/DailyAvailabilityFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/DailyAvailabilityFeatureSteps.cs
@@ -24,8 +24,8 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Availability
         {
             var siteId = GetSiteId();
             var fromDate = ParseNaturalLanguageDateOnly(from).ToString("yyyy-MM-dd");
-            var toDate = ParseNaturalLanguageDateOnly(until).ToString("yyyy-MM-dd");
-            var requestUrl = $"http://localhost:7071/api/daily-availability?site={siteId}&from={fromDate}&to={toDate}";
+            var untilDate = ParseNaturalLanguageDateOnly(until).ToString("yyyy-MM-dd");
+            var requestUrl = $"http://localhost:7071/api/daily-availability?site={siteId}&from={fromDate}&until={untilDate}";
 
             _response = await Http.GetAsync(requestUrl);
             _statusCode = _response.StatusCode;

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/DailyAvailabilityFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/DailyAvailabilityFeatureSteps.cs
@@ -1,0 +1,61 @@
+﻿using FluentAssertions;
+using Gherkin.Ast;
+using Nhs.Appointments.Api.Json;
+using Nhs.Appointments.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit.Gherkin.Quick;
+
+namespace Nhs.Appointments.Api.Integration.Scenarios.Availability
+{
+    [FeatureFile("./Scenarios/Availability/DailyAvailability.feature")]
+    public class DailyAvailabilityFeatureSteps : BaseFeatureSteps
+    {
+        private HttpResponseMessage _response;
+        private HttpStatusCode _statusCode;
+        private List<DailyAvailability> _actualResponse;
+
+        [When(@"I check daily availability for the current site between '(.+)' and '(.+)'")]
+        public async Task CheckDailyAvailability(string from, string until)
+        {
+            var siteId = GetSiteId();
+            var fromDate = ParseNaturalLanguageDateOnly(from).ToString("yyyy-MM-dd");
+            var toDate = ParseNaturalLanguageDateOnly(until).ToString("yyyy-MM-dd");
+            var requestUrl = $"http://localhost:7071/api/daily-availability?site={siteId}&from={fromDate}&to={toDate}";
+
+            _response = await Http.GetAsync(requestUrl);
+            _statusCode = _response.StatusCode;
+
+            (_, var result) = await JsonRequestReader.ReadRequestAsync<IEnumerable<DailyAvailability>>(await _response.Content.ReadAsStreamAsync());
+            _actualResponse = result.ToList();
+        }
+
+        [Then("the following daily availability is returned")]
+        public async Task AssertDailyAvailability(DataTable expectedDailyAvailabilityTable)
+        {
+            var expectedDailyAvailability = expectedDailyAvailabilityTable.Rows.Skip(1).Select(row =>
+                new DailyAvailability
+                {
+                    Date = ParseNaturalLanguageDateOnly(row.Cells.ElementAt(0).Value),
+                    Sessions =
+                    [
+                        new() {
+                            From = TimeOnly.Parse(row.Cells.ElementAt(1).Value),
+                            Until = TimeOnly.Parse(row.Cells.ElementAt(2).Value),
+                            Services = [row.Cells.ElementAt(3).Value],
+                            SlotLength = int.Parse(row.Cells.ElementAt(4).Value),
+                            Capacity = int.Parse(row.Cells.ElementAt(5).Value)
+                        }
+                    ]
+                });
+
+            _statusCode.Should().Be(HttpStatusCode.OK);
+            _actualResponse.Count.Should().Be(2);
+            _actualResponse.Should().BeEquivalentTo(expectedDailyAvailability);
+        }
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetDailyAvailabilityFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetDailyAvailabilityFunctionTests.cs
@@ -1,0 +1,118 @@
+﻿using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Nhs.Appointments.Api.Auth;
+using Nhs.Appointments.Api.Functions;
+using Nhs.Appointments.Api.Json;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Core;
+
+namespace Nhs.Appointments.Api.Tests.Functions
+{
+    public class GetDailyAvailabilityFunctionTests
+    {
+        private readonly Mock<IAvailabilityService> _mockAvailabilityService = new();
+        private readonly Mock<IValidator<GetDailyAvailabilityRequest>> _mockValidator = new();
+        private readonly Mock<IUserContextProvider> _mockUserContextProvider = new();
+        private readonly Mock<ILogger<GetDailyAvailabilityFunction>> _mockLogger = new();
+        private readonly Mock<IMetricsRecorder> _mockMetricsRecorder = new();
+
+        private readonly GetDailyAvailabilityFunction _sut;
+
+        public GetDailyAvailabilityFunctionTests()
+        {
+            _sut = new GetDailyAvailabilityFunction(
+                _mockAvailabilityService.Object,
+                _mockValidator.Object,
+                _mockUserContextProvider.Object,
+                _mockLogger.Object,
+                _mockMetricsRecorder.Object);
+
+            _mockValidator.Setup(x => x.ValidateAsync(It.IsAny<GetDailyAvailabilityRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ValidationResult());
+        }
+
+        [Fact]
+        public async Task RunAsync_ReturnsDailyAvailability()
+        {
+            var fromDate = DateOnly.FromDateTime(new DateTime(2024, 12, 1));
+            var toDate = DateOnly.FromDateTime(new DateTime(2024, 12, 8));
+
+            var availability = new List<DailyAvailability>
+            {
+                new()
+                {
+                    Date = DateOnly.FromDateTime(new DateTime(2024, 12, 1)),
+                    Sessions =
+                    [
+                        new()
+                        {
+                            From = new TimeOnly(11, 00),
+                            Until = new TimeOnly(16, 00),
+                            Capacity = 2,
+                            SlotLength = 5,
+                            Services = ["RSV:Adult"]
+                        }
+                    ]
+                },
+                new()
+                {
+                    Date = DateOnly.FromDateTime(new DateTime(2024, 12, 4)),
+                    Sessions =
+                    [
+                        new()
+                        {
+                            From = new TimeOnly(11, 00),
+                            Until = new TimeOnly(16, 00),
+                            Capacity = 2,
+                            SlotLength = 5,
+                            Services = ["RSV:Adult"]
+                        }
+                    ]
+                }
+            };
+
+            _mockAvailabilityService.Setup(x => x.GetDailyAvailability(It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+                .ReturnsAsync(availability);
+
+            var request = CreateRequest();
+
+            var result = await _sut.RunAsync(request) as ContentResult;
+
+            result.StatusCode.Should().Be(200);
+
+            var response = await ReadResponseAsync<IEnumerable<DailyAvailability>>(result.Content);
+
+            response.Should().NotBeNull();
+            response.Any().Should().BeTrue();
+            response.Count().Should().Be(2);
+        }
+
+        private static HttpRequest CreateRequest()
+        {
+            var context = new DefaultHttpContext();
+            var request = context.Request;
+            request.QueryString = new QueryString("?site=TEST01&from=2024-12-01&to=2024-12-08");
+            request.Headers.Add("Authorization", "Test 123");
+            return request;
+        }
+
+        private static async Task<TRequest> ReadResponseAsync<TRequest>(string response)
+        {
+            var deserializerSettings = new JsonSerializerSettings
+            {
+                Converters =
+                {
+                    new ShortTimeOnlyJsonConverter()
+                },
+            };
+            var body = await new StringReader(response).ReadToEndAsync();
+            return JsonConvert.DeserializeObject<TRequest>(body, deserializerSettings);
+        }
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetDailyAvailabilityFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetDailyAvailabilityFunctionTests.cs
@@ -97,7 +97,7 @@ namespace Nhs.Appointments.Api.Tests.Functions
         {
             var context = new DefaultHttpContext();
             var request = context.Request;
-            request.QueryString = new QueryString("?site=TEST01&from=2024-12-01&to=2024-12-08");
+            request.QueryString = new QueryString("?site=TEST01&from=2024-12-01&until=2024-12-08");
             request.Headers.Add("Authorization", "Test 123");
             return request;
         }

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetDailyAvailabilityRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetDailyAvailabilityRequestValidatorTests.cs
@@ -48,7 +48,7 @@ namespace Nhs.Appointments.Api.Tests.Validators
             result.IsValid.Should().BeFalse();
             result.Errors.Count.Should().Be(2);
             result.Errors.First().PropertyName.Should().Be(nameof(GetDailyAvailabilityRequest.From));
-            result.Errors.Last().PropertyName.Should().Be(nameof(GetDailyAvailabilityRequest.To));
+            result.Errors.Last().PropertyName.Should().Be(nameof(GetDailyAvailabilityRequest.Until));
         }
 
         [Fact]

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetDailyAvailabilityRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetDailyAvailabilityRequestValidatorTests.cs
@@ -1,0 +1,74 @@
+﻿using FluentAssertions;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Api.Validators;
+
+namespace Nhs.Appointments.Api.Tests.Validators
+{
+    public class GetDailyAvailabilityRequestValidatorTests
+    {
+        private readonly GetDailyAvailabilityRequestValidator _sut = new();
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public void FailsValidation_WhenSiteIsEmpty(string site)
+        {
+            var request = new GetDailyAvailabilityRequest(site, "2024-12-01", "2024-12-10");
+            var result = _sut.Validate(request);
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Count.Should().Be(1);
+            result.Errors.Single().PropertyName.Should().Be(nameof(GetDailyAvailabilityRequest.Site));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public void FailsValidation_WhenFromDateNotProvided(string from)
+        {
+            var request = new GetDailyAvailabilityRequest("TEST01", from, "2024-12-10");
+            var result = _sut.Validate(request);
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Count.Should().Be(1);
+            result.Errors.Single().PropertyName.Should().Be(nameof(GetDailyAvailabilityRequest.From));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public void FailsValidation_WhenToDateNotProvided(string to)
+        {
+            var request = new GetDailyAvailabilityRequest("TEST01", "2024-12-10", to);
+            var result = _sut.Validate(request);
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Count.Should().Be(2);
+            result.Errors.First().PropertyName.Should().Be(nameof(GetDailyAvailabilityRequest.From));
+            result.Errors.Last().PropertyName.Should().Be(nameof(GetDailyAvailabilityRequest.To));
+        }
+
+        [Fact]
+        public void FailsValidation_WhenFromDateIsAfterToDate()
+        {
+            var request = new GetDailyAvailabilityRequest("TEST01", "2024-12-10", "2024-12-01");
+            var result = _sut.Validate(request);
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Count.Should().Be(1);
+            result.Errors.Single().PropertyName.Should().Be(nameof(GetDailyAvailabilityRequest.From));
+        }
+
+        [Fact]
+        public void PassesValidation()
+        {
+            var request = new GetDailyAvailabilityRequest("TEST01", "2024-12-01", "2024-12-10");
+            var result = _sut.Validate(request);
+
+            result.IsValid.Should().BeTrue();
+        }
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
@@ -318,4 +318,71 @@ public class AvailabilityServiceTests
         result[1].From.Should().Be(DateOnly.FromDateTime(new DateTime(2025, 4, 3)));
         result[1].To.Should().BeNull();
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task GetDailyAvailability_ThrowsArgumentException_WhenSiteIsNullOrEmpty(string site)
+    {
+        var result = async () => { await _sut.GetDailyAvailability(site, DateOnly.FromDateTime(new DateTime(2024, 12, 3)), DateOnly.FromDateTime(new DateTime(2024, 12, 8))); };
+        await result.Should().ThrowAsync<ArgumentException>().WithMessage("Site must have a value.");
+    }
+
+    [Fact]
+    public async Task GetDailyAvailability_ThrowsArgumentException_WhenFromDateIsBeforeToDate()
+    {
+        var fromDate = DateOnly.FromDateTime(new DateTime(2024, 12, 8));
+        var toDate = DateOnly.FromDateTime(new DateTime(2024, 12, 1));
+        var result = async () => { await _sut.GetDailyAvailability("TEST01", fromDate, toDate); };
+        await result.Should().ThrowAsync<ArgumentException>().WithMessage("From date must be before to date.");
+    }
+
+    [Fact]
+    public async Task GetDailyAvailabiltiy_ReturnsAvailabilityWithinDateRange()
+    {
+        var fromDate = DateOnly.FromDateTime(new DateTime(2024, 12, 1));
+        var toDate = DateOnly.FromDateTime(new DateTime(2024, 12, 8));
+
+        var availability = new List<DailyAvailability>
+        {
+            new()
+            {
+                Date = DateOnly.FromDateTime(new DateTime(2024, 12, 1)),
+                Sessions =
+                [
+                    new()
+                    {
+                        From = TimeOnly.FromTimeSpan(TimeSpan.FromHours(11)),
+                        Until = TimeOnly.FromTimeSpan(TimeSpan.FromHours(16)),
+                        Capacity = 2,
+                        SlotLength = 5,
+                        Services = ["RSV:Adult"]
+                    }
+                ]
+            },
+            new()
+            {
+                Date = DateOnly.FromDateTime(new DateTime(2024, 12, 4)),
+                Sessions =
+                [
+                    new()
+                    {
+                        From = TimeOnly.FromTimeSpan(TimeSpan.FromHours(11)),
+                        Until = TimeOnly.FromTimeSpan(TimeSpan.FromHours(16)),
+                        Capacity = 2,
+                        SlotLength = 5,
+                        Services = ["RSV:Adult"]
+                    }
+                ]
+            }
+        };
+
+        _availabilityStore.Setup(x => x.GetDailyAvailability(It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(availability);
+
+        var result = await _sut.GetDailyAvailability("TEST01", fromDate, toDate);
+
+        result.Any().Should().BeTrue();
+        result.Count().Should().Be(2);
+    }
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
@@ -319,24 +319,6 @@ public class AvailabilityServiceTests
         result[1].To.Should().BeNull();
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    public async Task GetDailyAvailability_ThrowsArgumentException_WhenSiteIsNullOrEmpty(string site)
-    {
-        var result = async () => { await _sut.GetDailyAvailability(site, DateOnly.FromDateTime(new DateTime(2024, 12, 3)), DateOnly.FromDateTime(new DateTime(2024, 12, 8))); };
-        await result.Should().ThrowAsync<ArgumentException>().WithMessage("Site must have a value.");
-    }
-
-    [Fact]
-    public async Task GetDailyAvailability_ThrowsArgumentException_WhenFromDateIsBeforeToDate()
-    {
-        var fromDate = DateOnly.FromDateTime(new DateTime(2024, 12, 8));
-        var toDate = DateOnly.FromDateTime(new DateTime(2024, 12, 1));
-        var result = async () => { await _sut.GetDailyAvailability("TEST01", fromDate, toDate); };
-        await result.Should().ThrowAsync<ArgumentException>().WithMessage("From date must be before to date.");
-    }
-
     [Fact]
     public async Task GetDailyAvailabiltiy_ReturnsAvailabilityWithinDateRange()
     {


### PR DESCRIPTION
This is PART 1 of multiple pull requests for APPT-338. This part includes

- New GET daily-availability endpoint which returns the daily availability document in a list for each day between the date range requested
- Unit tests and integration tests for the new endpoint
- Front end changes that are hooked up to this endpoint (no booking / unbooked calculations so far, merely hooking this up on the front end)
- Front end unit tests
- Front end TODOs