### PR TITLE
Exp/alternative site search

### DIFF
--- a/infrastructure/resources/database.tf
+++ b/infrastructure/resources/database.tf
@@ -57,6 +57,19 @@ resource "azurerm_cosmosdb_sql_container" "nbs_mya_core_container" {
       max_throughput = autoscale_settings.value["max_throughput"]
     }
   }
+
+  indexing_policy {
+    indexing_mode = "consistent"
+    included_path {
+      path = "/*"
+    }
+    excluded_path {
+      path = "/_etag/?"
+    }
+    spatial_index {
+      path = "/location/?"
+    }
+  }
 }
 
 resource "azurerm_cosmosdb_sql_container" "nbs_mya_index_container" {

--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -20,8 +20,7 @@ stages:
   - stage: Deploy${{parameters.env}}
     displayName: Deploy ${{parameters.env}}
     dependsOn: Build
-#    condition: and(succeeded(), eq(${{parameters.isMain}}, true))
-    condition: succeeded()
+    condition: and(succeeded(), eq(${{parameters.isMain}}, true))    
     variables:
       - group: ${{parameters.variable_group}}
     jobs:

--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -39,7 +39,7 @@ public class GetSitesByAreaFunction(ISiteService siteService, IValidator<GetSite
 
     protected override async Task<ApiResult<IEnumerable<SiteWithDistance>>> HandleRequest(GetSitesByAreaRequest request, ILogger logger)
     {
-        var sites = await siteService.FindSitesByArea(request.longitude, request.latitude, request.searchRadius, request.maximumRecords, request.accessNeeds);
+        var sites = await siteService.FindSitesByArea(request.longitude, request.latitude, request.searchRadius, request.maximumRecords, request.accessNeeds, request.ignoreCache);
         return ApiResult<IEnumerable<SiteWithDistance>>.Success(sites);
     }
     
@@ -47,6 +47,7 @@ public class GetSitesByAreaFunction(ISiteService siteService, IValidator<GetSite
     {
         var errors = new List<ErrorMessageResponseItem>();
         var accessNeeds = req.Query.ContainsKey("accessNeeds") ? req.Query["accessNeeds"].ToString().Split(',') : Array.Empty<string>();
+        var ignoreCache = req.Query.ContainsKey("ignoreCache") ? bool.Parse(req.Query["ignoreCache"]) : false;
         if (accessNeeds.Any(string.IsNullOrEmpty))
         {
             errors.Add(new ErrorMessageResponseItem { Property = "accessNeeds", Message = "Access needs cannot be contain empty values" });
@@ -56,6 +57,6 @@ public class GetSitesByAreaFunction(ISiteService siteService, IValidator<GetSite
         var latitude = double.Parse(req.Query["lat"]);
         var searchRadius = int.Parse(req.Query["searchRadius"]);
         var maximumRecords = int.Parse(req.Query["maxRecords"]);
-        return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetSitesByAreaRequest request)>((errors.AsReadOnly(), new GetSitesByAreaRequest(longitude, latitude, searchRadius, maximumRecords, accessNeeds)));
+        return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetSitesByAreaRequest request)>((errors.AsReadOnly(), new GetSitesByAreaRequest(longitude, latitude, searchRadius, maximumRecords, accessNeeds, ignoreCache)));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Models/GetSitesByAreaRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/GetSitesByAreaRequest.cs
@@ -1,3 +1,3 @@
-﻿namespace Nhs.Appointments.Api.Models;
+namespace Nhs.Appointments.Api.Models;
 
-public record GetSitesByAreaRequest(double longitude, double latitude, int searchRadius, int maximumRecords, string[] accessNeeds);
+public record GetSitesByAreaRequest(double longitude, double latitude, int searchRadius, int maximumRecords, string[] accessNeeds, bool ignoreCache);

--- a/src/api/Nhs.Appointments.Core/ISiteStore.cs
+++ b/src/api/Nhs.Appointments.Core/ISiteStore.cs
@@ -1,10 +1,10 @@
-﻿namespace Nhs.Appointments.Core;
+namespace Nhs.Appointments.Core;
 
 public interface ISiteStore
-{
-    Task<IEnumerable<SiteWithDistance>> GetSitesByArea(double longitude, double latitude, int searchRadius);
+{    
     Task<Site> GetSiteById(string siteId);
     Task<OperationResult> UpdateSiteAttributes(string siteId, string scope, IEnumerable<AttributeValue> attributeValues);
     Task AssignPrefix(string site, int prefix);
     Task<int> GetReferenceNumberGroup(string site);
+    Task<IEnumerable<Site>> GetAllSites();
 }

--- a/src/api/Nhs.Appointments.Core/Nhs.Appointments.Core.csproj
+++ b/src/api/Nhs.Appointments.Core/Nhs.Appointments.Core.csproj
@@ -12,6 +12,7 @@
 		<PackageReference Include="MassTransit" Version="8.3.4" />
 		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.45.2" />
 		<PackageReference Include="Microsoft.Extensions.Azure" Version="1.9.0" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -57,18 +57,17 @@ public class SiteService(ISiteStore siteStore, IMemoryCache memoryCache, TimePro
 
     private int CalculateDistanceInMetres(double lat1, double lon1, double lat2, double lon2)
     {
-        if ((lat1 == lat2) && (lon1 == lon2))
-        {
+        var epsilon = 0.000001f;
+        var deltaLatitude = lat1 - lat2;
+        var deltaLongitude = lon1 - lon2;
+
+        if( Math.Abs(deltaLatitude) < epsilon && Math.Abs(deltaLongitude) < epsilon )
             return 0;
-        }
-        else
-        {
-            var theta = lon1 - lon2;
-            var dist = Math.Sin(DegreesToRadians(lat1)) * Math.Sin(DegreesToRadians(lat2)) + Math.Cos(DegreesToRadians(lat1)) * Math.Cos(DegreesToRadians(lat2)) * Math.Cos(DegreesToRadians(theta));
-            dist = Math.Acos(dist);
-            dist = RadiansToDegrees(dist);
-            return (int)(dist * 60 * 1.1515 * 1.609344 * 1000);
-        }
+
+        var dist = Math.Sin(DegreesToRadians(lat1)) * Math.Sin(DegreesToRadians(lat2)) + Math.Cos(DegreesToRadians(lat1)) * Math.Cos(DegreesToRadians(lat2)) * Math.Cos(DegreesToRadians(deltaLongitude));
+        dist = Math.Acos(dist);
+        dist = RadiansToDegrees(dist);
+        return (int)(dist * 60 * 1.1515 * 1.609344 * 1000);        
     }
 
     private double DegreesToRadians(double deg) => (deg * Math.PI / 180.0);

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -1,24 +1,37 @@
-﻿namespace Nhs.Appointments.Core;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Nhs.Appointments.Core;
 
 public interface ISiteService
 {
-    Task<IEnumerable<SiteWithDistance>> FindSitesByArea(double longitude, double latitude, int searchRadius, int maximumRecords, IEnumerable<string> accessNeeds);
+    Task<IEnumerable<SiteWithDistance>> FindSitesByArea(double longitude, double latitude, int searchRadius, int maximumRecords, IEnumerable<string> accessNeeds, bool ignoreCache);
     Task<Site> GetSiteByIdAsync(string siteId, string scope = "*");
-    Task<OperationResult> UpdateSiteAttributesAsync(string siteId, string scope, IEnumerable<AttributeValue> attributeValues);
+    Task<OperationResult> UpdateSiteAttributesAsync(string siteId, string scope, IEnumerable<AttributeValue> attributeValues);    
 }
 
-public class SiteService(ISiteStore siteStore) : ISiteService
+public class SiteService(ISiteStore siteStore, IMemoryCache memoryCache, TimeProvider time) : ISiteService
 {
-    public async Task<IEnumerable<SiteWithDistance>> FindSitesByArea(double longitude, double latitude, int searchRadius, int maximumRecords, IEnumerable<string> accessNeeds)
-    {
+    public async Task<IEnumerable<SiteWithDistance>> FindSitesByArea(double longitude, double latitude, int searchRadius, int maximumRecords, IEnumerable<string> accessNeeds, bool ignoreCache = false)
+    {        
         var attributeIds = accessNeeds.Where(an => string.IsNullOrEmpty(an) == false).Select(an => $"accessibility/{an}").ToList();
-        var sites = await siteStore.GetSitesByArea(longitude, latitude, searchRadius);
+
+        var sites = memoryCache.Get("sites") as IEnumerable<Site>;
+        if (sites == null || ignoreCache)
+        {
+            sites = await siteStore.GetAllSites();            
+            memoryCache.Set("sites", sites, time.GetUtcNow().AddMinutes(10));
+        }
+
+        var sitesWithDistance = sites
+                .Select(s => new SiteWithDistance(s, (int)(CalculateDistance(s.Location.Coordinates[1], s.Location.Coordinates[0], latitude, longitude, 'K') * 1000)));
+
         Func<SiteWithDistance, bool> filterPredicate = attributeIds.Any() ?
             s => attributeIds.All(attr => s.Site.AttributeValues.SingleOrDefault(a => a.Id == attr)?.Value == "true") :
             s => true;
         
-        return sites
-            .Where(filterPredicate) 
+        return sitesWithDistance
+            .Where(s => s.Distance <= searchRadius)
+            .Where(filterPredicate)
             .OrderBy(site => site.Distance)
             .Take(maximumRecords);
     }
@@ -35,10 +48,51 @@ public class SiteService(ISiteStore siteStore) : ISiteService
         site.AttributeValues = site.AttributeValues.Where(a => a.Id.Contains($"{scope}/", StringComparison.CurrentCultureIgnoreCase));
 
         return site;
-    }
+    }    
 
     public Task<OperationResult> UpdateSiteAttributesAsync(string siteId, string scope, IEnumerable<AttributeValue> attributeValues)
     {
         return siteStore.UpdateSiteAttributes(siteId, scope, attributeValues);
+    }
+
+    private double CalculateDistance(double lat1, double lon1, double lat2, double lon2, char unit)
+    {
+        if ((lat1 == lat2) && (lon1 == lon2))
+        {
+            return 0;
+        }
+        else
+        {
+            double theta = lon1 - lon2;
+            double dist = Math.Sin(deg2rad(lat1)) * Math.Sin(deg2rad(lat2)) + Math.Cos(deg2rad(lat1)) * Math.Cos(deg2rad(lat2)) * Math.Cos(deg2rad(theta));
+            dist = Math.Acos(dist);
+            dist = rad2deg(dist);
+            dist = dist * 60 * 1.1515;
+            if (unit == 'K')
+            {
+                dist = dist * 1.609344;
+            }
+            else if (unit == 'N')
+            {
+                dist = dist * 0.8684;
+            }
+            return (dist);
+        }
+    }
+
+    //:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    //::  This function converts decimal degrees to radians             :::
+    //:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    private double deg2rad(double deg)
+    {
+        return (deg * Math.PI / 180.0);
+    }
+
+    //:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    //::  This function converts radians to decimal degrees             :::
+    //:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+    private double rad2deg(double rad)
+    {
+        return (rad / Math.PI * 180.0);
     }
 }

--- a/src/api/Nhs.Appointments.Persistance/SiteStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/SiteStore.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Microsoft.Azure.Cosmos;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
@@ -7,22 +7,15 @@ namespace Nhs.Appointments.Persistance;
 
 public class SiteStore(ITypedDocumentCosmosStore<SiteDocument> cosmosStore) : ISiteStore
 {
-    public Task<IEnumerable<SiteWithDistance>> GetSitesByArea(double longitude, double latitude, int searchRadius)
-    {
-        var query = new QueryDefinition(
-                query: "SELECT site, ROUND(ST_DISTANCE(site.location, {\"type\": \"Point\", \"coordinates\":[@longitude, @latitude]})) as distance " + 
-                       "FROM core_data site " + 
-                       "WHERE site.docType = @docType AND ST_DISTANCE(site.location, {\"type\": \"Point\", \"coordinates\":[@longitude, @latitude]}) < @searchRadius")
-            .WithParameter("@longitude", longitude)
-            .WithParameter("@latitude", latitude)
-            .WithParameter("@searchRadius", searchRadius)
-            .WithParameter("@docType", "site");
-        return cosmosStore.RunSqlQueryAsync<SiteWithDistance>(query);
-    }
     
     public Task<Site> GetSiteById(string siteId)
     {
         return GetOrDefault(siteId);
+    }
+
+    public Task<IEnumerable<Site>> GetAllSites()
+    {
+        return cosmosStore.RunQueryAsync<Site>(sd => sd.DocumentType == "site");
     }
 
     public async Task<int> GetReferenceNumberGroup(string site)

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
@@ -1,4 +1,4 @@
-﻿Feature: Site search
+Feature: Site search
   
   Scenario: Retrieve all sites within a designated distance
     Given The following sites exist in the system
@@ -12,9 +12,9 @@
       | 50          | 6000          | 0.082     | 51.5     |
     Then the following sites and distances are returned
       | Site | Name   | Address    |  PhoneNumber  | Region | ICB  | Attributes                   | Longitude   | Latitude  | Distance |
-      | 1    | Site-1 | 1 Roadside |  0113 1111111 | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 663      |
-      | 2    | Site-2 | 2 Roadside |  0113 2222222 | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4833     |
-      | 4    | Site-4 | 4 Roadside |  0113 4444444 | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5684     |
+      | 1    | Site-1 | 1 Roadside |  0113 1111111 | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+      | 2    | Site-2 | 2 Roadside |  0113 2222222 | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
+      | 4    | Site-4 | 4 Roadside |  0113 4444444 | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
 
   Scenario: Only return the number of sites requested
     Given The following sites exist in the system
@@ -28,8 +28,8 @@
       | 2           | 100000        | -0.082    | -51.5    |
     Then the following sites and distances are returned
       | Site | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude    | Latitude   | Distance |
-      | 5    | Site-5 | 5 Roadside | 0113 5555555 | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 | 663      |
-      | 6    | Site-6 | 6 Roadside | 0113 6666666 | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 | 4833     |
+      | 5    | Site-5 | 5 Roadside | 0113 5555555 | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 | 662      |
+      | 6    | Site-6 | 6 Roadside | 0113 6666666 | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 | 4819     |
 
   Scenario: Only return sites with requested access needs
     Given The following sites exist in the system
@@ -41,4 +41,4 @@
       | 50          | 100000        | -0.082   | -51.5    | attr_one,attr_two |
     Then the following sites and distances are returned
       | Site | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                                              | Longitude | Latitude | Distance |
-      | 9    | Site-9 | 9 Roadside | 0113 9999999 | R9     | ICB9 | accessibility/attr_one=true,accessibility/attr_two=true | -0.0827   | -51.5    | 49       |
+      | 9    | Site-9 | 9 Roadside | 0113 9999999 | R9     | ICB9 | accessibility/attr_one=true,accessibility/attr_two=true | -0.0827   | -51.5    | 48       |

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
@@ -30,7 +30,7 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         var longitude = row.Cells.ElementAt(2).Value;
         var latitude = row.Cells.ElementAt(3).Value;
         var accessNeeds = row.Cells.ElementAt(4).Value;
-        _response = await Http.GetAsync($"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&accessNeeds={accessNeeds}");
+        _response = await Http.GetAsync($"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&accessNeeds={accessNeeds}&ignoreCache=true");
         _statusCode = _response.StatusCode;
         (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(await _response.Content.ReadAsStreamAsync());
     }
@@ -43,7 +43,7 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         var searchRadiusNumber = row.Cells.ElementAt(1).Value;
         var longitude = row.Cells.ElementAt(2).Value;
         var latitude = row.Cells.ElementAt(3).Value;
-        _response = await Http.GetAsync($"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}");
+        _response = await Http.GetAsync($"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&ignoreCache=true");
         _statusCode = _response.StatusCode;
         (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(await _response.Content.ReadAsStreamAsync());
     }

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesByAreaFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesByAreaFunctionTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
@@ -15,7 +15,7 @@ namespace Nhs.Appointments.Api.Tests.Functions;
 
 public class GetSitesByAreaFunctionTests
 {
-    private readonly Mock<ISiteService> _siteService = new();
+    private readonly Mock<ISiteService> _siteService = new();    
     private readonly Mock<IValidator<GetSitesByAreaRequest>> _validator = new();
     private readonly Mock<IUserContextProvider> _userContextProvider = new();
     private readonly Mock<ILogger<GetSitesByAreaFunction>> _logger = new();
@@ -40,7 +40,7 @@ public class GetSitesByAreaFunctionTests
         var request = CreateRequest(34.6, 2.1, 10, 10, true, accessNeeds);
         var result = await _sut.RunAsync(request) as ContentResult;
         result?.StatusCode.Should().Be(400);
-        _siteService.Verify(x => x.FindSitesByArea(34.6, 2.1, 10, 10, Array.Empty<string>()), Times.Never());
+        _siteService.Verify(x => x.FindSitesByArea(34.6, 2.1, 10, 10, Array.Empty<string>(), false), Times.Never());
     }
 
     [Fact]
@@ -65,11 +65,11 @@ public class GetSitesByAreaFunctionTests
                     Location: new Location("point", [0.1, 10])),
                 Distance: 100)
         };
-        _siteService.Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds })).ReturnsAsync(sites);
+        _siteService.Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false)).ReturnsAsync(sites);
         var request = CreateRequest(longitude, latitude, searchRadius, maxRecords, true, accessNeeds);
         var result = await _sut.RunAsync(request) as ContentResult;
         result?.StatusCode.Should().Be(200);
