### PR TITLE
Appt 338/fix booked count

### DIFF
--- a/src/client/src/app/lib/services/timeService.test.ts
+++ b/src/client/src/app/lib/services/timeService.test.ts
@@ -6,7 +6,6 @@ import {
   toTwoDigitFormat,
 } from '@services/timeService';
 import { TimeComponents } from '@types';
-import dayjs from 'dayjs';
 
 describe('Time Service', () => {
   it.each([

--- a/src/client/src/app/lib/services/viewAvailabilityService.test.ts
+++ b/src/client/src/app/lib/services/viewAvailabilityService.test.ts
@@ -79,9 +79,14 @@ describe('View Availability Service', () => {
     expect(detailedWeekView.length).toBe(7);
 
     const firstDay = detailedWeekView[0];
-    expect(firstDay.unbooked).toBe(167);
+    expect(firstDay.unbooked).toBe(191);
     expect(firstDay.booked).toBe(1);
-    expect(firstDay.totalAppointments).toBe(168);
-    expect(firstDay.serviceInformation?.length).toBe(1);
+    expect(firstDay.totalAppointments).toBe(192);
+    expect(firstDay.serviceInformation?.length).toBe(2);
+
+    if (firstDay.serviceInformation) {
+      expect(firstDay.serviceInformation[0].serviceDetails[0].booked).toBe(1);
+      expect(firstDay.serviceInformation[1].serviceDetails[0].booked).toBe(0);
+    }
   });
 });

--- a/src/client/src/app/testing/data.ts
+++ b/src/client/src/app/testing/data.ts
@@ -328,7 +328,7 @@ const mockBookings: Booking[] = [
   },
   {
     reference: '8642',
-    from: '2024-12-02T14:05:00',
+    from: '2024-12-02T10:35:00',
     duration: 5,
     service: 'RSV:Adult',
     site: 'TEST01',
@@ -491,10 +491,17 @@ const mockWeekAvailability: DailyAvailability[] = [
     sessions: [
       {
         capacity: 2,
-        from: '09:00',
+        from: '10:00',
         until: '16:00',
         slotLength: 5,
-        services: ['RSV (Adult)'],
+        services: ['RSV:Adult'],
+      },
+      {
+        capacity: 1,
+        from: '12:00',
+        until: '16:00',
+        slotLength: 5,
+        services: ['RSV:Adult'],
       },
     ],
   },
@@ -506,7 +513,7 @@ const mockWeekAvailability: DailyAvailability[] = [
         from: '09:00',
         until: '14:00',
         slotLength: 5,
-        services: ['RSV (Adult)'],
+        services: ['RSV:Adult'],
       },
     ],
   },


### PR DESCRIPTION
Added fix for booking count where a booking would appear in the count when we have overlapping sessions. Agreed approach for now was to add the count to the earliest session and go from there. This PR also includes some ordering to sort the sessions in time ascending order.