### PR TITLE
Avoid unnecessary server trips when using tabs and pagination

### DIFF
--- a/src/client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -19,7 +19,7 @@ import RightChevron from './icons/right-chevron';
 import Select from './select';
 import SummaryList, { SummaryListItem } from './summary-list';
 import Table from './table';
-import Tabs, { TabsChildren } from './tabs';
+import Tabs, { Tab } from './tabs';
 import Tag, { TagColor } from './tag';
 import TextArea from './text-area';
 import TextInput from './text-input';
@@ -35,7 +35,6 @@ import Pagination from './pagination';
 export type {
   Breadcrumb,
   SummaryListItem,
-  TabsChildren,
   TagColor,
   NavigationLink,
   PaginationLink,
@@ -68,6 +67,7 @@ export {
   SummaryList,
   Table,
   Tabs,
+  Tab,
   Tag,
   TextArea,
   TextInput,

--- a/src/client/src/app/lib/components/nhsuk-frontend/pagination.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/pagination.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 export type PaginationLink = {
   title: string;
   href: string;
+  onClick?: () => void;
 };
 
 type PaginationProps = {
@@ -29,6 +30,7 @@ const Pagination = ({ previous, next }: PaginationProps) => {
             <Link
               className="nhsuk-pagination__link nhsuk-pagination__link--prev"
               href={previous.href}
+              onClick={previous.onClick}
             >
               <span className="nhsuk-pagination__title">Previous</span>
               <span className="nhsuk-u-visually-hidden">:</span>
@@ -51,6 +53,7 @@ const Pagination = ({ previous, next }: PaginationProps) => {
             <Link
               className="nhsuk-pagination__link nhsuk-pagination__link--next"
               href={next.href}
+              onClick={next.onClick}
             >
               <span className="nhsuk-pagination__title">Next</span>
               <span className="nhsuk-u-visually-hidden">:</span>

--- a/src/client/src/app/lib/components/nhsuk-frontend/tabs.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/tabs.tsx
@@ -1,53 +1,98 @@
-export type TabsChildren = {
-  isSelected: boolean;
-  url: string;
-  tabTitle: string;
-  content: React.ReactNode;
+'use client';
+import {
+  Children,
+  cloneElement,
+  FunctionComponentElement,
+  ReactNode,
+} from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+
+type TabProps = {
+  title: string;
+  children: ReactNode;
 };
 
-type Props = {
-  children: TabsChildren[];
+type InjectedTabProps = {
+  tabIndex: number;
+  isActive: boolean;
 };
 
-const Tabs = ({ children }: Props) => {
+type TabsProps = {
+  title?: string;
+  children: ReactNode;
+  initialTab?: number;
+};
+
+/**
+ * A tabs component adhering to the NHS UK Frontend design system.
+ * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
+ * @see https://service-manual.nhs.uk/design-system/components/tabs
+ */
+const Tabs = ({ title, children, initialTab = 0 }: TabsProps) => {
+  const searchParams = useSearchParams();
+  const params = new URLSearchParams(searchParams.toString());
+  const activeTab = Number(params.get('tab')) ?? initialTab;
+
+  const filteredChildren = Children.toArray(
+    children,
+  ) as FunctionComponentElement<TabProps & InjectedTabProps>[];
+
   return (
     <div className="nhsuk-tabs" data-module="nhsuk-tabs">
-      {renderTabs(children)}
-      {renderTabContents(children)}
+      {title && <h2 className="nhsuk-tabs__title">{title}</h2>}
+
+      <ul className="nhsuk-tabs__list">
+        {filteredChildren.map((tab, index) => {
+          return (
+            <li
+              key={`tab-header-${index}`}
+              className={`nhsuk-tabs__list-item ${index === activeTab ? 'nhsuk-tabs__list-item--selected' : ''}`}
+              aria-label={tab.props.title}
+            >
+              <Link
+                className="nhsuk-tabs__tab"
+                href={''}
+                onClick={() => {
+                  params.set('tab', String(index));
+                  window.history.pushState(null, '', `?${params.toString()}`);
+                }}
+              >
+                {tab.props.title}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+
+      {filteredChildren.map((tab, index) => {
+        return cloneElement<TabProps & InjectedTabProps>(tab, {
+          tabIndex: index,
+          isActive: index === activeTab,
+        });
+      })}
     </div>
   );
 };
 
-const renderTabs = (tabs: TabsChildren[]) => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const Tab = ({ title, children, ...rest }: TabProps) => {
+  const injectedTabProps = rest as InjectedTabProps;
+  const { isActive } = injectedTabProps;
+
+  if (!isActive) {
+    return null;
+  }
+
   return (
-    <ul className="nhsuk-tabs__list">
-      {tabs.map((tab, key) => (
-        <li
-          key={key}
-          className={`nhsuk-tabs__list-item ${
-            tab.isSelected ? 'nhsuk-tabs__list-item--selected' : ''
-          }`}
-        >
-          <a href={tab.url} className="nhsuk-tabs__tab">
-            {tab.tabTitle}
-          </a>
-        </li>
-      ))}
-    </ul>
-  );
-};
-
-const renderTabContents = (tabs: TabsChildren[]) => {
-  return tabs.map((tab, key) => (
     <div
-      className={`nhsuk-tabs__panel ${
-        !tab.isSelected ? 'nhsuk-tabs__panel--hidden' : ''
-      }`}
-      key={key}
+      key={`tab-content-panel-${injectedTabProps.tabIndex}`}
+      className="nhsuk-tabs__panel"
+      id={`tab-content-panel-${injectedTabProps.tabIndex}`}
     >
-      {tab.content}
+      {children}
     </div>
-  ));
+  );
 };
 
 export default Tabs;

--- a/src/client/src/app/lib/components/nhsuk-frontend/tabs.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/tabs.tsx
@@ -22,6 +22,7 @@ type TabsProps = {
   title?: string;
   children: ReactNode;
   initialTab?: number;
+  onSwitchTab?: (params: URLSearchParams) => void;
 };
 
 /**
@@ -29,7 +30,7 @@ type TabsProps = {
  * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
  * @see https://service-manual.nhs.uk/design-system/components/tabs
  */
-const Tabs = ({ title, children, initialTab = 0 }: TabsProps) => {
+const Tabs = ({ title, children, initialTab = 0, onSwitchTab }: TabsProps) => {
   const searchParams = useSearchParams();
   const params = new URLSearchParams(searchParams.toString());
   const activeTab = Number(params.get('tab')) ?? initialTab;
@@ -55,6 +56,9 @@ const Tabs = ({ title, children, initialTab = 0 }: TabsProps) => {
                 href={''}
                 onClick={() => {
                   params.set('tab', String(index));
+                  if (onSwitchTab) {
+                    onSwitchTab(params);
+                  }
                   window.history.pushState(null, '', `?${params.toString()}`);
                 }}
               >

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.test.tsx
@@ -1,17 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import { DailyAppointmentsPage } from './daily-appointments-page';
 import { mockBookings } from '@testing/data';
+import { SearchParamsContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+import { ReadonlyURLSearchParams } from 'next/navigation';
 
 describe('View Daily Appointments', () => {
   it('renders appointments', () => {
     render(
-      <DailyAppointmentsPage
-        bookings={mockBookings}
-        page={1}
-        date={'2024-12-24'}
-        site="TEST01"
-        displayAction={true}
-      />,
+      <SearchParamsContext.Provider
+        value={new ReadonlyURLSearchParams('date=2024-12-24&page=1')}
+      >
+        <DailyAppointmentsPage
+          bookings={mockBookings}
+          site="TEST01"
+          displayAction={true}
+        />
+      </SearchParamsContext.Provider>,
     );
 
     expect(

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Table, ButtonGroup } from '@nhsuk-frontend-components';
+import { Table, Pagination } from '@nhsuk-frontend-components';
 import { AttendeeDetails, ContactItem, Booking } from '@types';
 import { formatDateTimeToTime, dateToString } from '@services/timeService';
 import { ReactNode } from 'react';
@@ -107,28 +107,28 @@ export const DailyAppointmentsPage = ({
     <>
       {appointmentsTableData && <Table {...appointmentsTableData}></Table>}
 
-      {/* TODO: Implement the pagination component and in the first screenshot of https://nhsd-jira.digital.nhs.uk/browse/APPT-367 and replace these links
-      // (styles mismatch raised as a defect by testers whilst testing) */}
-      <ButtonGroup>
-        {page > 1 && (
-          <Link
-            onClick={() => {
-              params.set('page', String(page - 1));
-              window.history.pushState(null, '', `?${params.toString()}`);
-            }}
-            href={''}
-          >{`Page ${page - 1}`}</Link>
-        )}
-        {hasNextPage() && (
-          <Link
-            onClick={() => {
-              params.set('page', String(page + 1));
-              window.history.pushState(null, '', `?${params.toString()}`);
-            }}
-            href={''}
-          >{`Page ${page + 1}`}</Link>
-        )}
-      </ButtonGroup>
+      <Pagination
+        previous={{
+          title: `Page ${page - 1}`,
+          href: '',
+          onClick: () => {
+            params.set('page', String(page - 1));
+            window.history.pushState(null, '', `?${params.toString()}`);
+          },
+        }}
+        next={
+          hasNextPage()
+            ? {
+                title: `Page ${page + 1}`,
+                href: '',
+                onClick: () => {
+                  params.set('page', String(page + 1));
+                  window.history.pushState(null, '', `?${params.toString()}`);
+                },
+              }
+            : null
+        }
+      />
     </>
   );
 };

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.tsx
@@ -1,54 +1,40 @@
-import { Table, Pagination, PaginationLink } from '@nhsuk-frontend-components';
+'use client';
+import { Table, ButtonGroup } from '@nhsuk-frontend-components';
 import { AttendeeDetails, ContactItem, Booking } from '@types';
 import { formatDateTimeToTime, dateToString } from '@services/timeService';
 import { ReactNode } from 'react';
-import dayjs from 'dayjs';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+
+const ROWS_PER_PAGE = 50;
 
 type Props = {
   bookings: Booking[];
-  page: number;
-  date: string;
   site: string;
   displayAction: boolean;
-  activeTab?: string;
 };
 
 export const DailyAppointmentsPage = ({
   bookings,
-  page,
-  date,
   site,
   displayAction,
-  activeTab,
 }: Props) => {
-  const rowsPerPage = 50;
+  const searchParams = useSearchParams();
+  const params = new URLSearchParams(searchParams.toString());
+
+  const page = Number(params.get('page')) ?? 1;
 
   const hasNextPage = (): boolean => {
-    return page * rowsPerPage < bookings.length;
+    return page * ROWS_PER_PAGE < bookings.length;
   };
-  const buildNextPage = (): PaginationLink | null => {
-    if (!hasNextPage()) return null;
 
-    return {
-      title: `Page ${page + 1}`,
-      href: `daily-appointments?date=${dayjs(date).format('YYYY-MM-DD')}&page=${page + 1}${activeTab ? `&tab=${activeTab}` : ''}`,
-    };
-  };
-  const buildPreviousPage = (): PaginationLink | null => {
-    if (page === 1) return null;
-
-    return {
-      title: `Page ${page - 1}`,
-      href: `daily-appointments?date=${dayjs(date).format('YYYY-MM-DD')}&page=${page - 1}${activeTab ? `&tab=${activeTab}` : ''}`,
-    };
-  };
   const getPagedBookings = (b: Booking[]): Booking[] => {
-    const startIndex = page == 1 ? 0 : (page - 1) * rowsPerPage;
-    const endIndex = startIndex + rowsPerPage;
+    const startIndex = page == 1 ? 0 : (page - 1) * ROWS_PER_PAGE;
+    const endIndex = startIndex + ROWS_PER_PAGE;
 
     return b.slice(startIndex, endIndex);
   };
+
   const mapContactDetails = (contactDetails: ContactItem[]): ReactNode => {
     return contactDetails.map((details, key) => {
       return (
@@ -59,6 +45,7 @@ export const DailyAppointmentsPage = ({
       );
     });
   };
+
   const mapNameAndNHSNumber = (attendeeDetails: AttendeeDetails): ReactNode => {
     return (
       <span>
@@ -68,6 +55,7 @@ export const DailyAppointmentsPage = ({
       </span>
     );
   };
+
   const mapTableData = () => {
     if (!bookings.length) {
       return undefined;
@@ -112,12 +100,35 @@ export const DailyAppointmentsPage = ({
 
     return { headers, rows };
   };
+
   const appointmentsTableData = mapTableData();
 
   return (
     <>
       {appointmentsTableData && <Table {...appointmentsTableData}></Table>}
-      <Pagination previous={buildPreviousPage()} next={buildNextPage()} />
+
+      {/* TODO: Implement the pagination component and in the first screenshot of https://nhsd-jira.digital.nhs.uk/browse/APPT-367 and replace these links
+      // (styles mismatch raised as a defect by testers whilst testing) */}
+      <ButtonGroup>
+        {page > 1 && (
+          <Link
+            onClick={() => {
+              params.set('page', String(page - 1));
+              window.history.pushState(null, '', `?${params.toString()}`);
+            }}
+            href={''}
+          >{`Page ${page - 1}`}</Link>
+        )}
+        {hasNextPage() && (
+          <Link
+            onClick={() => {
+              params.set('page', String(page + 1));
+              window.history.pushState(null, '', `?${params.toString()}`);
+            }}
+            href={''}
+          >{`Page ${page + 1}`}</Link>
+        )}
+      </ButtonGroup>
     </>
   );
 };

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
@@ -46,7 +46,11 @@ const Page = async ({ params, searchParams }: PageProps) => {
 
   return (
     <NhsPage title={title} caption={site.name} backLink={backLink}>
-      <Tabs>
+      <Tabs
+        onSwitchTab={searchParameters => {
+          searchParameters.set('page', '1');
+        }}
+      >
         <Tab title="Scheduled">
           <DailyAppointmentsPage
             bookings={bookings.filter(b => b.status === 'Booked')}

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
@@ -46,7 +46,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
 
   return (
     <NhsPage title={title} caption={site.name} backLink={backLink}>
-      <Tabs initialTab={searchParams.tab === 'Cancelled' ? 1 : 0}>
+      <Tabs>
         <Tab title="Scheduled">
           <DailyAppointmentsPage
             bookings={bookings.filter(b => b.status === 'Booked')}


### PR DESCRIPTION
- Resolves console errors that `tabs.test.tsx` was causing
- Moves the logic for handling tab selection into the Tabs component so the consumer doesn't have to implement it themselves
- Refactors the tabs/pagination on these pages to avoid unnecessary server round-trips