### PR TITLE
Add data import reports to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,5 @@ FakesAssemblies/
 
 # dotnet format report
 dotnet-format-report.json
+data/CosmosDbSeeder/data_import_report.md
+data/CosmosDbSeeder/data_import_summary.md


### PR DESCRIPTION
Add the data import markdown reports to .gitignore so they don't appear as changes after running the DB seeder