### PR TITLE
APPT-364: Prevent the availability re-calculator from flipping supported provisional bookings

### DIFF
--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -173,7 +173,7 @@ public class BookingsService(
 
             if (targetSlot != null)
             {
-                if (booking.Status != AppointmentStatus.Booked)
+                if (booking.Status != AppointmentStatus.Booked && booking.Status != AppointmentStatus.Provisional)
                 {
                     await SetBookingStatus(booking.Reference, AppointmentStatus.Booked);
                     booking.Status = AppointmentStatus.Booked;

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/ApplyAvailabilityTemplate.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/ApplyAvailabilityTemplate.feature
@@ -72,8 +72,13 @@
     And the following orphaned bookings exist
       | Date     | Time  | Duration | Service | Reference   |
       | Tomorrow | 09:20 | 5        | COVID   | 57492-10293 |
+    And the following provisional bookings have been made
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:30 | 5        | COVID   | 19283-50682 |
     When I apply the following availability template
       | From     | Until             | Days     | TimeFrom | TimeUntil | SlotLength | Capacity | Services | Mode      |
       | Tomorrow | 2 days from today | Relative | 09:00    | 10:00     | 5          | 3        | COVID    | Overwrite |
     Then the booking with reference '57492-10293' has been 'Booked'
+    And the booking with reference '19283-50682' has status 'Provisional'
     And an audit function document was created for user 'api@test' and function 'ApplyAvailabilityTemplateFunction'
+    

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/SetAvailability.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/SetAvailability.feature
@@ -49,10 +49,14 @@
     And the following orphaned bookings exist
       | Date     | Time  | Duration | Service | Reference   |
       | Tomorrow | 09:20 | 5        | COVID   | 37492-16293 |
+    And the following provisional bookings have been made
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:30 | 5        | COVID   | 79237-10283 |
     When I apply the following availability
       | Date     | From  | Until | SlotLength | Capacity | Services | Mode      |
       | Tomorrow | 09:00 | 17:00 | 5          | 1        | COVID    | Overwrite |
     Then the booking with reference '37492-16293' has been 'Booked'
+    And the booking with reference '79237-10283' has status 'Provisional'
     And an audit function document was created for user 'api@test' and function 'SetAvailabilityFunction'
 
   Scenario: Edit an existing session


### PR DESCRIPTION
The availability re-calculator currently uses the definition of a `Live Booking` to generate the list of bookings to operate over.
It does this because Provisional bookings still consume availability, however due to an oversight it was flipping Provisional bookings from Provisional -> Booked when it determined that they still had supporting availability. 

This PR fixes that bug, and adds in tests to cover this case. It also covers some extra cases, such as Cancelled appointments and date Created by ordering.