-        _siteService.Verify(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }), Times.Once());
+        _siteService.Verify(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false), Times.Once());
     }
 
     [Fact]
@@ -93,18 +93,18 @@ public class GetSitesByAreaFunctionTests
                     Location: new Location("point", [0.1, 10])),
                 Distance: 100)
         };
-        _siteService.Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>())).ReturnsAsync(sites);
+        _siteService.Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false)).ReturnsAsync(sites);
         var request = CreateRequest(longitude, latitude, searchRadius, maxRecords, false);
         var result = await _sut.RunAsync(request) as ContentResult;
         result?.StatusCode.Should().Be(200);
-        _siteService.Verify(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>()), Times.Once());
+        _siteService.Verify(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false), Times.Once());
     }
 
 
     private static HttpRequest CreateRequest(double longitude, double latitude, int searchRadius, int maxRecords, bool includeAccessNeedsWhenEmpty, params string[] accessNeeds)
     {
         var context = new DefaultHttpContext();
-        var queryString = $"?long={longitude}&lat={latitude}&searchRadius={searchRadius}&maxRecords={maxRecords}";
+        var queryString = $"?long={longitude}&lat={latitude}&searchRadius={searchRadius}&maxRecords={maxRecords}&ignoreCache=false";
         if (accessNeeds.Any() || includeAccessNeedsWhenEmpty)
             queryString += $"&accessNeeds={string.Join(",", accessNeeds)}";
         var request = context.Request;

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Api.Validators;
 
@@ -18,7 +18,8 @@ public class GetSitesByAreaRequestValidatorTests
             0.123,
             50000,
             50,
-            ["access_need_a", "access_need_b"]
+            ["access_need_a", "access_need_b"],
+            false
         );
         
         var result = _sut.Validate(request);
