### PR TITLE
APPT-545: Return user to week view after Going Back from appropriate wizard step

### DIFF
--- a/src/client/src/app/lib/components/nhsuk-frontend/back-link.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/back-link.tsx
@@ -38,7 +38,10 @@ const BackLink = (props: Props) => {
         role="link"
         className="nhsuk-back-link__link"
         href={''}
-        onClick={props.onClick}
+        onClick={e => {
+          e.preventDefault();
+          props.onClick();
+        }}
       >
         <LeftChevron />
         {props.text}

--- a/src/client/src/app/site/[site]/create-availability/wizard/availability-template-wizard.tsx
+++ b/src/client/src/app/site/[site]/create-availability/wizard/availability-template-wizard.tsx
@@ -78,6 +78,10 @@ const AvailabilityTemplateWizard = ({ site, date }: Props) => {
       : router.push(`/site/${site.id}/create-availability`);
   };
 
+  const returnToWeekView = () => {
+    router.replace(`/site/${site.id}/view-availability/week?date=${date}`);
+  };
+
   return (
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(submitForm)}>
@@ -99,7 +103,12 @@ const AvailabilityTemplateWizard = ({ site, date }: Props) => {
             {stepProps => <DaysOfWeekStep {...stepProps} />}
           </WizardStep>
           <WizardStep>
-            {stepProps => <TimeAndCapacityStep {...stepProps} />}
+            {stepProps => (
+              <TimeAndCapacityStep
+                {...stepProps}
+                goToPreviousStepOverride={date ? returnToWeekView : undefined}
+              />
+            )}
           </WizardStep>
           <WizardStep>
             {stepProps => <SelectServicesStep {...stepProps} />}

--- a/src/client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.test.tsx
+++ b/src/client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.test.tsx
@@ -1,5 +1,5 @@
 import render from '@testing/render';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { CreateAvailabilityFormValues } from './availability-template-wizard';
 import MockForm from '@testing/mockForm';
 import TimeAndCapacityStep from './time-and-capacity-step';
@@ -413,5 +413,44 @@ describe('Time and Capacity Step', () => {
       screen.getByText('Session end time must be after the start time'),
     ).toBeInTheDocument();
     expect(screen.queryByText('Appointment length is required')).toBeNull();
+  });
+
+  it('can be supplied with an alternative implementation for going back a step', async () => {
+    const goToPreviousStepOverride = jest.fn();
+
+    const { user } = render(
+      <MockForm<CreateAvailabilityFormValues>
+        submitHandler={jest.fn()}
+        defaultValues={{
+          session: {
+            startTime: {
+              hour: 9,
+              minute: 30,
+            },
+            endTime: {
+              hour: 8,
+              minute: 0,
+            },
+          },
+        }}
+      >
+        <TimeAndCapacityStep
+          stepNumber={1}
+          currentStep={1}
+          isActive
+          setCurrentStep={mockSetCurrentStep}
+          goToNextStep={mockGoToNextStep}
+          goToLastStep={mockGoToLastStep}
+          goToPreviousStep={mockGoToPreviousStep}
+          goToPreviousStepOverride={goToPreviousStepOverride}
+        />
+      </MockForm>,
+    );
+
+    await user.click(screen.getByRole('link', { name: 'Go back' }));
+
+    waitFor(() => {
+      expect(goToPreviousStepOverride).toHaveBeenCalled();
+    });
   });
 });

--- a/src/client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
+++ b/src/client/src/app/site/[site]/create-availability/wizard/time-and-capacity-step.tsx
@@ -18,6 +18,10 @@ import { formatTimeString } from '@services/timeService';
 import { ChangeEvent } from 'react';
 import { sessionLengthInMinutes } from '@services/availabilityCalculatorService';
 
+type TimeAndCapacityStepProps = {
+  goToPreviousStepOverride?: () => void;
+};
+
 const TimeAndCapacityStep = ({
   goToNextStep,
   goToLastStep,
@@ -25,7 +29,8 @@ const TimeAndCapacityStep = ({
   returnRouteUponCancellation,
   goToPreviousStep,
   setCurrentStep,
-}: InjectedWizardProps) => {
+  goToPreviousStepOverride,
+}: InjectedWizardProps & TimeAndCapacityStepProps) => {
   const { watch, formState, trigger, control, getValues } =
     useFormContext<CreateAvailabilityFormValues>();
   const { errors, isValid: allStepsAreValid, touchedFields } = formState;
@@ -63,6 +68,11 @@ const TimeAndCapacityStep = ({
   };
 
   const onBack = async () => {
+    if (goToPreviousStepOverride) {
+      goToPreviousStepOverride();
+      return;
+    }
+
     if (getValues('sessionType') === 'repeating') {
       goToPreviousStep();
     } else {


### PR DESCRIPTION
I had intended to do this properly, but time constraints being what they are this is a temporary hacky measure to meet the requirement. 

If a user has clicked on "Add Session" from the Week View availability page, they will be jumped straight into the wizard at step 4 (since we already have all the information steps 1-3 gather). When they click "Go Back", rather than actually navigate the wizard they want this to return them to the Week View page. 

I will do this properly in the fullness of time by creating a separate wizard with only steps 4 and 5 (since the summary screen is also not needed in this journey, but they haven't complained about that yet). This might be a post-beta change though!