### PR TITLE
prevent sending reminders for recently booked appointments

### DIFF
--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -125,8 +125,11 @@ public class BookingsService(
 
     public async Task SendBookingReminders()
     {
-        var bookings = await GetBookings(time.GetLocalNow().DateTime, time.GetLocalNow().AddDays(3).DateTime);
-        foreach (var booking in bookings.Where(b => !b.ReminderSent))
+        var windowStart = time.GetLocalNow().DateTime;
+        var windowEnd = windowStart.AddDays(3);
+
+        var bookings = await GetBookings(windowStart, windowEnd);
+        foreach (var booking in bookings.Where(b => !b.ReminderSent && b.Created < windowStart.AddDays(-1)))
         {
             var reminders = eventFactory.BuildBookingEvents<BookingReminder>(booking);
             await bus.Send(reminders);

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -222,6 +222,13 @@ public abstract partial class BaseFeatureSteps : Feature
         return SetupBookings(siteDesignation, dataTable, BookingType.Confirmed);
     }
 
+    [Given("the following recent bookings have been made")]
+    [And("the following recent bookings have been made")]
+    public Task SetupRecentBookings(Gherkin.Ast.DataTable dataTable)
+    {
+        return SetupBookings("A", dataTable, BookingType.Recent);
+    }
+
     [Given("the following provisional bookings have been made")]
     [And("the following provisional bookings have been made")]
     public Task SetupProvisionalBookings(Gherkin.Ast.DataTable dataTable)
@@ -248,7 +255,7 @@ public abstract partial class BaseFeatureSteps : Feature
             Service = row.Cells.ElementAt(3).Value,
             Site = GetSiteId(siteDesignation),
             Status = MapStatus(bookingType),
-            Created = bookingType == BookingType.ExpiredProvisional ? DateTime.UtcNow.AddMinutes(-10) : DateTime.UtcNow,
+            Created = GetCreationDateTime(bookingType),
             AttendeeDetails = new Core.AttendeeDetails
             {
                 NhsNumber = NhsNumber,
@@ -277,7 +284,7 @@ public abstract partial class BaseFeatureSteps : Feature
                 Id = BookingReferences.GetBookingReference(index, bookingType),
                 NhsNumber = NhsNumber,
                 Status = MapStatus(bookingType),
-                Created = bookingType == BookingType.ExpiredProvisional ? DateTime.UtcNow.AddMinutes(-10) : DateTime.UtcNow,
+                Created = GetCreationDateTime(bookingType),
                 From = DateTime.ParseExact($"{ParseNaturalLanguageDateOnly(row.Cells.ElementAt(0).Value).ToString("yyyy-MM-dd")} {row.Cells.ElementAt(1).Value}", "yyyy-MM-dd HH:mm", null),
             });
 
@@ -293,6 +300,15 @@ public abstract partial class BaseFeatureSteps : Feature
 
         MadeBookings.AddRange(bookings);
     }
+
+    protected static DateTime GetCreationDateTime(BookingType type) => type switch
+    {
+        BookingType.Recent => DateTime.UtcNow.AddHours(-18),
+        BookingType.Confirmed => DateTime.UtcNow.AddHours(-48),
+        BookingType.Provisional => DateTime.UtcNow.AddMinutes(-2),
+        BookingType.ExpiredProvisional => DateTime.UtcNow.AddMinutes(-8),
+        _ => throw new ArgumentOutOfRangeException(nameof(type))
+    };
 
     protected static DayOfWeek[] ParseDays(string pattern)
     {
@@ -313,6 +329,7 @@ public abstract partial class BaseFeatureSteps : Feature
 
     protected AppointmentStatus MapStatus(BookingType bookingType) => bookingType switch
     {
+        BookingType.Recent => AppointmentStatus.Booked,
         BookingType.Confirmed => AppointmentStatus.Booked,
         BookingType.Provisional => AppointmentStatus.Provisional,
         BookingType.ExpiredProvisional => AppointmentStatus.Provisional,
@@ -446,7 +463,7 @@ public abstract partial class BaseFeatureSteps : Feature
         return results;
     }
 
-    public enum BookingType { Confirmed, Provisional, ExpiredProvisional}
+    public enum BookingType { Recent, Confirmed, Provisional, ExpiredProvisional}
 
     [GeneratedRegex("^(?<format>Today|today|Tomorrow|tomorrow|Yesterday|yesterday|(((?<magnitude>[0-9]+) (?<period>days|day|weeks|week|months|month|years|year) (?<direction>from|before) (now|today))))$")]
     private static partial Regex NaturalLanguageRelativeDate();
@@ -458,7 +475,7 @@ public class BookingReferenceManager
 
     public string GetBookingReference(int index, BaseFeatureSteps.BookingType bookingType)
     {
-        if (bookingType != BaseFeatureSteps.BookingType.Confirmed)
+        if (bookingType != BaseFeatureSteps.BookingType.Confirmed && bookingType != BaseFeatureSteps.BookingType.Recent)
             index += 50;
         
         if(_bookingReferences.ContainsKey(index) == false)

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.cs
@@ -9,7 +9,6 @@ using FluentAssertions;
 using Nhs.Appointments.Api.Json;
 using Nhs.Appointments.Core;
 
-
 namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
 {
     [FeatureFile("./Scenarios/Booking/QueryBookingByNhsNumber.feature")]
@@ -39,7 +38,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
                     Duration = int.Parse(row.Cells.ElementAt(2).Value),
                     Service = row.Cells.ElementAt(3).Value,
                     Site = GetSiteId(),
-                    Created = DateTime.UtcNow,
+                    Created = GetCreationDateTime(BookingType.Confirmed),
                     Status = AppointmentStatus.Booked,
                     AttendeeDetails = new AttendeeDetails
                     {

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunReminders.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunReminders.feature
@@ -1,6 +1,6 @@
 ﻿Feature: RunReminders
 
-     Scenario: Running reminders sends reminders for upcoming appointments	
+    Scenario: Running reminders sends reminders for upcoming appointments	
         Given the site is configured for MYA
         And the following bookings have been made
             | Date              | Time  | Duration | Service |
@@ -10,6 +10,14 @@
             | Recipient | Notification         |
             | email     | COVID Email Reminder |
             | phone     | COVID SMS Reminder   |
+
+     Scenario: Running reminders does not send reminders for recently made appointments	
+        Given the site is configured for MYA
+        And the following recent bookings have been made
+            | Date              | Time  | Duration | Service |
+            | 2 days from today | 09:20 | 5        | COVID   |
+        When the reminders job runs
+        Then no notifications are sent out            
 
      Scenario: Running reminders targets correct document types
         Given the site is configured for MYA


### PR DESCRIPTION
Will not send a reminder if a booking was made less than 24 hours ago (includes rescheduled bookings)