@@ -37,7 +38,8 @@ public class GetSitesByAreaRequestValidatorTests
             latitude,
             50000,
             50,
-            ["access_need_a", "access_need_b"]
+            ["access_need_a", "access_need_b"],
+            false
         );
         
         var result = _sut.Validate(request);
@@ -56,7 +58,8 @@ public class GetSitesByAreaRequestValidatorTests
             0.456,
             searchRadius,
             50,
-            ["access_need_a", "access_need_b"]
+            ["access_need_a", "access_need_b"],
+            false
         );
         
         var result = _sut.Validate(request);
@@ -75,7 +78,8 @@ public class GetSitesByAreaRequestValidatorTests
             0.456,
             50000,
             maxRecords,
-            ["access_need_a", "access_need_b"]
+            ["access_need_a", "access_need_b"],
+            false
         );
         
         var result = _sut.Validate(request);
@@ -94,7 +98,8 @@ public class GetSitesByAreaRequestValidatorTests
             latitude,
             searchRadius,
             maxRecords,
-            ["access_need_a", "access_need_b"]
+            ["access_need_a", "access_need_b"],
+            false
         );
         var result = _sut.Validate(request);
         result.IsValid.Should().BeTrue();


### PR DESCRIPTION
This changes the way we run site searches. The function app will now do the heavy lifting by pulling all sites into a memory cache and doing the geospatial search, moving away from the search being in cosmos. The sites list will be stored in a cache which means that subsequent site search function calls will reuse existing functions, so even though the cost of getting all sites is greater (in terms of RUs on the database) the caching reduces the overall hit on the database. This has been tested in load test conditions and showed a significant reduction of load on the database. The cache is set for an absolute expiration of 10 minutes, this means that changes to site information may take 10 minutes to be reflected in site search