### PR TITLE
APPT-509: Introduce Orphaned appointment status and recalculate when availability changes

### DIFF
--- a/src/api/Nhs.Appointments.Core/AvailabilityCalculator.cs
+++ b/src/api/Nhs.Appointments.Core/AvailabilityCalculator.cs
@@ -3,10 +3,18 @@
 public interface IAvailabilityCalculator
 {
     Task<IEnumerable<SessionInstance>> CalculateAvailability(string site, string service, DateOnly from, DateOnly until);
+
+    IEnumerable<SessionInstance> GetAvailableSlots(IEnumerable<SessionInstance> sessions,
+        IEnumerable<Booking> bookings);
 }
 
 public class AvailabilityCalculator(IAvailabilityStore availabilityStore, IBookingsDocumentStore bookingDocumentStore, TimeProvider time) : IAvailabilityCalculator
 {
+    private readonly AppointmentStatus[] _liveStatuses = [AppointmentStatus.Booked, AppointmentStatus.Provisional];
+
+    private bool IsExpiredProvisional(Booking b) =>
+        b.Status == AppointmentStatus.Provisional && b.Created < time.GetUtcNow().AddMinutes(-5);
+
     public async Task<IEnumerable<SessionInstance>> CalculateAvailability(string site, string service, DateOnly from, DateOnly until)
     {
         var allSessions = await availabilityStore.GetSessions(site, from, until);
@@ -14,33 +22,42 @@ public class AvailabilityCalculator(IAvailabilityStore availabilityStore, IBooki
             ? allSessions
             : allSessions.Where(s => s.Services.Contains(service));
 
-        if (filteredSessions.Any())
+        var bookings = await bookingDocumentStore.GetInDateRangeAsync(from.ToDateTime(new TimeOnly(0, 0)),
+            until.ToDateTime(new TimeOnly(23, 59)), site);
+
+        return GetAvailableSlots(filteredSessions, bookings);
+    }
+
+    public IEnumerable<SessionInstance> GetAvailableSlots(IEnumerable<SessionInstance> sessions,
+        IEnumerable<Booking> bookings)
+    {
+        var slots = new List<SessionInstance>();
+        foreach (var session in sessions)
         {
-            var slots = new List<SessionInstance>();
-            foreach (var session in filteredSessions)
-            {
-                slots.AddRange(session.Divide(TimeSpan.FromMinutes(session.SlotLength)).Select(sl => new SessionInstance(sl) { Services = session.Services, Capacity = session.Capacity }));
-            }
-
-            var bookings = await bookingDocumentStore.GetInDateRangeAsync(from.ToDateTime(new TimeOnly(0, 0)), until.ToDateTime(new TimeOnly(23, 59)), site);
-
-            var liveStatuses = new[] { AppointmentStatus.Booked, AppointmentStatus.Provisional };
-            var isExpiredProvisional = (Booking b) => b.Status == AppointmentStatus.Provisional && b.Created < time.GetUtcNow().AddMinutes(-5);
-            var liveBookings = bookings
-                .Where(b => liveStatuses.Contains(b.Status))
-                .Where(b => isExpiredProvisional(b) == false);
-
-            foreach (var booking in liveBookings)
-            {
-                var slot = slots.FirstOrDefault(s => s.Capacity > 0 && s.From == booking.From && s.Duration.TotalMinutes == booking.Duration && s.Services.Contains(booking.Service));
-                if(slot != null)
-                {
-                    slot.Capacity--;
-                }
-            }
-
-            return slots.Where(s => s.Capacity > 0);
+            slots.AddRange(session.Divide(TimeSpan.FromMinutes(session.SlotLength)).Select(sl =>
+                new SessionInstance(sl) { Services = session.Services, Capacity = session.Capacity }));
         }
-        return Enumerable.Empty<SessionInstance>();
+
+        if (slots.Count == 0)
+        {
+            return [];
+        }
+
+        var liveBookings = bookings
+            .Where(b => _liveStatuses.Contains(b.Status))
+            .Where(b => IsExpiredProvisional(b) == false);
+
+        foreach (var booking in liveBookings)
+        {
+            var slot = slots.FirstOrDefault(s =>
+                s.Capacity > 0 && s.From == booking.From && (int)s.Duration.TotalMinutes == booking.Duration &&
+                s.Services.Contains(booking.Service));
+            if (slot != null)
+            {
+                slot.Capacity--;
+            }
+        }
+
+        return slots.Where(s => s.Capacity > 0);
     }
 }

--- a/src/api/Nhs.Appointments.Core/Booking.cs
+++ b/src/api/Nhs.Appointments.Core/Booking.cs
@@ -1,5 +1,4 @@
 using Newtonsoft.Json;
-using System.Text.Json;
 
 namespace Nhs.Appointments.Core;
 
@@ -76,5 +75,6 @@ public enum AppointmentStatus
     Unknown,
     Provisional,
     Booked,
-    Cancelled
+    Cancelled,
+    Orphaned
 }

