### PR TITLE
Appt-XXX: Introduce client basePath

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - AuthProvider_ChallengePhrase=ThisIsntRandomButItNeedsToBe43CharactersLong
       - AuthProvider_ClientId=nhs-appts-local
       - AuthProvider_ReturnUri=http://localhost:7071/api/auth-return
-      - AuthProvider_ClientCodeExchangeUri=http://localhost:3000/auth/set-cookie
+      - AuthProvider_ClientCodeExchangeUri=http://localhost:3000/manage-your-appointments/auth/set-cookie
       - Notifications_Provider=local
       - BookingRemindersCronSchedule=0 0 8 * * *
       - UnconfirmedProvisionalBookingsCronSchedule=*/5 * * * *

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       NBS_API_BASE_URL: http://api:80
       AUTH_HOST: http://localhost:7071
+      CLIENT_BASE_PATH: /manage-your-appointments
 
     volumes:
       - ./src/client/src:/app/src
@@ -50,7 +51,6 @@ services:
       - SPLUNK_HOST_URL=http://splunk:8088/services/collector/raw
       - SPLUNK_HEC_TOKEN=e2c421cf-9228-4ab2-a6e8-877741df569a
 
-  
   splunk:
     image: splunk/splunk:latest
     container_name: splunk

--- a/infrastructure/resources/api.tf
+++ b/infrastructure/resources/api.tf
@@ -44,7 +44,7 @@ resource "azurerm_windows_function_app" "nbs_mya_func_app" {
     AuthProvider_ChallengePhrase               = var.auth_provider_challenge_phrase
     AuthProvider_ClientId                      = var.auth_provider_client_id
     AuthProvider_ClientSecret                  = var.auth_provider_client_secret
-    AuthProvider_ClientCodeExchangeUri         = "${var.web_app_base_uri}/auth/set-cookie"
+    AuthProvider_ClientCodeExchangeUri         = "${var.web_app_base_uri}/manage-your-appointments/auth/set-cookie"
     AuthProvider_ReturnUri                     = "${var.func_app_base_uri}/api/auth-return"
     Notifications_Provider                     = "azure"
     GovNotifyBaseUri                           = var.gov_notify_base_uri
@@ -96,7 +96,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_func_app_preview" {
     AuthProvider_ChallengePhrase               = var.auth_provider_challenge_phrase
     AuthProvider_ClientId                      = var.auth_provider_client_id
     AuthProvider_ClientSecret                  = var.auth_provider_client_secret
-    AuthProvider_ClientCodeExchangeUri         = "${var.web_app_slot_base_uri}/auth/set-cookie"
+    AuthProvider_ClientCodeExchangeUri         = "${var.web_app_slot_base_uri}/manage-your-appointments/auth/set-cookie"
     AuthProvider_ReturnUri                     = "${var.func_app_slot_base_uri}/api/auth-return"
     Notifications_Provider                     = "azure"
     GovNotifyBaseUri                           = var.gov_notify_base_uri

--- a/infrastructure/resources/web.tf
+++ b/infrastructure/resources/web.tf
@@ -26,6 +26,7 @@ resource "azurerm_linux_web_app" "nbs_mya_web_app_service" {
   app_settings = {
     NBS_API_BASE_URL = "https://${azurerm_windows_function_app.nbs_mya_func_app.default_hostname}"
     AUTH_HOST        = "https://${azurerm_windows_function_app.nbs_mya_func_app.default_hostname}"
+    CLIENT_BASE_PATH = "/manage-your-appointments"
   }
 
   sticky_settings {
@@ -52,6 +53,7 @@ resource "azurerm_linux_web_app_slot" "nbs_mya_web_app_preview" {
   app_settings = {
     NBS_API_BASE_URL = "https://${azurerm_windows_function_app_slot.nbs_mya_func_app_preview[0].default_hostname}"
     AUTH_HOST        = "https://${azurerm_windows_function_app_slot.nbs_mya_func_app_preview[0].default_hostname}"
+    CLIENT_BASE_PATH = "/manage-your-appointments"
   }
 
   identity {

--- a/src/api/Nhs.Appointments.Api/local.settings.json
+++ b/src/api/Nhs.Appointments.Api/local.settings.json
@@ -20,7 +20,7 @@
     "AuthProvider_JwksUri": "http://localhost:8020/.well-known/openid-configuration/jwks",
     "AuthProvider_ChallengePhrase": "ThisIsntRandomButItNeedsToBe43CharactersLong",
     "AuthProvider_ClientId": "nhs-appts-local",
-    "AuthProvider_ClientCodeExchangeUri": "http://localhost:3000/auth/set-cookie",
+    "AuthProvider_ClientCodeExchangeUri": "http://localhost:3000/manage-your-appointments/auth/set-cookie",
     "AuthProvider_ReturnUri": "http://localhost:7071/api/auth-return",
     "Notifications_Provider": "local",
     "GovNotifyApiKey": "test",

--- a/src/client/.env
+++ b/src/client/.env
@@ -1,2 +1,3 @@
 NBS_API_BASE_URL=http://localhost:7071
 AUTH_HOST=http://localhost:7071
+CLIENT_BASE_PATH=/manage-your-appointments

--- a/src/client/next.config.mjs
+++ b/src/client/next.config.mjs
@@ -4,7 +4,18 @@ const nextConfig = {
   env: {
     BUILD_NUMBER: process.env.BUILD_BUILDNUMBER ?? '',
   },
-  output: 'standalone'
+  output: 'standalone',
+  basePath: process.env.CLIENT_BASE_PATH,
+  redirects: async () => {
+    return [
+      {
+        source: '/',
+        basePath: false,
+        destination: process.env.CLIENT_BASE_PATH,
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/client/src/app/auth/set-cookie/route.ts
+++ b/src/client/src/app/auth/set-cookie/route.ts
@@ -30,8 +30,8 @@ export async function GET(request: NextRequest) {
   const previousPage = cookies().get('previousPage');
   if (previousPage) {
     cookies().delete('previousPage');
-    redirect(previousPage.value);
+    redirect(`${process.env.CLIENT_BASE_PATH}/${previousPage.value}`);
   }
 
-  redirect('/');
+  redirect(process.env.CLIENT_BASE_PATH ?? '/');
 }

--- a/src/client/src/app/auth/set-cookie/route.ts
+++ b/src/client/src/app/auth/set-cookie/route.ts
@@ -3,7 +3,6 @@ import { redirect } from 'next/navigation';
 import { NextRequest } from 'next/server';
 import { cookies } from 'next/headers';
 import {
-  assertEulaAcceptance,
   fetchAccessToken,
   fetchUserProfile,
 } from '@services/appointmentsService';
@@ -24,8 +23,8 @@ export async function GET(request: NextRequest) {
   cookies().set('token', tokenResponse.token);
   revalidateTag('user');
 
-  const userProfile = await fetchUserProfile();
-  await assertEulaAcceptance(userProfile);
+  // Implicitly checks EULA is accepted, handles if not
+  await fetchUserProfile(`${process.env.CLIENT_BASE_PATH}/eula`);
 
   const previousPage = cookies().get('previousPage');
   if (previousPage) {

--- a/src/client/src/app/global.css
+++ b/src/client/src/app/global.css
@@ -27,6 +27,7 @@
 }
 
 .nhsuk-header-custom__user-control-link {
+  color: #fff;
   cursor: pointer;
   padding-inline-start: inherit;
   padding-inline-end: inherit;
@@ -41,6 +42,7 @@
 }
 
 .nhsuk-header-custom__user-control-link:hover {
+  color: #fff;
   box-shadow: 'none';
   text-decoration: underline;
 }
@@ -224,13 +226,13 @@
 .nhsuk-tabs__tab {
   display: inline-block;
   text-decoration: none;
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .nhsuk-tabs__list-item--selected > .nhsuk-tabs__tab {
   color: #0b0c0c;
 }
 
-.nhsuk-tabs__list-item:before {
+.nhsuk-tabs__list-item::before {
   content: none;
 }

--- a/src/client/src/app/home-page.test.tsx
+++ b/src/client/src/app/home-page.test.tsx
@@ -15,13 +15,13 @@ describe('Home Page', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Site Alpha' })).toHaveAttribute(
       'href',
-      `site/1001`,
+      `/site/1001`,
     );
 
     expect(screen.getByRole('link', { name: 'Site Beta' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Site Beta' })).toHaveAttribute(
       'href',
-      `site/1002`,
+      `/site/1002`,
     );
 
     expect(
@@ -29,7 +29,7 @@ describe('Home Page', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Site Gamma' })).toHaveAttribute(
       'href',
-      `site/1003`,
+      `/site/1003`,
     );
   });
 });

--- a/src/client/src/app/lib/components/site-list.test.tsx
+++ b/src/client/src/app/lib/components/site-list.test.tsx
@@ -78,7 +78,7 @@ describe('<SiteList>', () => {
     render(<SiteList sites={testSites} />);
     expect(screen.getByRole('link', { name: 'Site Alpha' })).toHaveAttribute(
       'href',
-      'site/1000',
+      '/site/1000',
     );
   });
 });

--- a/src/client/src/app/lib/components/site-list.tsx
+++ b/src/client/src/app/lib/components/site-list.tsx
@@ -18,7 +18,7 @@ const SiteList = ({ sites }: Props) => {
             <Link
               aria-label={s.name}
               className="nhsuk-back-link__link"
-              href={`site/${s.id}`}
+              href={`/site/${s.id}`}
             >
               {s.name}
             </Link>

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -30,22 +30,27 @@ export const fetchAccessToken = async (code: string) => {
   return handleBodyResponse(response);
 };
 
-export const fetchUserProfile = async (): Promise<UserProfile> => {
+export const fetchUserProfile = async (
+  eulaRoute = '/eula',
+): Promise<UserProfile> => {
   const response = await appointmentsApi.get<UserProfile>('user/profile', {
     next: { tags: ['user'] },
   });
 
   const userProfile = handleBodyResponse(response);
-  await assertEulaAcceptance(userProfile);
+  await assertEulaAcceptance(userProfile, eulaRoute);
   return userProfile;
 };
 
-export const assertEulaAcceptance = async (userProfile: UserProfile) => {
+export const assertEulaAcceptance = async (
+  userProfile: UserProfile,
+  eulaRoute = '/eula',
+) => {
   if (userProfile.availableSites.length > 0) {
     const eulaVersion = await fetchEula();
 
     if (eulaVersion.versionDate !== userProfile.latestAcceptedEulaVersion) {
-      redirect('/eula');
+      redirect(eulaRoute);
     }
   }
 };

--- a/src/client/src/app/site/[site]/site-page.test.tsx
+++ b/src/client/src/app/site/[site]/site-page.test.tsx
@@ -76,7 +76,7 @@ describe('Site Page', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Manage users' })).toHaveAttribute(
       'href',
-      `${mockSite.id}/users`,
+      `/site/${mockSite.id}/users`,
     );
   });
 
@@ -116,7 +116,7 @@ describe('Site Page', () => {
       screen.getByRole('link', {
         name: 'Change site details and accessibility information',
       }),
-    ).toHaveAttribute('href', `${mockSite.id}/details`);
+    ).toHaveAttribute('href', `/site/${mockSite.id}/details`);
   });
 
   it('does not show the site management page if the user may not see it', () => {
@@ -154,7 +154,7 @@ describe('Site Page', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'Create availability' }),
-    ).toHaveAttribute('href', `${mockSite.id}/create-availability`);
+    ).toHaveAttribute('href', `/site/${mockSite.id}/create-availability`);
   });
 
   it('does not show the create availability page if the user may not see it', () => {

--- a/src/client/src/app/site/[site]/site-page.tsx
+++ b/src/client/src/app/site/[site]/site-page.tsx
@@ -33,7 +33,7 @@ export const SitePage = ({
           {permissionsRelevantToCards.includes('availability:query') && (
             <li className="nhsuk-grid-column-one-third nhsuk-card-group__item">
               <Card
-                href={`${site.id}/view-availability`}
+                href={`/site/${site.id}/view-availability`}
                 title="View availability and manage appointments for your site"
               />
             </li>
@@ -41,7 +41,7 @@ export const SitePage = ({
           {permissionsRelevantToCards.includes('availability:setup') && (
             <li className="nhsuk-grid-column-one-third nhsuk-card-group__item">
               <Card
-                href={`${site.id}/create-availability`}
+                href={`/site/${site.id}/create-availability`}
                 title="Create availability"
               />
             </li>
@@ -50,14 +50,14 @@ export const SitePage = ({
             permissionsRelevantToCards.includes('site:view')) && (
             <li className="nhsuk-grid-column-one-third nhsuk-card-group__item">
               <Card
-                href={`${site.id}/details`}
+                href={`/site/${site.id}/details`}
                 title="Change site details and accessibility information"
               />
             </li>
           )}
           {permissionsRelevantToCards.includes('users:view') && (
             <li className="nhsuk-grid-column-one-third nhsuk-card-group__item">
-              <Card href={`${site.id}/users`} title="Manage users" />
+              <Card href={`/site/${site.id}/users`} title="Manage users" />
             </li>
           )}
         </ul>

--- a/src/client/testing/create-and-remove-user.spec.ts
+++ b/src/client/testing/create-and-remove-user.spec.ts
@@ -161,20 +161,26 @@ test('Displays a notification banner after removing a user, which disappears whe
 });
 
 test('Receives 403 error when trying to remove self', async ({ page }) => {
-  await page.goto(`/site/ABC01/users/remove?user=zzz_test_user_1@nhs.net`);
+  await page.goto(
+    `/manage-your-appointments/site/ABC01/users/remove?user=zzz_test_user_1@nhs.net`,
+  );
 
   await expect(notAuthorizedPage.title).toBeVisible();
 });
 
 test('Receives 404 when trying to remove an invalid user', async ({ page }) => {
-  await page.goto(`/site/ABC01/users/remove?user=not-a-user`);
+  await page.goto(
+    `/manage-your-appointments/site/ABC01/users/remove?user=not-a-user`,
+  );
 
   await expect(notFoundPage.title).toBeVisible();
   await expect(notFoundPage.notFoundMessageText).toBeVisible();
 });
 
 test('Receives 403 error when trying to edit self', async ({ page }) => {
-  await page.goto(`/site/ABC01/users/manage?user=zzz_test_user_1@nhs.net`);
+  await page.goto(
+    `/manage-your-appointments/site/ABC01/users/manage?user=zzz_test_user_1@nhs.net`,
+  );
 
   await expect(notAuthorizedPage.title).toBeVisible();
 });

--- a/src/client/testing/eula.spec.ts
+++ b/src/client/testing/eula.spec.ts
@@ -64,7 +64,7 @@ test('A user with an out of date EULA version is prompted with the EULA consent 
 
   await eulaConsentPage.acceptAndContinueButton.click();
 
-  await page.waitForURL('/');
+  await page.waitForURL('**/');
   await expect(siteSelectionPage.title).toBeVisible();
 
   await rootPage.logOutButton.click();
@@ -78,6 +78,6 @@ test('A user with an out of date EULA version is prompted with the EULA consent 
   await oAuthPage.page.getByLabel('Password').press('Enter');
 
   // do not expect to see the EULA consent page again
-  await page.waitForURL('/');
+  await page.waitForURL('**/');
   await expect(siteSelectionPage.title).toBeVisible();
 });

--- a/src/client/testing/page-objects/root.ts
+++ b/src/client/testing/page-objects/root.ts
@@ -22,6 +22,6 @@ export default class RootPage {
   }
 
   async goto() {
-    await this.page.goto('/');
+    await this.page.goto('/manage-your-appointments/');
   }
 }

--- a/src/client/testing/playwright.env
+++ b/src/client/testing/playwright.env
@@ -1,4 +1,4 @@
-BASE_URL=http://localhost:3000
+BASE_URL=http://localhost:3000/manage-your-appointments
 SEED_COSMOS_BEFORE_RUN=true
 COSMOS_ENDPOINT=https://localhost:8081
 COSMOS_TOKEN=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==

--- a/src/client/testing/user-management-permissions.spec.ts
+++ b/src/client/testing/user-management-permissions.spec.ts
@@ -66,7 +66,7 @@ test('Navigating straight to the user management page works as expected', async 
   await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser1);
 
-  await page.goto('/site/ABC01/users');
+  await page.goto('/manage-your-appointments/site/ABC01/users');
   await expect(usersPage.title).toBeVisible();
 });
 
@@ -77,11 +77,11 @@ test('Navigating straight to the user management page displays an appropriate er
   await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser3);
 
-  await page.goto('/site/ABC01/users');
+  await page.goto('/manage-your-appointments/site/ABC01/users');
   await expect(usersPage.emailColumn).not.toBeVisible();
   await expect(notAuthorizedPage.title).toBeVisible();
 
-  await page.goto('/site/ABC01/users/manage');
+  await page.goto('/manage-your-appointments/site/ABC01/users/manage');
   await expect(userManagementPage.emailInput).not.toBeVisible();
   await expect(notAuthorizedPage.title).toBeVisible();
 });


### PR DESCRIPTION
Prepends `/manage-your-appointments` to all client routes, using NextJS' [basePath ](https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath) configuration property. 

Frustratingly, this works within components whilst using [Link](https://nextjs.org/docs/pages/api-reference/components/link), or within server actions when invoking redirect, but NOT when invoking redirect from a route handler. This has been raised as an [open issue](https://github.com/vercel/next.js/issues/56229) several times on Vercel's github page, e.g. 

To get around this, I've introduced the basePath as an environment variable and manually prepended it to URLs derived during the `set-cookie` route handler. As this is our only route handler for now, it's tech debt I'm willing (but grumpy) to incur. 