### PR TITLE
APPT-146 - Get booking by reference number endpoint update

### DIFF
--- a/src/api/Nhs.Appointments.Api/Models/QueryBookingByReferenceRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/QueryBookingByReferenceRequest.cs
@@ -1,3 +1,3 @@
-﻿namespace Nhs.Appointments.Api.Models;
+namespace Nhs.Appointments.Api.Models;
 
-public record QueryBookingByReferenceRequest(string bookingReference);
+public record QueryBookingByReferenceRequest(string bookingReference, string site);

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -385,8 +385,10 @@ export const fetchDailyAvailability = async (
   return handleBodyResponse(response);
 };
 
-export const fetchBooking = async (reference: string) => {
-  const response = await appointmentsApi.get<Booking>(`booking/${reference}`);
+export const fetchBooking = async (reference: string, site: string) => {
+  const response = await appointmentsApi.get<Booking>(
+    `booking/${reference}?site=${site}`,
+  );
 
   return handleBodyResponse(response);
 };

--- a/src/client/src/app/site/[site]/appointment/[reference]/cancel/page.tsx
+++ b/src/client/src/app/site/[site]/appointment/[reference]/cancel/page.tsx
@@ -19,7 +19,7 @@ const Page = async ({ params }: PageProps) => {
   const site = await fetchSite(params.site);
   await assertPermission(site.id, 'booking:cancel');
 
-  const booking = await fetchBooking(params.reference);
+  const booking = await fetchBooking(params.reference, site.id);
   if (!booking || booking.status === 'Cancelled') {
     notFound();
   }

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/QueryBookingByReferenceNumberTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/QueryBookingByReferenceNumberTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Nhs.Appointments.Api.Auth;
+using Nhs.Appointments.Api.Functions;
+using Nhs.Appointments.Api.Json;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Core;
+
+namespace Nhs.Appointments.Api.Tests.Functions;
+public class QueryBookingByReferenceNumberTests
+{
+    private readonly Mock<IValidator<QueryBookingByReferenceRequest>> _validator = new();
+    private readonly Mock<IUserContextProvider> _userContextProvider = new();
+    private readonly Mock<ILogger<QueryBookingByReferenceFunction>> _logger = new();
+    private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
+    private readonly Mock<IBookingsService> _bookingService = new();
+
+    private readonly QueryBookingByReferenceFunction _sut;
+
+    public QueryBookingByReferenceNumberTests()
+    {
+        _sut = new QueryBookingByReferenceFunction(
+            _bookingService.Object,
+            _validator.Object,
+            _userContextProvider.Object,
+            _logger.Object,
+            _metricsRecorder.Object);
+
+        _validator.Setup(x => x.ValidateAsync(It.IsAny<QueryBookingByReferenceRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new ValidationResult()));
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsSuccessResponse_AndBookingWhenFound()
+    {
+        const string bookingRef = "ABC123";
+        const string site = "TEST01";
+        var booking = new Booking
+        {
+            Reference = bookingRef,
+            From = DateTime.Now.AddDays(1),
+            Duration = 5,
+            AttendeeDetails = new AttendeeDetails
+            {
+                FirstName = "John",
+                LastName = "Bloggs",
+                NhsNumber = "1234567890"
+            },
+            Site = site
+        };
+
+        _bookingService.Setup(x => x.GetBookingByReference(It.IsAny<string>()))
+            .ReturnsAsync(booking);
+
+        var request = new QueryBookingByReferenceRequest(bookingRef, site);
+        var httpRequest = CreateRequest(request.site);
+
+        var result = await _sut.RunAsync(httpRequest) as ContentResult;
+        result.StatusCode.Should().Be(200);
+
+        var response = await ReadResponseAsync<Booking>(result.Content);
+        response.Should().BeEquivalentTo(booking);
+        response.Reference.Should().Be(bookingRef);
+        response.Site.Should().Be(site);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsNotFoundResponse_WhenReferenceAndSiteDoNotMatch()
+    {
+        const string bookingRef = "ABC123";
+        var booking = new Booking
+        {
+            Reference = bookingRef,
+            From = DateTime.Now.AddDays(1),
+            Duration = 5,
+            AttendeeDetails = new AttendeeDetails
+            {
+                FirstName = "John",
+                LastName = "Bloggs",
+                NhsNumber = "1234567890"
+            },
+            Site = "TEST01"
+        };
+
+        _bookingService.Setup(x => x.GetBookingByReference(It.IsAny<string>()))
+            .ReturnsAsync(booking);
+
+        var request = new QueryBookingByReferenceRequest(bookingRef, "TEST03");
+        var httpRequest = CreateRequest(request.site);
+
+        var result = await _sut.RunAsync(httpRequest) as ContentResult;
+        result.StatusCode.Should().Be(404);
+    }
+
+    private static HttpRequest CreateRequest(string site)
+    {
+        var context = new DefaultHttpContext();
+        var request = context.Request;
+        request.Headers.Append("Authorization", "Test 123");
+        request.QueryString = new QueryString($"?site={site}");
+        return request;
+    }
+
+    private static async Task<TRequest> ReadResponseAsync<TRequest>(string response)
+    {
+        var deserializerSettings = new JsonSerializerSettings
+        {
+            Converters =
+            {
+                new ShortTimeOnlyJsonConverter(), new ShortDateOnlyJsonConverter(), new NullableShortDateOnlyJsonConverter()
+            },
+
+        };
+        var body = await new StringReader(response).ReadToEndAsync();
+        return JsonConvert.DeserializeObject<TRequest>(body, deserializerSettings);
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/QueryBookingByReferenceRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/QueryBookingByReferenceRequestValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Api.Validators;
 
@@ -12,7 +12,7 @@ public class QueryBookingByReferenceRequestValidatorTests
     [Fact]
     public void Validate_ReturnsError_WhenSiteIsBlank()
     {
-        var testRequest = new QueryBookingByReferenceRequest("");
+        var testRequest = new QueryBookingByReferenceRequest("", string.Empty);
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -22,7 +22,7 @@ public class QueryBookingByReferenceRequestValidatorTests
     [Fact]
     public void Validate_ReturnsSuccess_WhenRequestIsValid()
     {
-        var testRequest = new QueryBookingByReferenceRequest("ref");
+        var testRequest = new QueryBookingByReferenceRequest("ref", string.Empty);
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeTrue();
         result.Errors.Should().HaveCount(0);


### PR DESCRIPTION
Adding an optional site query string to the GetBookingByReferenceNumber endpoint so we can access it from the front end without having the booking:query permission set globally.