### PR TITLE
APPT-XXX: Fix title being appended to empty breadcrumb trails

### DIFF
--- a/src/client/src/app/lib/components/nhs-page.tsx
+++ b/src/client/src/app/lib/components/nhs-page.tsx
@@ -49,7 +49,9 @@ const NhsPage = async ({
       <Breadcrumbs
         trail={[
           ...breadcrumbs,
-          ...(!omitTitleFromBreadcrumbs ? [{ name: title }] : []),
+          ...(breadcrumbs.length > 0 && !omitTitleFromBreadcrumbs
+            ? [{ name: title }]
+            : []),
         ]}
       />
       <NhsMainContainer>


### PR DESCRIPTION
Some pages recently had their breadcrumbs removed, but didn't have the `omitTitleFromBreadcrumbs` argument added. Hence the page title has still been appearing as a sole breadcrumb. 

Since it's a bit unclear from the tickets/designs exactly which pages should have breadcrumbs, I'm not reviewing them all here. This PR simply adds in an extra condition to the automatic title addition so it won't add to the title to the empty array.