### PR TITLE
Tiny styling bug fix

### DIFF
--- a/src/client/src/app/site/[site]/users/users-page.tsx
+++ b/src/client/src/app/site/[site]/users/users-page.tsx
@@ -53,7 +53,7 @@ export const UsersPage = ({
             ...(canSeeAdminControls
               ? [
                   ...(userProfile.emailAddress === user.id
-                    ? []
+                    ? ['', '']
                     : [
                         <EditRoleAssignmentsButton
                           key={`edit-${user.id}`}


### PR DESCRIPTION
I noticed the table styling is off for rows without the Manage/Remove actions. This is because we're rendering null rather than empty `<td>` elements. This PR passes two empty strings instead so the table still renders `<td>` elements with their border styling.

<img width="800" alt="Screenshot 2025-01-02 132415" src="https://github.com/user-attachments/assets/d302edd9-62bd-4f1e-b22c-f4684349306a" />
<img width="830" alt="image" src="https://github.com/user-attachments/assets/16f4377d-e77c-4ab7-b7aa-b03b295d0059" />