--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -171,16 +171,17 @@ public class BookingsService(
 
             if (canScheduleBooking)
             {
-                recalculatedScheduledBookings.Add(booking);
                 if (booking.Status != AppointmentStatus.Booked)
                 {
                     await SetBookingStatus(booking.Reference, AppointmentStatus.Booked);
+                    booking.Status = AppointmentStatus.Booked;
                 }
 
-                return;
+                recalculatedScheduledBookings.Add(booking);
+                continue;
             }
 
-            if (booking.Status == AppointmentStatus.Booked)
+            if (booking.Status is AppointmentStatus.Booked or AppointmentStatus.Provisional)
             {
                 await SetBookingStatus(booking.Reference, AppointmentStatus.Orphaned);
             }

--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -155,6 +155,7 @@ public class BookingsService(
         var dayEnd = day.ToDateTime(new TimeOnly(23, 59));
 
         var bookings = (await GetBookings(dayStart, dayEnd, site))
+            .Where(b => b.Status is not AppointmentStatus.Cancelled)
             .OrderBy(b => b.Created);
 
         var sessionsOnThatDay =

--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -15,6 +15,7 @@ public interface IBookingsService
     Task SendBookingReminders();
     Task<BookingConfirmationResult> ConfirmProvisionalBooking(string bookingReference, IEnumerable<ContactItem> contactDetails, string bookingToReschedule);
     Task<IEnumerable<string>> RemoveUnconfirmedProvisionalBookings();
+    Task RecalculateAppointmentStatuses(string site, DateOnly day);
 }    
 
 public class BookingsService(
@@ -87,6 +88,7 @@ public class BookingsService(
         }
 
         await bookingDocumentStore.UpdateStatus(bookingReference, AppointmentStatus.Cancelled);
+        await RecalculateAppointmentStatuses(booking.Site, DateOnly.FromDateTime(booking.From));
 
         if (booking.ContactDetails != null)
         {

--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -167,7 +167,7 @@ public class BookingsService(
             var availableSlots =
                 availabilityCalculator.GetAvailableSlots(sessionsOnThatDay, recalculatedScheduledBookings);
             var canScheduleBooking = availableSlots.Any(sl =>
-                sl.From == booking.From && (int)sl.Duration.TotalMinutes == extantBooking.Duration);
+                sl.From == booking.From && (int)sl.Duration.TotalMinutes == booking.Duration);
 
             if (canScheduleBooking)
             {
@@ -176,6 +176,8 @@ public class BookingsService(
                 {
                     await SetBookingStatus(booking.Reference, AppointmentStatus.Booked);
                 }
+
+                return;
             }
 
             if (booking.Status == AppointmentStatus.Booked)

--- a/src/api/Nhs.Appointments.Core/ScheduleTemplate.cs
+++ b/src/api/Nhs.Appointments.Core/ScheduleTemplate.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 namespace Nhs.Appointments.Core;
@@ -34,6 +34,8 @@ public class SessionInstance : TimePeriod
     public string[] Services { get; set; }
     public int SlotLength { get; set; }
     public int Capacity { get; set; }
+    public IEnumerable<SessionInstance> ToSlots() => Divide(TimeSpan.FromMinutes(SlotLength)).Select(sl =>
+                new SessionInstance(sl) { Services = Services, Capacity = Capacity });
 }
 
 public class Template

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AutoMapper;
+using Gherkin.Ast;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Linq;
 using Nhs.Appointments.Api.Json;
@@ -14,6 +15,8 @@ using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance;
 using Nhs.Appointments.Persistance.Models;
 using Xunit.Gherkin.Quick;
+using Feature = Xunit.Gherkin.Quick.Feature;
+using Location = Nhs.Appointments.Core.Location;
 using Role = Nhs.Appointments.Persistance.Models.Role;
 using RoleAssignment = Nhs.Appointments.Persistance.Models.RoleAssignment;
 
@@ -88,14 +91,14 @@ public abstract partial class BaseFeatureSteps : Feature
 
     [Given("the following sessions")]
     [And("the following sessions")]
-    public Task SetupSessions(Gherkin.Ast.DataTable dataTable)
+    public Task SetupSessions(DataTable dataTable)
     {
         return SetupSessions("A", dataTable);
     }
 
     [Given(@"the following sessions for site '(\w)'")]
     [And(@"the following sessions for site '(\w)'")]
-    public async Task SetupSessions(string siteDesignation, Gherkin.Ast.DataTable dataTable)
+    public async Task SetupSessions(string siteDesignation, DataTable dataTable)
     {
         var site = GetSiteId(siteDesignation);
         var availabilityDocuments = DailyAvailabilityDocumentsFromTable(site, dataTable);
@@ -115,7 +118,8 @@ public abstract partial class BaseFeatureSteps : Feature
         return nhsNumber == "*" ? NhsNumber : nhsNumber;
     }
 
-    protected IEnumerable<DailyAvailabilityDocument> DailyAvailabilityDocumentsFromTable(string site, Gherkin.Ast.DataTable dataTable)
+    protected IEnumerable<DailyAvailabilityDocument> DailyAvailabilityDocumentsFromTable(string site,
+        DataTable dataTable)
     {
         var sessions = dataTable.Rows.Skip(1).Select((row, index) => new DailyAvailabilityDocument
         {
@@ -210,52 +214,57 @@ public abstract partial class BaseFeatureSteps : Feature
 
     [Given("the following bookings have been made")]
     [And("the following bookings have been made")]
-    public Task SetupBookings(Gherkin.Ast.DataTable dataTable)
+    public Task SetupBookings(DataTable dataTable)
     {
         return SetupBookings("A", dataTable);
     }
 
     [And(@"the following bookings have been made for site '(\w)'")]
-    public Task SetupBookings(string siteDesignation, Gherkin.Ast.DataTable dataTable)
+    public Task SetupBookings(string siteDesignation, DataTable dataTable)
     {
         return SetupBookings(siteDesignation, dataTable, BookingType.Confirmed);
     }
 
     [Given("the following recent bookings have been made")]
     [And("the following recent bookings have been made")]
-    public Task SetupRecentBookings(Gherkin.Ast.DataTable dataTable)
+    public Task SetupRecentBookings(DataTable dataTable)
     {
         return SetupBookings("A", dataTable, BookingType.Recent);
     }
 
     [Given("the following provisional bookings have been made")]
     [And("the following provisional bookings have been made")]
-    public Task SetupProvisionalBookings(Gherkin.Ast.DataTable dataTable)
+    public Task SetupProvisionalBookings(DataTable dataTable)
     {
         return SetupBookings("A", dataTable, BookingType.Provisional);
     }
 
     [Given("the following expired provisional bookings have been made")]
     [And("the following expired provisional bookings have been made")]
-    public Task SetupExpiredProvisionalBookings(Gherkin.Ast.DataTable dataTable)
+    public Task SetupExpiredProvisionalBookings(DataTable dataTable)
     {
         return SetupBookings("A", dataTable, BookingType.ExpiredProvisional);
     }
 
-    protected async Task SetupBookings(string siteDesignation, Gherkin.Ast.DataTable dataTable, BookingType bookingType)
+    [And("the following orphaned bookings exist")]
+    public Task SetupOrphanedBookings(DataTable dataTable) => SetupBookings("A", dataTable, BookingType.Orphaned);
+
+    protected async Task SetupBookings(string siteDesignation, DataTable dataTable, BookingType bookingType)
     {
         var bookings = dataTable.Rows.Skip(1).Select((row, index) => new BookingDocument
         {
-            Id = BookingReferences.GetBookingReference(index, bookingType),
+            Id = row.Cells.ElementAtOrDefault(4)?.Value ??
+                 BookingReferences.GetBookingReference(index, bookingType),
             DocumentType = "booking",
-            Reference = BookingReferences.GetBookingReference(index, bookingType),
+            Reference = row.Cells.ElementAtOrDefault(4)?.Value ??
+                        BookingReferences.GetBookingReference(index, bookingType),
             From = DateTime.ParseExact($"{ParseNaturalLanguageDateOnly(row.Cells.ElementAt(0).Value).ToString("yyyy-MM-dd")} {row.Cells.ElementAt(1).Value}", "yyyy-MM-dd HH:mm", null),
             Duration = int.Parse(row.Cells.ElementAt(2).Value),
             Service = row.Cells.ElementAt(3).Value,
             Site = GetSiteId(siteDesignation),
             Status = MapStatus(bookingType),
             Created = GetCreationDateTime(bookingType),
-            AttendeeDetails = new Core.AttendeeDetails
+            AttendeeDetails = new AttendeeDetails
             {
                 NhsNumber = NhsNumber,
                 FirstName = "FirstName",
@@ -277,10 +286,12 @@ public abstract partial class BaseFeatureSteps : Feature
         var bookingIndexDocuments = dataTable.Rows.Skip(1).Select(
             (row, index) => new BookingIndexDocument
             {
-                Reference = BookingReferences.GetBookingReference(index, bookingType),
+                Reference = row.Cells.ElementAtOrDefault(4)?.Value ??
+                            BookingReferences.GetBookingReference(index, bookingType),
                 Site = GetSiteId(),
                 DocumentType = "booking_index",
-                Id = BookingReferences.GetBookingReference(index, bookingType),
+                Id = row.Cells.ElementAtOrDefault(4)?.Value ??
+                     BookingReferences.GetBookingReference(index, bookingType),
                 NhsNumber = NhsNumber,
                 Status = MapStatus(bookingType),
                 Created = GetCreationDateTime(bookingType),
@@ -306,6 +317,7 @@ public abstract partial class BaseFeatureSteps : Feature
         BookingType.Confirmed => DateTime.UtcNow.AddHours(-48),
         BookingType.Provisional => DateTime.UtcNow.AddMinutes(-2),
         BookingType.ExpiredProvisional => DateTime.UtcNow.AddMinutes(-8),
+        BookingType.Orphaned => DateTime.UtcNow.AddHours(-64),
         _ => throw new ArgumentOutOfRangeException(nameof(type))
     };
 
@@ -332,6 +344,7 @@ public abstract partial class BaseFeatureSteps : Feature
         BookingType.Confirmed => AppointmentStatus.Booked,
         BookingType.Provisional => AppointmentStatus.Provisional,
         BookingType.ExpiredProvisional => AppointmentStatus.Provisional,
+        BookingType.Orphaned => AppointmentStatus.Orphaned,
         _ => throw new ArgumentOutOfRangeException(nameof(bookingType)),
     };
     
@@ -453,7 +466,7 @@ public abstract partial class BaseFeatureSteps : Feature
         return results;
     }
 
-    public enum BookingType { Recent, Confirmed, Provisional, ExpiredProvisional}
+    public enum BookingType { Recent, Confirmed, Provisional, ExpiredProvisional, Orphaned }
 
     [GeneratedRegex("^(?<format>Today|today|Tomorrow|tomorrow|Yesterday|yesterday|(((?<magnitude>[0-9]+) (?<period>days|day|weeks|week|months|month|years|year) (?<direction>from|before) (now|today))))$")]
     private static partial Regex NaturalLanguageRelativeDate();

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
@@ -40,42 +40,6 @@ public abstract class BookingBaseFeatureSteps : BaseFeatureSteps
         Response = await Http.PostAsJsonAsync($"http://localhost:7071/api/booking", payload);
     }
     
-    [And(@"the original booking has been '(\w+)'")]
-    public Task AssertRescheduledBookingStatus(string outcome)
-    {
-        return AssertBookingStatus(outcome);
-    }
-    
-    [Then(@"the booking has been '(\w+)'")]
-    public async Task AssertBookingStatus(string status)
-    {
-        var expectedStatus = Enum.Parse<AppointmentStatus>(status);
-        var bookingReference = BookingReferences.GetBookingReference(0, BookingType.Confirmed);
-
-        await AssertBookingStatusByReference(bookingReference, expectedStatus);
-    }
-
-    [Then(@"the booking with reference '(.+)' has been '(.+)'")]
-    public async Task AssertSpecificBookingStatus(string bookingReference, string status)
-    {
-        var expectedStatus = Enum.Parse<AppointmentStatus>(status);
-
-        await AssertBookingStatusByReference(bookingReference, expectedStatus);
-    }
-
-    private async Task AssertBookingStatusByReference(string bookingReference, AppointmentStatus status)
-    {
-        var siteId = GetSiteId();
-        var bookingDocument = await Client.GetContainer("appts", "booking_data")
-            .ReadItemAsync<BookingDocument>(bookingReference, new PartitionKey(siteId));
-        bookingDocument.Resource.Status.Should().Be(status);
-        bookingDocument.Resource.StatusUpdated.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(10));
-
-        var indexDocument = await Client.GetContainer("appts", "index_data")
-            .ReadItemAsync<BookingDocument>(bookingReference, new PartitionKey("booking_index"));
-        indexDocument.Resource.Status.Should().Be(status);
-    }
-    
     [Then(@"the call should fail with (\d*)")]
     public void AssertFailureCode(int statusCode) => Response.StatusCode.Should().Be((HttpStatusCode)statusCode);
 }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Gherkin.Ast;
+using Microsoft.Azure.Cosmos;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
 using Xunit.Gherkin.Quick;
@@ -14,7 +17,7 @@ public abstract class BookingBaseFeatureSteps : BaseFeatureSteps
     protected HttpResponseMessage Response { get; set; }
     
     [When("I make a provisional appointment with the following details")]
-    public async Task MakeProvisionalBooking(Gherkin.Ast.DataTable dataTable)
+    public async Task MakeProvisionalBooking(DataTable dataTable)
     {
         var cells = dataTable.Rows.ElementAt(1).Cells;
 
@@ -47,21 +50,32 @@ public abstract class BookingBaseFeatureSteps : BaseFeatureSteps
     public async Task AssertBookingStatus(string status)
     {
         var expectedStatus = Enum.Parse<AppointmentStatus>(status);
-        Response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
-
-        var siteId = GetSiteId();
         var bookingReference = BookingReferences.GetBookingReference(0, BookingType.Confirmed);
-        var bookingDocument = await Client.GetContainer("appts", "booking_data").ReadItemAsync<BookingDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey(siteId));            
-        bookingDocument.Resource.Status.Should().Be(expectedStatus);
+
+        await AssertBookingStatusByReference(bookingReference, expectedStatus);
+    }
+
+    [Then(@"the booking with reference '(.+)' has been '(.+)'")]
+    public async Task AssertSpecificBookingStatus(string bookingReference, string status)
+    {
+        var expectedStatus = Enum.Parse<AppointmentStatus>(status);
+
+        await AssertBookingStatusByReference(bookingReference, expectedStatus);
+    }
+
+    private async Task AssertBookingStatusByReference(string bookingReference, AppointmentStatus status)
+    {
+        var siteId = GetSiteId();
+        var bookingDocument = await Client.GetContainer("appts", "booking_data")
+            .ReadItemAsync<BookingDocument>(bookingReference, new PartitionKey(siteId));
+        bookingDocument.Resource.Status.Should().Be(status);
         bookingDocument.Resource.StatusUpdated.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(10));
 
-        var indexDocument = await Client.GetContainer("appts", "index_data").ReadItemAsync<BookingDocument>(bookingReference, new Microsoft.Azure.Cosmos.PartitionKey("booking_index"));
-        indexDocument.Resource.Status.Should().Be(expectedStatus);
+        var indexDocument = await Client.GetContainer("appts", "index_data")
+            .ReadItemAsync<BookingDocument>(bookingReference, new PartitionKey("booking_index"));
+        indexDocument.Resource.Status.Should().Be(status);
     }
     
     [Then(@"the call should fail with (\d*)")]
-    public void AssertFailureCode(int statusCode)
-    {
-        Response.StatusCode.Should().Be((System.Net.HttpStatusCode)statusCode);
-    }
+    public void AssertFailureCode(int statusCode) => Response.StatusCode.Should().Be((HttpStatusCode)statusCode);
 }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Cancel.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Cancel.feature
@@ -1,11 +1,25 @@
 ﻿Feature: Appointment cancellation
 
-    Scenario: Cancel a booking appointment
-        Given the following sessions
-          | Date     | From  | Until | Services | Slot Length | Capacity |
-          | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
-        And the following bookings have been made
-          | Date     | Time  | Duration | Service |
-          | Tomorrow | 09:20 | 5        | COVID   |
-        When I cancel the appointment
-        Then the booking has been 'Cancelled'
+  Scenario: Cancel a booking appointment
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following bookings have been made
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:20 | 5        | COVID   |
+    When I cancel the appointment
+    Then the booking has been 'Cancelled'
+
+  Scenario: Cancel a booking appointment which can be replaced by an orphaned appointment
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following bookings have been made
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:20 | 5        | COVID   | 68374-29374 |
+    And the following orphaned bookings exist
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:20 | 5        | COVID   | 85032-19283 |
+    When I cancel the appointment with reference '68374-29374'
+    Then the booking with reference '68374-29374' has been 'Cancelled'
+    Then the booking with reference '85032-19283' has been 'Booked'

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/CancelFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/CancelFeatureSteps.cs
@@ -1,18 +1,19 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Xunit.Gherkin.Quick;
 
-namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
+namespace Nhs.Appointments.Api.Integration.Scenarios.Booking;
+
+[FeatureFile("./Scenarios/Booking/Cancel.feature")]
+public sealed class CancelFeatureSteps : BookingBaseFeatureSteps
 {
-    [FeatureFile("./Scenarios/Booking/Cancel.feature")]
-    public sealed class CancelFeatureSteps : BookingBaseFeatureSteps
+    [When(@"I cancel the appointment")]
+    public async Task CancelAppointment()
     {
-        [When(@"I cancel the appointment")]
-        public async Task CancelAppointment()
-        {
-            var bookingReference = BookingReferences.GetBookingReference(0, BookingType.Confirmed);
-            Response = await Http.PostAsync($"http://localhost:7071/api/booking/{bookingReference}/cancel", null);
-        }
+        var bookingReference = BookingReferences.GetBookingReference(0, BookingType.Confirmed);
+        Response = await Http.PostAsync($"http://localhost:7071/api/booking/{bookingReference}/cancel", null);
     }
+
+    [When(@"I cancel the appointment with reference '(.+)'")]
+    public async Task CancelAppointmentWithReference(string reference) => Response =
+        await Http.PostAsync($"http://localhost:7071/api/booking/{reference}/cancel", null);
 }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/ApplyAvailabilityTemplate.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/ApplyAvailabilityTemplate.feature
@@ -16,18 +16,18 @@
 
   Scenario: Overwrites existing daily availability
     Given the following sessions
-      | Date              | From  | Until | Services | Slot Length | Capacity |
-      | Tomorrow          | 09:00 | 17:00 | COVID    | 5           | 2        |
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 17:00 | COVID    | 5           | 2        |
     When I apply the following availability template
-      | From     | Until             | Days     | TimeFrom | TimeUntil | SlotLength  | Capacity | Services | Mode      |
-      | Tomorrow | 2 days from today | Relative | 11:00    | 12:00     | 10          | 1        | RSV      | Overwrite | 
+      | From     | Until             | Days     | TimeFrom | TimeUntil | SlotLength | Capacity | Services | Mode      |
+      | Tomorrow | 2 days from today | Relative | 11:00    | 12:00     | 10         | 1        | RSV      | Overwrite |
     Then the request is successful and the following daily availability sessions are created
-      | Date              | From  | Until | Services | Slot Length  | Capacity |
-      | Tomorrow          | 11:00 | 12:00 | RSV      | 10           | 1        |
-      | 2 days from today | 11:00 | 12:00 | RSV      | 10           | 1        |
+      | Date              | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow          | 11:00 | 12:00 | RSV      | 10          | 1        |
+      | 2 days from today | 11:00 | 12:00 | RSV      | 10          | 1        |
     And the following availability created events are created
-      | Type     | By       | FromDate | ToDate            | Template_Days | FromTime | UntilTime | SlotLength  | Capacity | Services |
-      | Template | api@test | Tomorrow | 2 days from today | Relative      | 11:00    | 12:00     | 10          | 1        | RSV      |
+      | Type     | By       | FromDate | ToDate            | Template_Days | FromTime | UntilTime | SlotLength | Capacity | Services |
+      | Template | api@test | Tomorrow | 2 days from today | Relative      | 11:00    | 12:00     | 10         | 1        | RSV      |
 
   Scenario: Can add new sessions to existing availability
     Given the following sessions
@@ -37,28 +37,38 @@
       | From     | Until             | Days     | TimeFrom | TimeUntil | SlotLength | Capacity | Services | Mode     |
       | Tomorrow | 2 days from today | Relative | 09:00    | 10:00     | 10         | 2        | COVID    | Additive |
     Then the request is successful and the following daily availability sessions are created
-      | Date              | From  | Until | Services |  Slot Length | Capacity |
-      | Tomorrow          | 09:00 | 17:00 | COVID    | 5            | 1        |
-      | Tomorrow          | 09:00 | 10:00 | COVID    | 10           | 2        |
-      | 2 days from today | 09:00 | 10:00 | COVID    | 10           | 2        |
+      | Date              | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow          | 09:00 | 17:00 | COVID    | 5           | 1        |
+      | Tomorrow          | 09:00 | 10:00 | COVID    | 10          | 2        |
+      | 2 days from today | 09:00 | 10:00 | COVID    | 10          | 2        |
     And the following availability created events are created
-      | Type     | By       | FromDate | ToDate            | Template_Days | FromTime | UntilTime | SlotLength  | Capacity | Services |
-      | Template | api@test | Tomorrow | 2 days from today | Relative      | 09:00    | 10:00     | 10          | 2        | COVID    |
+      | Type     | By       | FromDate | ToDate            | Template_Days | FromTime | UntilTime | SlotLength | Capacity | Services |
+      | Template | api@test | Tomorrow | 2 days from today | Relative      | 09:00    | 10:00     | 10         | 2        | COVID    |
 
   Scenario: Can add new sessions to 2 different availability periods
     Given the following sessions
-      | Date              | From  | Until | Services | Slot Length  | Capacity |
-      | Tomorrow          | 09:00 | 17:00 | COVID    | 5            | 2        |
-      | 2 days from today | 13:00 | 15:00 | RSV      | 10           | 1        |
+      | Date              | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow          | 09:00 | 17:00 | COVID    | 5           | 2        |
+      | 2 days from today | 13:00 | 15:00 | RSV      | 10          | 1        |
     When I apply the following availability template
       | From     | Until             | Days     | TimeFrom | TimeUntil | SlotLength | Capacity | Services | Mode     |
       | Tomorrow | 2 days from today | Relative | 09:00    | 10:00     | 15         | 3        | FLU      | Additive |
     Then the request is successful and the following daily availability sessions are created
-      | Date              | From  | Until | Services |  Slot Length  | Capacity |
-      | Tomorrow          | 09:00 | 17:00 | COVID    | 5             | 2        |
-      | Tomorrow          | 09:00 | 10:00 | FLU      | 15            | 3        |
-      | 2 days from today | 13:00 | 15:00 | RSV      | 10            | 1        |
-      | 2 days from today | 09:00 | 10:00 | FLU      | 15            | 3        |
+      | Date              | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow          | 09:00 | 17:00 | COVID    | 5           | 2        |
+      | Tomorrow          | 09:00 | 10:00 | FLU      | 15          | 3        |
+      | 2 days from today | 13:00 | 15:00 | RSV      | 10          | 1        |
+      | 2 days from today | 09:00 | 10:00 | FLU      | 15          | 3        |
     And the following availability created events are created
-      | Type     | By       | FromDate | ToDate            | Template_Days | FromTime | UntilTime | SlotLength  | Capacity | Services |
-      | Template | api@test | Tomorrow | 2 days from today | Relative      | 09:00    | 10:00     | 15          | 3        | FLU      |
+      | Type     | By       | FromDate | ToDate            | Template_Days | FromTime | UntilTime | SlotLength | Capacity | Services |
+      | Template | api@test | Tomorrow | 2 days from today | Relative      | 09:00    | 10:00     | 15         | 3        | FLU      |
+
+  Scenario: Appointment status is recalculated after an availability template is applied
+    Given there is no existing availability
+    And the following orphaned bookings exist
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:20 | 5        | COVID   | 57492-10293 |
+    When I apply the following availability template
+      | From     | Until             | Days     | TimeFrom | TimeUntil | SlotLength | Capacity | Services | Mode      |
+      | Tomorrow | 2 days from today | Relative | 09:00    | 10:00     | 5          | 3        | COVID    | Overwrite |
+    Then the booking with reference '57492-10293' has been 'Booked'

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/SetAvailability.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/SetAvailability.feature
@@ -14,29 +14,39 @@
 
   Scenario: Overwrite existing availability for a single day
     Given the following sessions
-      | Date              | From  | Until | Services | Slot Length | Capacity |
-      | Tomorrow          | 09:00 | 17:00 | COVID    | 5           | 2        |
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 17:00 | COVID    | 5           | 2        |
     When I apply the following availability
-      | Date     | From  | Until | SlotLength  | Capacity | Services | Mode      |
-      | Tomorrow | 12:00 | 15:00 | 10          | 2        | FLU      | Overwrite |
+      | Date     | From  | Until | SlotLength | Capacity | Services | Mode      |
+      | Tomorrow | 12:00 | 15:00 | 10         | 2        | FLU      | Overwrite |
     Then the request is successful and the following daily availability sessions are created
-      | Date     | From  | Until | Services | Slot Length  | Capacity |
-      | Tomorrow | 12:00 | 15:00 | FLU      | 10           | 2        |
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 12:00 | 15:00 | FLU      | 10          | 2        |
     And the following availability created events are created
-      | Type              | By       | FromDate | ToDate | Template_Days | FromTime | UntilTime | SlotLength  | Capacity | Services |
-      | SingleDateSession | api@test | Tomorrow |        |               | 12:00    | 15:00     | 10          | 2        | FLU      |
+      | Type              | By       | FromDate | ToDate | Template_Days | FromTime | UntilTime | SlotLength | Capacity | Services |
+      | SingleDateSession | api@test | Tomorrow |        |               | 12:00    | 15:00     | 10         | 2        | FLU      |
 
   Scenario: Can add new sessions to existing availability for a single day
     Given the following sessions
       | Date     | From  | Until | Services | Slot Length | Capacity |
       | Tomorrow | 09:00 | 17:00 | COVID    | 5           | 2        |
     When I apply the following availability
-      | Date     | From  | Until | SlotLength  | Capacity | Services | Mode     |
-      | Tomorrow | 12:00 | 15:00 | 10          | 2        | FLU      | Additive |
+      | Date     | From  | Until | SlotLength | Capacity | Services | Mode     |
+      | Tomorrow | 12:00 | 15:00 | 10         | 2        | FLU      | Additive |
     Then the request is successful and the following daily availability sessions are created
       | Date     | From  | Until | Services | Slot Length | Capacity |
       | Tomorrow | 09:00 | 17:00 | COVID    | 5           | 2        |
       | Tomorrow | 12:00 | 15:00 | FLU      | 10          | 2        |
     And the following availability created events are created
-      | Type              | By       | FromDate | ToDate | Template_Days | FromTime | UntilTime | SlotLength  | Capacity | Services |
-      | SingleDateSession | api@test | Tomorrow |        |               | 12:00    | 15:00     | 10          | 2        | FLU      |
+      | Type              | By       | FromDate | ToDate | Template_Days | FromTime | UntilTime | SlotLength | Capacity | Services |
+      | SingleDateSession | api@test | Tomorrow |        |               | 12:00    | 15:00     | 10         | 2        | FLU      |
+
+  Scenario: Appointment status is recalculated after availability is created
+    Given there is no existing availability
+    And the following orphaned bookings exist
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:20 | 5        | COVID   | 37492-16293 |
+    When I apply the following availability
+      | Date     | From  | Until | SlotLength | Capacity | Services | Mode      |
+      | Tomorrow | 09:00 | 17:00 | 5          | 1        | COVID    | Overwrite |
+    Then the booking with reference '37492-16293' has been 'Booked'

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingsServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingsServiceTests.cs
@@ -379,7 +379,8 @@ namespace Nhs.Appointments.Core.UnitTests
                         Reference = "1",
                         AttendeeDetails = new AttendeeDetails { FirstName = "Daniel", LastName = "Dixon" },
                         Status = AppointmentStatus.Booked,
-                        Duration = 10
+                        Duration = 10,
+                        Service = "Service 1"
                     },
                     new()
                     {
@@ -387,7 +388,8 @@ namespace Nhs.Appointments.Core.UnitTests
                         Reference = "2",
                         AttendeeDetails = new AttendeeDetails { FirstName = "Alexander", LastName = "Cooper" },
                         Status = AppointmentStatus.Booked,
-                        Duration = 10
+                        Duration = 10,
+                        Service = "Service 1"
                     },
                     new()
                     {
@@ -395,7 +397,8 @@ namespace Nhs.Appointments.Core.UnitTests
                         Reference = "3",
                         AttendeeDetails = new AttendeeDetails { FirstName = "Alexander", LastName = "Brown" },
                         Status = AppointmentStatus.Booked,
-                        Duration = 10
+                        Duration = 10,
+                        Service = "Service 1"
                     },
                     new()
                     {
@@ -403,7 +406,8 @@ namespace Nhs.Appointments.Core.UnitTests
                         Reference = "4",
                         AttendeeDetails = new AttendeeDetails { FirstName = "Bob", LastName = "Dawson" },
                         Status = AppointmentStatus.Booked,
-                        Duration = 10
+                        Duration = 10,
+                        Service = "Service 1"
                     }
                 };
 
@@ -450,7 +454,8 @@ namespace Nhs.Appointments.Core.UnitTests
                         Reference = "1",
                         AttendeeDetails = new AttendeeDetails { FirstName = "Daniel", LastName = "Dixon" },
                         Status = AppointmentStatus.Orphaned,
-                        Duration = 10
+                        Duration = 10,
+                        Service = "Service 1"
                     },
                     new()
                     {
@@ -458,7 +463,8 @@ namespace Nhs.Appointments.Core.UnitTests
                         Reference = "2",
                         AttendeeDetails = new AttendeeDetails { FirstName = "Alexander", LastName = "Cooper" },
                         Status = AppointmentStatus.Orphaned,
-                        Duration = 10
+                        Duration = 10,
+                        Service = "Service 1"
                     }
                 };
 

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingsServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingsServiceTests.cs
@@ -11,6 +11,7 @@ namespace Nhs.Appointments.Core.UnitTests
         private readonly Mock<IReferenceNumberProvider> _referenceNumberProvider = new();
         private readonly Mock<ISiteLeaseManager> _siteLeaseManager = new();
         private readonly Mock<IAvailabilityCalculator> _availabilityCalculator = new();
