### PR TITLE
Skip flaky integration tests to stabilise build

### DIFF
--- a/src/client/testing/eula.spec.ts
+++ b/src/client/testing/eula.spec.ts
@@ -19,30 +19,31 @@ test.beforeEach(async ({ page }) => {
   eulaConsentPage = new EulaConsentPage(page);
 });
 
-test('A user with an out of date EULA consent version is prompted with the EULA consent page', async ({
-  page,
-}) => {
-  await rootPage.goto();
-  await rootPage.pageContentLogInButton.click();
+test.fixme(
+  'A user with an out of date EULA consent version is prompted with the EULA consent page',
+  async ({ page }) => {
+    await rootPage.goto();
+    await rootPage.pageContentLogInButton.click();
 
-  await oAuthPage.page
-    .getByLabel('Username')
-    .fill(TEST_USERS.testUser5.username);
-  await oAuthPage.page
-    .getByLabel('Password')
-    .fill(TEST_USERS.testUser5.password);
-  await oAuthPage.page.getByLabel('Password').press('Enter');
+    await oAuthPage.page
+      .getByLabel('Username')
+      .fill(TEST_USERS.testUser5.username);
+    await oAuthPage.page
+      .getByLabel('Password')
+      .fill(TEST_USERS.testUser5.password);
+    await oAuthPage.page.getByLabel('Password').press('Enter');
 
-  await page.waitForURL('**/eula');
-  await expect(eulaConsentPage.title).toBeVisible();
+    await page.waitForURL('**/eula');
+    await expect(eulaConsentPage.title).toBeVisible();
 
-  // Try to bypass EULA consent
-  await page.goto('/');
+    // Try to bypass EULA consent
+    await page.goto('/');
 
-  await page.waitForURL('**/eula');
-  await expect(eulaConsentPage.title).toBeVisible();
-  await expect(siteSelectionPage.title).not.toBeVisible();
-});
+    await page.waitForURL('**/eula');
+    await expect(eulaConsentPage.title).toBeVisible();
+    await expect(siteSelectionPage.title).not.toBeVisible();
+  },
+);
 
 test('A user with an out of date EULA version is prompted with the EULA consent page on login, but not again after they have consented', async ({
   page,

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Eula/ConsentToEula.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Eula/ConsentToEula.feature
@@ -1,5 +1,6 @@
 ﻿Feature: Eula
 
+  @ignore
   Scenario: Consent to the latest EULA
     Given the latest EULA is as follows
       | VersionDate |

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunReminders.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunReminders.feature
@@ -1,5 +1,6 @@
 ﻿Feature: RunReminders
 
+    @ignore
     Scenario: Running reminders sends reminders for upcoming appointments	
         Given the site is configured for MYA
         And the following bookings have been made


### PR DESCRIPTION
Tests are skipped temporarily until investigated and fixed