### PR TITLE
APPT-392: Use the updated session on the Edit Session confirmation screen

### DIFF
--- a/src/client/src/app/site/[site]/availability/edit/confirmed/edit-session-confirmed.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/confirmed/edit-session-confirmed.tsx
@@ -1,32 +1,33 @@
 import { Table, InsetText } from '@components/nhsuk-frontend';
-import {
-  SessionServicesCell,
-  SessionTimesCell,
-} from '@components/session-summary-table';
-import { SessionSummary, Site } from '@types';
+import { AvailabilitySession, clinicalServices, Site } from '@types';
 import Link from 'next/link';
 
 type PageProps = {
-  sessionSummary: SessionSummary;
+  updatedSession: AvailabilitySession;
   site: Site;
   date: string;
 };
 
-const EditSessionConfirmed = ({ sessionSummary, site, date }: PageProps) => {
+const EditSessionConfirmed = ({ updatedSession, site, date }: PageProps) => {
   return (
     <>
       <Table
         headers={['Time', 'Services']}
         rows={[
           [
-            <SessionTimesCell
-              key={`session-0-start-and-end-time`}
-              sessionSummary={sessionSummary}
-            />,
-            <SessionServicesCell
-              key={`session-0-service-name`}
-              sessionSummary={sessionSummary}
-            />,
+            <strong key={`session-0-start-and-end-time`}>
+              {`${updatedSession.from} - ${updatedSession.until}`}
+            </strong>,
+            <>
+              {updatedSession.services.map((service, serviceIndex) => {
+                return (
+                  <span key={`service-name-${serviceIndex}`}>
+                    {clinicalServices.find(cs => cs.value === service)?.label}
+                    <br />
+                  </span>
+                );
+              })}
+            </>,
           ],
         ]}
       />

--- a/src/client/src/app/site/[site]/availability/edit/confirmed/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/confirmed/page.tsx
@@ -1,5 +1,5 @@
 import { assertPermission, fetchSite } from '@services/appointmentsService';
-import { SessionSummary } from '@types';
+import { AvailabilitySession } from '@types';
 import NhsPage from '@components/nhs-page';
 import dayjs from 'dayjs';
 import EditSessionConfirmed from './edit-session-confirmed';
@@ -7,7 +7,7 @@ import EditSessionConfirmed from './edit-session-confirmed';
 type PageProps = {
   searchParams: {
     date: string;
-    session: string;
+    updatedSession: string;
   };
   params: {
     site: string;
@@ -19,7 +19,9 @@ const Page = async ({ searchParams, params }: PageProps) => {
   await assertPermission(site.id, 'availability:setup');
   const date = dayjs(searchParams.date, 'YYYY-MM-DD');
 
-  const sessionSummary: SessionSummary = JSON.parse(atob(searchParams.session));
+  const updatedSession: AvailabilitySession = JSON.parse(
+    atob(searchParams.updatedSession),
+  );
 
   return (
     <NhsPage
@@ -33,7 +35,7 @@ const Page = async ({ searchParams, params }: PageProps) => {
       }}
     >
       <EditSessionConfirmed
-        sessionSummary={sessionSummary}
+        updatedSession={updatedSession}
         site={site}
         date={searchParams.date}
       />

--- a/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
-import { Site, SessionSummary, Session } from '@types';
+import { Site, SessionSummary, Session, AvailabilitySession } from '@types';
 import { useRouter } from 'next/navigation';
 import { editSession } from '@services/appointmentsService';
 import {
@@ -71,19 +71,19 @@ const EditSessionTimeAndCapacityForm = ({
   const submitForm: SubmitHandler<EditSessionFormValues> = async (
     form: EditSessionFormValues,
   ) => {
+    const updatedSession: AvailabilitySession = {
+      from: formatTimeString(form.newSession.startTime) ?? '',
+      until: formatTimeString(form.newSession.endTime) ?? '',
+      slotLength: form.newSession.slotLength,
+      capacity: form.newSession.capacity,
+      services: form.newSession.services,
+    };
+
     await editSession({
       date,
       site: site.id,
       mode: 'Edit',
-      sessions: [
-        {
-          from: formatTimeString(form.newSession.startTime) ?? '',
-          until: formatTimeString(form.newSession.endTime) ?? '',
-          slotLength: form.newSession.slotLength,
-          capacity: form.newSession.capacity,
-          services: form.newSession.services,
-        },
-      ],
+      sessions: [updatedSession],
       sessionToEdit: {
         from: formatTimeString(form.sessionToEdit.startTime) ?? '',
         until: formatTimeString(form.sessionToEdit.endTime) ?? '',
@@ -94,7 +94,7 @@ const EditSessionTimeAndCapacityForm = ({
     });
 
     router.push(
-      `edit/confirmed?session=${btoa(JSON.stringify(existingSession))}&date=${date}`,
+      `edit/confirmed?updatedSession=${btoa(JSON.stringify(updatedSession))}&date=${date}`,
     );
   };
 


### PR DESCRIPTION
The confirmation screen after editing a session is currently still populated with the original session pre-edit. 

To do this more securely we should have the API return the updated session and display that, but for now this PR just displays the new session object that the frontend passes in the request, since we know by this point that the request was successful. 