+        private readonly Mock<IAvailabilityStore> _availabilityStore = new();
         private readonly Mock<IMessageBus> _messageBus = new();
 
         public BookingsServiceTests()
@@ -20,6 +21,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 _referenceNumberProvider.Object,
                 _siteLeaseManager.Object,
                 _availabilityCalculator.Object,
+                _availabilityStore.Object,
                 new EventFactory(),
                 _messageBus.Object,
                 TimeProvider.System);
@@ -39,7 +41,9 @@ namespace Nhs.Appointments.Core.UnitTests
             _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync("TEST1");
 
             var leaseManager = new FakeLeaseManager();
-            var bookingService = new BookingsService(_bookingsDocumentStore.Object, _referenceNumberProvider.Object, leaseManager, _availabilityCalculator.Object, new EventFactory(), _messageBus.Object, TimeProvider.System);
+            var bookingService = new BookingsService(_bookingsDocumentStore.Object, _referenceNumberProvider.Object,
+                leaseManager, _availabilityCalculator.Object, _availabilityStore.Object, new EventFactory(),
+                _messageBus.Object, TimeProvider.System);
             
             var task = Task.Run(() => bookingService.MakeBooking(booking));
             await Task.Delay(100);


### PR DESCRIPTION
- Introduces the concept of "Orphaned" appointments and extends the `AppointmentStatus` enum
- Creates a method for programmatically re-assessing the status of every appointment for a given day, adopting any orphans if possible and orphaning any scheduled appointments if needed.
- Calls this method after single day availability is created, availability templates are applied, or appointments are cancelled. 
- Adds tests for all the above