### PR TITLE
Appt 574 - Change Site data structure. ID as random GUID, ODSCode as new field.

### DIFF
--- a/data/CosmosDbSeeder/items/local/booking_data/20250701.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250701.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250701",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250702.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250702.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250702",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250704.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250704.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250704",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250706.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250706.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250706",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250707.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250707.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250707",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250709.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250709.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250709",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250711.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250711.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250711",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250713.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250713.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250713",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250714.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250714.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250714",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250716.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250716.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250716",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250718.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250718.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250718",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250720.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250720.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250720",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250721.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250721.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250721",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250723.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250723.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250723",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250725.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250725.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250725",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250727.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250727.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250727",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250728.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250728.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250728",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250730.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250730.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250730",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250801.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250801.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250801",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250803.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250803.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250803",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250804.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250804.json
@@ -9,7 +9,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250804",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/20250805.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/20250805.json
@@ -23,7 +23,7 @@
       "capacity": 2
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "20250805",
   "docType": "daily_availability"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/availability_created_ABC02_20200101145431233324.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/availability_created_ABC02_20200101145431233324.json
@@ -13,7 +13,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "availability_created_ABC02_20200101145431233324",
   "docType": "availability_created_event"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/availability_created_ABC02_20241121083813735010.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/availability_created_ABC02_20241121083813735010.json
@@ -13,7 +13,7 @@
       "capacity": 5
     }
   ],
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "availability_created_ABC02_20241121083813735010",
   "docType": "availability_created_event"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/availability_created_ABC02_20241121085224173987.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/availability_created_ABC02_20241121085224173987.json
@@ -16,7 +16,7 @@
   "from": "2025-07-01",
   "to": "2025-08-05",
   "sessions": null,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "availability_created_ABC02_20241121085224173987",
   "docType": "availability_created_event"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_01.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_01.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-01",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_02.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_02.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-02",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_03.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_03.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-03",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_04.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_04.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-04",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_05.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_05.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-05",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_06.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_06.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-06",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_07.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_07.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-07",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_08.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_08.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-08",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_09.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_09.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-09",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_10.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_10.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-10",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_11.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_11.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-11",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_12.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_12.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-12",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_13.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_13.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-13",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_14.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_14.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-14",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_15.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_15.json
@@ -21,7 +21,7 @@
     "decisionReason": "test"
   },
   "reminderSent": false,
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "id": "seed-booking-reference-15",
   "docType": "booking"
 }

--- a/data/CosmosDbSeeder/items/local/core_data/cc2_user.json
+++ b/data/CosmosDbSeeder/items/local/core_data/cc2_user.json
@@ -5,19 +5,19 @@
   "roleAssignments": [
     {
       "role": "canned:availability-manager",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "canned:appointment-manager",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "canned:site-details-manager",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "canned:user-manager",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/local/core_data/cc_user.json
+++ b/data/CosmosDbSeeder/items/local/core_data/cc_user.json
@@ -5,31 +5,31 @@
   "roleAssignments": [
     {
       "role": "canned:availability-manager",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "canned:site-details-manager",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "canned:user-manager",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "canned:availability-manager",
-      "scope": "site:ABC02"
+      "scope": "site:6877d86e-c2df-4def-8508-e1eccf0ea6be"
     },
     {
       "role": "canned:appointment-manager",
-      "scope": "site:ABC02"
+      "scope": "site:6877d86e-c2df-4def-8508-e1eccf0ea6be"
     },
     {
       "role": "canned:site-details-manager",
-      "scope": "site:ABC02"
+      "scope": "site:6877d86e-c2df-4def-8508-e1eccf0ea6be"
     },
     {
       "role": "canned:user-manager",
-      "scope": "site:ABC02"
+      "scope": "site:6877d86e-c2df-4def-8508-e1eccf0ea6be"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/local/core_data/site_ABC01.json
+++ b/data/CosmosDbSeeder/items/local/core_data/site_ABC01.json
@@ -1,9 +1,10 @@
 {
-  "id": "ABC01",
+  "id": "5914b64a-66bb-4ee2-ab8a-94958c1fdfcb",
   "docType": "site",
   "name": "Robin Lane Medical Centre",
   "address": "Pudsey, Leeds, LS28 7BR",
   "phoneNumber": "0113 1111111",
+  "odsCode": "ABC01",
   "region": "R1",
   "integratedCareBoard": "ICB1",
   "location": {

--- a/data/CosmosDbSeeder/items/local/core_data/site_ABC02.json
+++ b/data/CosmosDbSeeder/items/local/core_data/site_ABC02.json
@@ -1,9 +1,10 @@
 {
-  "id": "ABC02",
+  "id": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "docType": "site",
   "name": "Church Lane Pharmacy",
   "address": "Pudsey, Leeds, LS28 7LD",
   "phoneNumber": "0113 2222222",
+  "odsCode": "ABC02",
   "region": "R2",
   "integratedCareBoard": "ICB2",
   "location": {

--- a/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_1.json
+++ b/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_1.json
@@ -5,11 +5,11 @@
   "roleAssignments": [
     {
       "role": "system:integration-test-user",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "system:integration-test-user",
-      "scope": "site:ABC02"
+      "scope": "site:6877d86e-c2df-4def-8508-e1eccf0ea6be"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_2.json
+++ b/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_2.json
@@ -5,11 +5,11 @@
   "roleAssignments": [
     {
       "role": "system:auditer",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "system:integration-test-user",
-      "scope": "site:ABC02"
+      "scope": "site:6877d86e-c2df-4def-8508-e1eccf0ea6be"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_3.json
+++ b/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_3.json
@@ -5,11 +5,11 @@
   "roleAssignments": [
     {
       "role": "canned:availability-manager",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "canned:availability-manager",
-      "scope": "site:ABC02"
+      "scope": "site:6877d86e-c2df-4def-8508-e1eccf0ea6be"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_5.json
+++ b/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_5.json
@@ -5,11 +5,11 @@
   "roleAssignments": [
     {
       "role": "canned:availability-manager",
-      "scope": "site:ABC01"
+      "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {
       "role": "canned:availability-manager",
-      "scope": "site:ABC02"
+      "scope": "site:6877d86e-c2df-4def-8508-e1eccf0ea6be"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_01_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_01_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-01",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "9513125169",
   "from": "2025-07-01T09:30:00",
   "created": "2025-01-03T12:58:28.701582+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_02_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_02_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-02",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "7172139688",
   "from": "2025-07-01T09:30:00",
   "created": "2025-02-15T14:23:45.123456+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_03_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_03_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-03",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "6202206927",
   "from": "2025-07-01T09:40:00",
   "created": "2025-03-10T08:45:30.654321+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_04_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_04_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-04",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "3654890846",
   "from": "2025-07-01T09:50:00",
   "created": "2025-04-05T11:12:34.789012+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_05_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_05_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-05",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "6261801025",
   "from": "2025-07-01T09:50:00",
   "created": "2025-05-20T16:45:12.345678+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_06_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_06_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-06",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "1678344364",
   "from": "2025-07-01T09:50:00",
   "created": "2025-06-25T09:30:45.987654+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_07_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_07_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-07",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "6572157723",
   "from": "2025-07-01T10:00:00",
   "created": "2025-02-01T10:15:30.123456+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_08_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_08_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-08",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "7278225602",
   "from": "2025-07-01T10:10:00",
   "created": "2025-03-12T13:45:00.654321+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_09_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_09_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-09",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "4384388941",
   "from": "2025-07-01T10:20:00",
   "created": "2025-01-30T17:20:15.789012+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_10_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_10_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-10",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "9597745660",
   "from": "2025-07-01T10:30:00",
   "created": "2025-10-22T11:55:45.123456+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_11_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_11_index.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-11",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "5927077529",
   "from": "2025-07-01T10:40:00",
   "created": "2025-03-05T08:30:30.654321+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_12.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_12.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-12",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "5682938172",
   "from": "2025-08-05T09:00:00",
   "created": "2025-08-01T08:30:30.654321+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_13.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_13.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-13",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "5932817282",
   "from": "2025-08-05T09:00:00",
   "created": "2025-08-01T09:47:23.654321+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_14.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_14.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-14",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "5873169458",
   "from": "2025-08-05T09:00:00",
   "created": "2025-08-01T09:54:16.654321+00:00",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_15.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_15.json
@@ -1,6 +1,6 @@
 {
   "reference": "seed-booking-reference-15",
-  "site": "ABC02",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
   "nhsNumber": "1975486535",
   "from": "2025-08-05T09:00:00",
   "created": "2025-08-01T06:23:46.654321+00:00",

--- a/data/CsvDataTool/CsvProcessor.cs
+++ b/data/CsvDataTool/CsvProcessor.cs
@@ -6,8 +6,7 @@ namespace CsvDataTool;
 
 public class CsvProcessor<TDocument, TMap>(
     Func<TDocument, Task> processRow,
-    Func<TDocument, string> getItemName,
-    Func<TDocument, TDocument> mutateDocument = null)
+    Func<TDocument, string> getItemName)
     where TMap : ClassMap
 {
     public async Task<IEnumerable<ReportItem>> ProcessFile(TextReader csvReader)
@@ -41,9 +40,7 @@ public class CsvProcessor<TDocument, TMap>(
         {
             csv.Context.RegisterClassMap<TMap>();
 
-            var imported = mutateDocument != null
-                ? csv.GetRecords<TDocument>().Select(mutateDocument)
-                : csv.GetRecords<TDocument>();
+            var imported = csv.GetRecords<TDocument>();
 
             foreach (var item in imported)
             {

--- a/data/CsvDataTool/CsvProcessor.cs
+++ b/data/CsvDataTool/CsvProcessor.cs
@@ -1,11 +1,13 @@
+using System.Globalization;
 using CsvHelper;
 using CsvHelper.Configuration;
-using System.Globalization;
+using Nhs.Appointments.Persistance.Models;
 
 namespace CsvDataTool;
 
-public class CsvProcessor<TDocument, TMap>(Func<TDocument, Task> processRow, Func<TDocument, string> getItemName) where TMap : ClassMap
-{ 
+public class CsvProcessor<TDocument, TMap>(Func<TDocument, Task> processRow, Func<TDocument, string> getItemName)
+    where TMap : ClassMap
+{
     public async Task<IEnumerable<ReportItem>> ProcessFile(TextReader csvReader)
     {
         var index = -1;
@@ -14,14 +16,15 @@ public class CsvProcessor<TDocument, TMap>(Func<TDocument, Task> processRow, Fun
         var config = new CsvConfiguration(CultureInfo.InvariantCulture)
         {
             HasHeaderRecord = true,
-            ShouldSkipRecord = args => { 
+            ShouldSkipRecord = args =>
+            {
                 index++;
                 return false;
-            }, 
+            },
             ReadingExceptionOccurred = args =>
             {
                 report.Add(new ReportItem(index, "", false, args.Exception.ToString()));
-                
+
                 return false;
             },
             BadDataFound = args =>
@@ -31,13 +34,26 @@ public class CsvProcessor<TDocument, TMap>(Func<TDocument, Task> processRow, Fun
             Delimiter = ",",
             Quote = '"'
         };
-        
+
         using (var csv = new CsvReader(csvReader, config))
         {
             csv.Context.RegisterClassMap<TMap>();
 
-            var imported = csv.GetRecords<TDocument>();
-            foreach(var item in imported)
+            var imported = csv.GetRecords<TDocument>().ToList();
+
+            //hacky way to generate a Site ID not provided in the CSV or mapping
+            if (typeof(TDocument) == typeof(SiteDocument))
+            {
+                var siteDocs = imported as List<SiteDocument>;
+                foreach (var siteDoc in siteDocs!)
+                {
+                    siteDoc.Id = $"{Guid.NewGuid()}";
+                }
+
+                imported = siteDocs as List<TDocument>;
+            }
+
+            foreach (var item in imported!)
             {
                 try
                 {
@@ -48,9 +64,9 @@ public class CsvProcessor<TDocument, TMap>(Func<TDocument, Task> processRow, Fun
                 {
                     report.Add(new ReportItem(index, getItemName(item), false, ex.Message));
                 }
-            }       
+            }
         }
 
         return report.ToArray();
-    }    
+    }
 }

--- a/data/CsvDataTool/ExampleData/sites.csv
+++ b/data/CsvDataTool/ExampleData/sites.csv
@@ -1,3 +1,3 @@
-﻿ID,Name,Address,PhoneNumber,Longitude,Latitude,ICB,Region,Site type,accessible_toilet,braille_translation_service,disabled_car_parking, car_parking, induction_loop,sign_language_service, step_free_access, text_relay,wheelchair_access 
+﻿OdsCode,Name,Address,PhoneNumber,Longitude,Latitude,ICB,Region,Site type,accessible_toilet,braille_translation_service,disabled_car_parking, car_parking, induction_loop,sign_language_service, step_free_access, text_relay,wheelchair_access 
 1,Example site,123 Test Street,01234 567890,1,60.1,Test ICB,Yorkshire,Unknown,,,,,,,,,
 this is a bad row

--- a/data/CsvDataTool/SiteDataImportHandler.cs
+++ b/data/CsvDataTool/SiteDataImportHandler.cs
@@ -6,15 +6,21 @@ public class SiteDataImportHandler(IFileOperations fileOperations) : IDataImport
 {
     public Task<IEnumerable<ReportItem>> ProcessFile(FileInfo inputFile, DirectoryInfo outputFolder)
     {
-        var processor = new CsvProcessor<SiteDocument, SiteMap>(s => WriteSiteDocument(s, outputFolder), s => s.Name);
+        var processor = new CsvProcessor<SiteDocument, SiteMap>(s => WriteSiteDocument(s, outputFolder), s => s.Name, MutateSiteDocument);
         using var fileReader = fileOperations.OpenText(inputFile);
         return processor.ProcessFile(fileReader);
     }
 
-    protected virtual Task WriteSiteDocument(SiteDocument siteDocument, DirectoryInfo outputDirectory)
+    private Task WriteSiteDocument(SiteDocument siteDocument, DirectoryInfo outputDirectory)
     {
         fileOperations.CreateFolder(outputDirectory);
         var filePath = Path.Combine(outputDirectory.FullName, $"site_{siteDocument.Id}.json");
         return fileOperations.WriteDocument(siteDocument, filePath);
+    }
+    
+    private static SiteDocument MutateSiteDocument(SiteDocument siteDocument)
+    {
+        siteDocument.Id = Guid.NewGuid().ToString();
+        return siteDocument;
     }
 }

--- a/data/CsvDataTool/SiteDataImportHandler.cs
+++ b/data/CsvDataTool/SiteDataImportHandler.cs
@@ -6,7 +6,7 @@ public class SiteDataImportHandler(IFileOperations fileOperations) : IDataImport
 {
     public Task<IEnumerable<ReportItem>> ProcessFile(FileInfo inputFile, DirectoryInfo outputFolder)
     {
-        var processor = new CsvProcessor<SiteDocument, SiteMap>(s => WriteSiteDocument(s, outputFolder), s => s.Name, MutateSiteDocument);
+        var processor = new CsvProcessor<SiteDocument, SiteMap>(s => WriteSiteDocument(s, outputFolder), s => s.Name);
         using var fileReader = fileOperations.OpenText(inputFile);
         return processor.ProcessFile(fileReader);
     }
@@ -16,11 +16,5 @@ public class SiteDataImportHandler(IFileOperations fileOperations) : IDataImport
         fileOperations.CreateFolder(outputDirectory);
         var filePath = Path.Combine(outputDirectory.FullName, $"site_{siteDocument.Id}.json");
         return fileOperations.WriteDocument(siteDocument, filePath);
-    }
-    
-    private static SiteDocument MutateSiteDocument(SiteDocument siteDocument)
-    {
-        siteDocument.Id = Guid.NewGuid().ToString();
-        return siteDocument;
     }
 }

--- a/data/CsvDataTool/SiteMap.cs
+++ b/data/CsvDataTool/SiteMap.cs
@@ -8,7 +8,10 @@ public class SiteMap : ClassMap<SiteDocument>
 {
     public SiteMap()
     {
-        Map(m => m.Id).Name("ID");
+        //ignore ID property and generate programatically
+        Map(m => m.Id).Ignore();
+
+        Map(m => m.OdsCode).Name("OdsCode");
         Map(m => m.Name).Name("Name");
         Map(m => m.Address).Name("Address");
         Map(m => m.PhoneNumber).Name("PhoneNumber");
@@ -16,23 +19,32 @@ public class SiteMap : ClassMap<SiteDocument>
             new Location(
                 "Point",
                 [x.Row.GetField<double>("Longitude"), x.Row.GetField<double>("Latitude")]
-                ));
+            ));
         Map(m => m.IntegratedCareBoard).Name("ICB");
         Map(m => m.Region).Name("Region");
         Map(m => m.DocumentType).Constant("site");
         Map(m => m.AttributeValues).Convert(x =>
         {
-            AttributeValue[] result = [
-                new AttributeValue("accessibility/accessible_toilet", ParseUserEnteredBoolean(x.Row["accessible_toilet"]).ToString()),
-                new AttributeValue("accessibility/braille_translation_service", ParseUserEnteredBoolean(x.Row["braille_translation_service"]).ToString()),
-                new AttributeValue("accessibility/disabled_car_parking", ParseUserEnteredBoolean(x.Row["disabled_car_parking"]).ToString()),
-                new AttributeValue("accessibility/car_parking", ParseUserEnteredBoolean(x.Row["car_parking"]).ToString()),
-                new AttributeValue("accessibility/induction_loop", ParseUserEnteredBoolean(x.Row["induction_loop"]).ToString()),
-                new AttributeValue("accessibility/sign_language_service", ParseUserEnteredBoolean(x.Row["sign_language_service"]).ToString()),
-                new AttributeValue("accessibility/step_free_access", ParseUserEnteredBoolean(x.Row["step_free_access"]).ToString()),
+            AttributeValue[] result =
+            [
+                new AttributeValue("accessibility/accessible_toilet",
+                    ParseUserEnteredBoolean(x.Row["accessible_toilet"]).ToString()),
+                new AttributeValue("accessibility/braille_translation_service",
+                    ParseUserEnteredBoolean(x.Row["braille_translation_service"]).ToString()),
+                new AttributeValue("accessibility/disabled_car_parking",
+                    ParseUserEnteredBoolean(x.Row["disabled_car_parking"]).ToString()),
+                new AttributeValue("accessibility/car_parking",
+                    ParseUserEnteredBoolean(x.Row["car_parking"]).ToString()),
+                new AttributeValue("accessibility/induction_loop",
+                    ParseUserEnteredBoolean(x.Row["induction_loop"]).ToString()),
+                new AttributeValue("accessibility/sign_language_service",
+                    ParseUserEnteredBoolean(x.Row["sign_language_service"]).ToString()),
+                new AttributeValue("accessibility/step_free_access",
+                    ParseUserEnteredBoolean(x.Row["step_free_access"]).ToString()),
                 new AttributeValue("accessibility/text_relay", ParseUserEnteredBoolean(x.Row["text_relay"]).ToString()),
-                new AttributeValue("accessibility/wheelchair_access", ParseUserEnteredBoolean(x.Row["wheelchair_access"]).ToString()),
-                ];
+                new AttributeValue("accessibility/wheelchair_access",
+                    ParseUserEnteredBoolean(x.Row["wheelchair_access"]).ToString()),
+            ];
 
             return result;
         });
@@ -44,6 +56,3 @@ public class SiteMap : ClassMap<SiteDocument>
         return possibleBool == "true" || possibleBool == "yes";
     }
 }
-
-
-

--- a/postman-collection/Appointment Service.postman_collection.json
+++ b/postman-collection/Appointment Service.postman_collection.json
@@ -1,1267 +1,1082 @@
 {
-	"info": {
-		"_postman_id": "97279d4c-a1ca-4269-93a0-42b217a78f0f",
-		"name": "Appointment Service",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "39091838"
-	},
-	"item": [
-		{
-			"name": "availability/apply-template",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"site\": \"{{site}}\",\r\n    \"from\": \"2024-12-01\",\r\n    \"until\": \"2024-12-31\",\r\n    \"mode\": \"Additive\",\r\n    \"template\": {\r\n        \"days\": [\r\n            \"Monday\",\r\n            \"Tuesday\",\r\n            \"Wednesday\",\r\n            \"Thursday\",\r\n            \"Friday\",\r\n            \"Saturday\",\r\n            \"Sunday\"\r\n        ],\r\n        \"sessions\": [\r\n            {\r\n                \"from\": \"09:00\",\r\n                \"until\": \"17:00\",\r\n                \"slotLength\": 5,\r\n                \"capacity\": 1,\r\n                \"services\": [\r\n                    \"COVID:18_74\"\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/availability/apply-template",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"availability",
-						"apply-template"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "availability",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"site\": \"{{site}}\",\r\n    \"date\": \"2025-01-01\",\r\n    \"mode\": \"Overwrite\",\r\n    \"sessions\": [\r\n        {\r\n            \"from\": \"09:00\",\r\n            \"until\": \"17:00\",\r\n            \"slotLength\": 5,\r\n            \"capacity\": 2,\r\n            \"services\": [\r\n                \"COVID:18_74\"\r\n            ]\r\n        },\r\n        {\r\n            \"from\": \"09:00\",\r\n            \"until\": \"16:00\",\r\n            \"slotLength\": 10,\r\n            \"capacity\": 1,\r\n            \"services\": [\r\n                \"COVID:18_74\"\r\n            ]\r\n        }\r\n    ]\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/availability",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"availability"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "availability/query - days",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"sites\": [{{sites}}],\r\n    \"service\": \"COVID:18_74\",\r\n    \"from\": \"2024-12-01\",\r\n    \"until\": \"2024-12-01\",\r\n    \"QueryType\": \"Days\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/availability/query",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"availability",
-						"query"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "availability/query - hours",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"sites\": [{{sites}}], \r\n    \"service\": \"COVID:18_74\",\r\n    \"from\": \"2024-12-01\",\r\n    \"until\": \"2024-12-01\",\r\n    \"queryType\": \"Hours\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/availability/query",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"availability",
-						"query"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "availability/query - slots",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"sites\": [{{sites}}], \r\n    \"service\": \"COVID:18_74\",\r\n    \"from\": \"2024-12-01\",\r\n    \"until\": \"2024-12-01\",\r\n    \"queryType\": \"slots\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/availability/query",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"availability",
-						"query"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "booking (PROVISIONAL)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"const responseJson = pm.response.json();\r",
-							"const reference = responseJson.bookingReference;\r",
-							"\r",
-							"pm.environment.set('bookingReference', reference);"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"from\": \"2024-12-01 09:00\",\r\n    \"duration\": 5,\r\n    \"service\": \"COVID:18_74\",\r\n    \"site\": \"{{site}}\",\r\n    \"kind\": \"Provisional\",\r\n    \"attendeeDetails\": {\r\n        \"nhsNumber\": \"{{nhsNumber}}\",\r\n        \"firstName\": \"MAUREEN\",\r\n        \"lastName\": \"CULLINGWORTH\",\r\n        \"dateOfBirth\": \"2000-01-01\"\r\n    },\r\n    \"additionalData\": {\r\n        \"isCallCentreBooking\": true,\r\n        \"callCentreHandlerEmail\": \"test@example.com\",\r\n        \"isAppBooking\": false,\r\n        \"selfReferralOccupation\": \"test\",\r\n        \"decisionReason\": \"test\"\r\n    }\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/booking",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"booking"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "booking (BOOKED)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"const responseJson = pm.response.json();\r",
-							"const reference = responseJson.bookingReference;\r",
-							"\r",
-							"pm.environment.set('bookingReference', reference);"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"from\": \"2024-12-01 09:00\",\r\n    \"duration\": 5,\r\n    \"service\": \"COVID:18_74\",\r\n    \"site\": \"{{site}}\",\r\n    \"attendeeDetails\": {\r\n        \"nhsNumber\": \"{{nhsNumber}}\",\r\n        \"firstName\": \"MAUREEN\",\r\n        \"lastName\": \"CULLINGWORTH\",\r\n        \"dateOfBirth\": \"2000-01-01\"\r\n    },\r\n    \"kind\": \"Booked\",\r\n    \"contactDetails\": [\r\n        {\r\n            \"type\": \"phone\",\r\n            \"value\": \"enter-phone-number\"\r\n        },\r\n        {\r\n            \"type\": \"email\",\r\n            \"value\": \"enter-email-address\"\r\n        },\r\n        {\r\n            \"type\": \"landline\",\r\n            \"value\": \"enter-landline-number\"\r\n        }\r\n    ],\r\n    \"additionalData\": {\r\n        \"isCallCentreBooking\": true,\r\n        \"callCentreHandlerEmail\": \"test@example.com\",\r\n        \"isAppBooking\": false,\r\n        \"selfReferralOccupation\": \"test\",\r\n        \"decisionReason\": \"test\"\r\n    }\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/booking",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"booking"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "booking/confirm",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"contactDetails\": [\r\n        {\r\n            \"type\": \"email\",\r\n            \"value\": \"enter-email-address\"\r\n        },\r\n        {\r\n            \"type\": \"phone\",\r\n            \"value\": \"enter-phone-number\"\r\n        }\r\n    ]\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/booking/{{bookingReference}}/confirm",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"booking",
-						"{{bookingReference}}",
-						"confirm"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "booking/confirm (RESCHEDULE)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"contactDetails\": [\r\n        {\r\n            \"type\": \"email\",\r\n            \"value\": \"enter-email-address\"\r\n        },\r\n        {\r\n            \"type\": \"phone\",\r\n            \"value\": \"enter-phone-number\"\r\n        }\r\n    ],\r\n    \"bookingToReschedule\": \"enter-booking-ref-for-booking-to-cancel\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/booking/{{bookingReference}}/confirm",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"booking",
-						"{{bookingReference}}",
-						"confirm"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "booking/query",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"from\": \"2024-12-01 00:00\",\r\n    \"to\": \"2024-12-01 23:59\",\r\n    \"site\": \"{{site}}\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/booking/query",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"booking",
-						"query"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "booking/cancel",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/booking/{{bookingReference}}/cancel",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"booking",
-						"{{bookingReference}}",
-						"cancel"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "booking/set-status",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"bookingReference\": \"{{bookingReference}}\",\r\n    \"status\": \"CheckedIn\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/booking/set-status",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"booking",
-						"set-status"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "sites/{site}/attributes",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"site\": \"{{site}}\",\r\n    \"scope\": \"*\",\r\n    \"attributeValues\": [\r\n        {\r\n            \"id\": \"accessibility/accessible_toilet\",\r\n            \"value\": \"false\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/braille_translation_service\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/disabled_car_parking_on_site\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/car_parking_on_site\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/induction_loop\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/sign_language_service\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/step_free_access\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/text_relay\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/wheelchair_access\",\r\n            \"value\": \"false\"\r\n        }\r\n    ]\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/sites/{{site}}/attributes",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"sites",
-						"{{site}}",
-						"attributes"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "user/roles",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"scope\": \"site:ABC01\",\r\n    \"user\": \"cc.agent@nhs.uk\",\r\n    \"roles\": [\r\n        {{enter-roles-to-assign}}\r\n    ]\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/user/roles",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"user",
-						"roles"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "user/remove",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"site\": \"{{site}}\",\r\n    \"user\": \"cc.agent@nhs.uk\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/user/remove",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"user",
-						"remove"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "system/run-reminders",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/system/run-reminders",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"system",
-						"run-reminders"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "system/run-provisional-sweep",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl}}/api/system/run-provisional-sweep",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"system",
-						"run-provisional-sweep"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "attributeDefinitions",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/attributeDefinitions",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"attributeDefinitions"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "booking/{ref}",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl}}/api/booking/{{bookingReference}}",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"booking",
-						"{{bookingReference}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "booking/{nhsNumber}",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl}}/api/booking?nhsNumber={{nhsNumber}}",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"booking"
-					],
-					"query": [
-						{
-							"key": "nhsNumber",
-							"value": "{{nhsNumber}}"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "site/meta",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/sites/{{site}}/meta",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"sites",
-						"{{site}}",
-						"meta"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "sites/{site}",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/sites/{{site}}",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"sites",
-						"{{site}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "sites",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/sites?long=-1.663038&lat=53.796638&searchRadius=100000&maxRecords=50",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"sites"
-					],
-					"query": [
-						{
-							"key": "long",
-							"value": "-1.663038"
-						},
-						{
-							"key": "lat",
-							"value": "53.796638"
-						},
-						{
-							"key": "searchRadius",
-							"value": "100000",
-							"description": "6000"
-						},
-						{
-							"key": "maxRecords",
-							"value": "50"
-						},
-						{
-							"key": "accessNeeds",
-							"value": "accessible_toilet,braille_translation_service",
-							"disabled": true
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "roles",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/roles?tag=canned",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"roles"
-					],
-					"query": [
-						{
-							"key": "tag",
-							"value": "canned"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "users",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/users?site={{site}}",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"users"
-					],
-					"query": [
-						{
-							"key": "site",
-							"value": "{{site}}"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "user/permissions",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/user/permissions?site={{site}}",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"user",
-						"permissions"
-					],
-					"query": [
-						{
-							"key": "site",
-							"value": "{{site}}"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "daily-availability",
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl}}/api/daily-availability?site=ABC02&from=2024-12-03&until=2024-12-08",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"daily-availability"
-					],
-					"query": [
-						{
-							"key": "site",
-							"value": "ABC02"
-						},
-						{
-							"key": "from",
-							"value": "2024-12-03"
-						},
-						{
-							"key": "until",
-							"value": "2024-12-08"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "wellKnownOdsCodeEntries",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/wellKnownOdsCodeEntries",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"wellKnownOdsCodeEntries"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "session/cancel",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "POST",
-				"header": [
-					{
-						"key": "ClientId",
-						"value": "{{clientId}}",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"site\": \"ABC02\",\r\n    \"date\": \"2025-01-15\",\r\n    \"from\": \"09:00\",\r\n    \"until\": \"16:00\",\r\n    \"services\": [\r\n        \"RSV:Adult\"\r\n    ],\r\n    \"slotLength\": 5,\r\n    \"capacity\": 2\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}/api/session/cancel",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"api",
-						"session",
-						"cancel"
-					]
-				}
-			},
-			"response": []
-		}
-	],
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					"var crypto = require('crypto-js')\r",
-					"var moment = require('moment')\r",
-					"\r",
-					"const secret = pm.environment.get(\"hmacKey\")\r",
-					"const method = pm.request.method;\r",
-					"const path = pm.variables.replaceIn(pm.request.url.getPath());\r",
-					"const queryString = pm.variables.replaceIn(pm.request.url.getQueryString())\r",
-					"const now = moment.utc();\r",
-					"const requestTimestamp = now.format();\r",
-					"const content = pm.variables.replaceIn(pm.request.body).toString() + queryString;\r",
-					"var hashedContentBase64 = crypto.SHA256(content).toString(crypto.enc.Base64);\r",
-					"var payload = method +\"\\n\" + path + \"\\n\" + requestTimestamp + \"\\n\" + hashedContentBase64\r",
-					"var keyBytes = crypto.enc.Base64.parse(secret);\r",
-					"var hashedPayloadBase64 = crypto.HmacSHA256(payload, keyBytes).toString(crypto.enc.Base64);\r",
-					"\r",
-					"pm.request.addHeader({\r",
-					"    'key': 'Authorization',\r",
-					"    'value': 'Signed ' + hashedPayloadBase64\r",
-					"});\r",
-					"pm.request.addHeader({\r",
-					"    'key': 'RequestTimestamp',\r",
-					"    'value': requestTimestamp\r",
-					"});"
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		}
-	]
+  "info": {
+    "_postman_id": "97279d4c-a1ca-4269-93a0-42b217a78f0f",
+    "name": "Appointment Service",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "39091838"
+  },
+  "item": [
+    {
+      "name": "availability/apply-template",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"site\": \"{{site}}\",\r\n    \"from\": \"2024-12-01\",\r\n    \"until\": \"2024-12-31\",\r\n    \"mode\": \"Additive\",\r\n    \"template\": {\r\n        \"days\": [\r\n            \"Monday\",\r\n            \"Tuesday\",\r\n            \"Wednesday\",\r\n            \"Thursday\",\r\n            \"Friday\",\r\n            \"Saturday\",\r\n            \"Sunday\"\r\n        ],\r\n        \"sessions\": [\r\n            {\r\n                \"from\": \"09:00\",\r\n                \"until\": \"17:00\",\r\n                \"slotLength\": 5,\r\n                \"capacity\": 1,\r\n                \"services\": [\r\n                    \"COVID:18_74\"\r\n                ]\r\n            }\r\n        ]\r\n    }\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/availability/apply-template",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability", "apply-template"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "availability",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"site\": \"{{site}}\",\r\n    \"date\": \"2025-01-01\",\r\n    \"mode\": \"Overwrite\",\r\n    \"sessions\": [\r\n        {\r\n            \"from\": \"09:00\",\r\n            \"until\": \"17:00\",\r\n            \"slotLength\": 5,\r\n            \"capacity\": 2,\r\n            \"services\": [\r\n                \"COVID:18_74\"\r\n            ]\r\n        },\r\n        {\r\n            \"from\": \"09:00\",\r\n            \"until\": \"16:00\",\r\n            \"slotLength\": 10,\r\n            \"capacity\": 1,\r\n            \"services\": [\r\n                \"COVID:18_74\"\r\n            ]\r\n        }\r\n    ]\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/availability",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "availability/query - days",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"sites\": [{{sites}}],\r\n    \"service\": \"COVID:18_74\",\r\n    \"from\": \"2024-12-01\",\r\n    \"until\": \"2024-12-01\",\r\n    \"QueryType\": \"Days\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/availability/query",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability", "query"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "availability/query - hours",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"sites\": [{{sites}}], \r\n    \"service\": \"COVID:18_74\",\r\n    \"from\": \"2024-12-01\",\r\n    \"until\": \"2024-12-01\",\r\n    \"queryType\": \"Hours\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/availability/query",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability", "query"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "availability/query - slots",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"sites\": [{{sites}}], \r\n    \"service\": \"COVID:18_74\",\r\n    \"from\": \"2024-12-01\",\r\n    \"until\": \"2024-12-01\",\r\n    \"queryType\": \"slots\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/availability/query",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability", "query"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "booking (PROVISIONAL)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const responseJson = pm.response.json();\r",
+              "const reference = responseJson.bookingReference;\r",
+              "\r",
+              "pm.environment.set('bookingReference', reference);"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"from\": \"2024-12-01 09:00\",\r\n    \"duration\": 5,\r\n    \"service\": \"COVID:18_74\",\r\n    \"site\": \"{{site}}\",\r\n    \"kind\": \"Provisional\",\r\n    \"attendeeDetails\": {\r\n        \"nhsNumber\": \"{{nhsNumber}}\",\r\n        \"firstName\": \"MAUREEN\",\r\n        \"lastName\": \"CULLINGWORTH\",\r\n        \"dateOfBirth\": \"2000-01-01\"\r\n    },\r\n    \"additionalData\": {\r\n        \"isCallCentreBooking\": true,\r\n        \"callCentreHandlerEmail\": \"test@example.com\",\r\n        \"isAppBooking\": false,\r\n        \"selfReferralOccupation\": \"test\",\r\n        \"decisionReason\": \"test\"\r\n    }\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/booking",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "booking (BOOKED)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const responseJson = pm.response.json();\r",
+              "const reference = responseJson.bookingReference;\r",
+              "\r",
+              "pm.environment.set('bookingReference', reference);"
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"from\": \"2024-12-01 09:00\",\r\n    \"duration\": 5,\r\n    \"service\": \"COVID:18_74\",\r\n    \"site\": \"{{site}}\",\r\n    \"attendeeDetails\": {\r\n        \"nhsNumber\": \"{{nhsNumber}}\",\r\n        \"firstName\": \"MAUREEN\",\r\n        \"lastName\": \"CULLINGWORTH\",\r\n        \"dateOfBirth\": \"2000-01-01\"\r\n    },\r\n    \"kind\": \"Booked\",\r\n    \"contactDetails\": [\r\n        {\r\n            \"type\": \"phone\",\r\n            \"value\": \"enter-phone-number\"\r\n        },\r\n        {\r\n            \"type\": \"email\",\r\n            \"value\": \"enter-email-address\"\r\n        },\r\n        {\r\n            \"type\": \"landline\",\r\n            \"value\": \"enter-landline-number\"\r\n        }\r\n    ],\r\n    \"additionalData\": {\r\n        \"isCallCentreBooking\": true,\r\n        \"callCentreHandlerEmail\": \"test@example.com\",\r\n        \"isAppBooking\": false,\r\n        \"selfReferralOccupation\": \"test\",\r\n        \"decisionReason\": \"test\"\r\n    }\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/booking",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "booking/confirm",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"contactDetails\": [\r\n        {\r\n            \"type\": \"email\",\r\n            \"value\": \"enter-email-address\"\r\n        },\r\n        {\r\n            \"type\": \"phone\",\r\n            \"value\": \"enter-phone-number\"\r\n        }\r\n    ]\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/booking/{{bookingReference}}/confirm",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "{{bookingReference}}", "confirm"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "booking/confirm (RESCHEDULE)",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        },
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"contactDetails\": [\r\n        {\r\n            \"type\": \"email\",\r\n            \"value\": \"enter-email-address\"\r\n        },\r\n        {\r\n            \"type\": \"phone\",\r\n            \"value\": \"enter-phone-number\"\r\n        }\r\n    ],\r\n    \"bookingToReschedule\": \"enter-booking-ref-for-booking-to-cancel\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/booking/{{bookingReference}}/confirm",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "{{bookingReference}}", "confirm"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "booking/query",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [""],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"from\": \"2024-12-01 00:00\",\r\n    \"to\": \"2024-12-01 23:59\",\r\n    \"site\": \"{{site}}\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/booking/query",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "query"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "booking/cancel",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/booking/{{bookingReference}}/cancel",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "{{bookingReference}}", "cancel"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "booking/set-status",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"bookingReference\": \"{{bookingReference}}\",\r\n    \"status\": \"CheckedIn\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/booking/set-status",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "set-status"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "sites/{site}/attributes",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"site\": \"{{site}}\",\r\n    \"scope\": \"*\",\r\n    \"attributeValues\": [\r\n        {\r\n            \"id\": \"accessibility/accessible_toilet\",\r\n            \"value\": \"false\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/braille_translation_service\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/disabled_car_parking_on_site\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/car_parking_on_site\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/induction_loop\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/sign_language_service\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/step_free_access\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/text_relay\",\r\n            \"value\": \"true\"\r\n        },\r\n        {\r\n            \"id\": \"accessibility/wheelchair_access\",\r\n            \"value\": \"false\"\r\n        }\r\n    ]\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/sites/{{site}}/attributes",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "sites", "{{site}}", "attributes"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "user/roles",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"scope\": \"site:ABC01\",\r\n    \"user\": \"cc.agent@nhs.uk\",\r\n    \"roles\": [\r\n        {{enter-roles-to-assign}}\r\n    ]\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/user/roles",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "user", "roles"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "user/remove",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"site\": \"{{site}}\",\r\n    \"user\": \"cc.agent@nhs.uk\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/user/remove",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "user", "remove"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "system/run-reminders",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/system/run-reminders",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "system", "run-reminders"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "system/run-provisional-sweep",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/system/run-provisional-sweep",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "system", "run-provisional-sweep"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "attributeDefinitions",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/attributeDefinitions",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "attributeDefinitions"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "booking/{ref}",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/booking/{{bookingReference}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "{{bookingReference}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "booking/{nhsNumber}",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/booking?nhsNumber={{nhsNumber}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking"],
+          "query": [
+            {
+              "key": "nhsNumber",
+              "value": "{{nhsNumber}}"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "site/meta",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/sites/{{site}}/meta",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "sites", "{{site}}", "meta"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "sites/{site}",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/sites/{{site}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "sites", "{{site}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "sites",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/sites?long=-1.663038&lat=53.796638&searchRadius=100000&maxRecords=50",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "sites"],
+          "query": [
+            {
+              "key": "long",
+              "value": "-1.663038"
+            },
+            {
+              "key": "lat",
+              "value": "53.796638"
+            },
+            {
+              "key": "searchRadius",
+              "value": "100000",
+              "description": "6000"
+            },
+            {
+              "key": "maxRecords",
+              "value": "50"
+            },
+            {
+              "key": "accessNeeds",
+              "value": "accessible_toilet,braille_translation_service",
+              "disabled": true
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "roles",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/roles?tag=canned",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "roles"],
+          "query": [
+            {
+              "key": "tag",
+              "value": "canned"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "users",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/users?site={{site}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "users"],
+          "query": [
+            {
+              "key": "site",
+              "value": "{{site}}"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "user/permissions",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/user/permissions?site={{site}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "user", "permissions"],
+          "query": [
+            {
+              "key": "site",
+              "value": "{{site}}"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "daily-availability",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/daily-availability?site=6877d86e-c2df-4def-8508-e1eccf0ea6be&from=2024-12-03&until=2024-12-08",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "daily-availability"],
+          "query": [
+            {
+              "key": "site",
+              "value": "6877d86e-c2df-4def-8508-e1eccf0ea6be"
+            },
+            {
+              "key": "from",
+              "value": "2024-12-03"
+            },
+            {
+              "key": "until",
+              "value": "2024-12-08"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "wellKnownOdsCodeEntries",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/wellKnownOdsCodeEntries",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "wellKnownOdsCodeEntries"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "session/cancel",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"site\": \"6877d86e-c2df-4def-8508-e1eccf0ea6be\",\r\n    \"date\": \"2025-01-15\",\r\n    \"from\": \"09:00\",\r\n    \"until\": \"16:00\",\r\n    \"services\": [\r\n        \"RSV:Adult\"\r\n    ],\r\n    \"slotLength\": 5,\r\n    \"capacity\": 2\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/session/cancel",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "session", "cancel"]
+        }
+      },
+      "response": []
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "var crypto = require('crypto-js')\r",
+          "var moment = require('moment')\r",
+          "\r",
+          "const secret = pm.environment.get(\"hmacKey\")\r",
+          "const method = pm.request.method;\r",
+          "const path = pm.variables.replaceIn(pm.request.url.getPath());\r",
+          "const queryString = pm.variables.replaceIn(pm.request.url.getQueryString())\r",
+          "const now = moment.utc();\r",
+          "const requestTimestamp = now.format();\r",
+          "const content = pm.variables.replaceIn(pm.request.body).toString() + queryString;\r",
+          "var hashedContentBase64 = crypto.SHA256(content).toString(crypto.enc.Base64);\r",
+          "var payload = method +\"\\n\" + path + \"\\n\" + requestTimestamp + \"\\n\" + hashedContentBase64\r",
+          "var keyBytes = crypto.enc.Base64.parse(secret);\r",
+          "var hashedPayloadBase64 = crypto.HmacSHA256(payload, keyBytes).toString(crypto.enc.Base64);\r",
+          "\r",
+          "pm.request.addHeader({\r",
+          "    'key': 'Authorization',\r",
+          "    'value': 'Signed ' + hashedPayloadBase64\r",
+          "});\r",
+          "pm.request.addHeader({\r",
+          "    'key': 'RequestTimestamp',\r",
+          "    'value': requestTimestamp\r",
+          "});"
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [""]
+      }
+    }
+  ]
 }

--- a/src/api/Nhs.Appointments.Core/Site.cs
+++ b/src/api/Nhs.Appointments.Core/Site.cs
@@ -3,55 +3,37 @@
 namespace Nhs.Appointments.Core;
 
 public record Site(
-    [JsonProperty("id")]
-    string Id,
-    [JsonProperty("name")]
-    string Name,
-    [JsonProperty("address")]
-    string Address,
-    [JsonProperty("phoneNumber")]
-    string PhoneNumber,
-    [JsonProperty("region")]
-    string Region,
-    [JsonProperty("integratedCareBoard")]
-    string IntegratedCareBoard,
-    [JsonProperty("attributeValues")]
-    IEnumerable<AttributeValue> AttributeValues,
-    [JsonProperty("location")]
-    Location Location
+    [JsonProperty("id")] string Id,
+    [JsonProperty("name")] string Name,
+    [JsonProperty("address")] string Address,
+    [JsonProperty("phoneNumber")] string PhoneNumber,
+    [JsonProperty("odsCode")] string OdsCode,
+    [JsonProperty("region")] string Region,
+    [JsonProperty("integratedCareBoard")] string IntegratedCareBoard,
+    [JsonProperty("attributeValues")] IEnumerable<AttributeValue> AttributeValues,
+    [JsonProperty("location")] Location Location
 )
 {
     public IEnumerable<AttributeValue> AttributeValues { get; set; } = AttributeValues;
 }
 
-public record Location
-(
-    [property:JsonProperty("type")]
-    string Type,
-    [property:JsonProperty("coordinates")]
+public record Location(
+    [property: JsonProperty("type")] string Type,
+    [property: JsonProperty("coordinates")]
     double[] Coordinates
 );
 
-public record AttributeValue
-(
-    [property:JsonProperty("id")]
-    string Id,
-    [property:JsonProperty("value")]
-    string Value
+public record AttributeValue(
+    [property: JsonProperty("id")] string Id,
+    [property: JsonProperty("value")] string Value
 );
 
-public record SiteWithDistance
-(
-    [JsonProperty("site")]
-    Site Site,
-    [JsonProperty("distance")]
-    int Distance
+public record SiteWithDistance(
+    [JsonProperty("site")] Site Site,
+    [JsonProperty("distance")] int Distance
 );
 
-public record AttributeRequest
-(
-    [JsonProperty("scope")]
-    string Scope,
-    [JsonProperty("attributeValues")]
-    IEnumerable<AttributeValue> AttributeValues
+public record AttributeRequest(
+    [JsonProperty("scope")] string Scope,
+    [JsonProperty("attributeValues")] IEnumerable<AttributeValue> AttributeValues
 );

--- a/src/api/Nhs.Appointments.Persistance/Models/SiteDocument.cs
+++ b/src/api/Nhs.Appointments.Persistance/Models/SiteDocument.cs
@@ -6,29 +6,21 @@ namespace Nhs.Appointments.Persistance.Models;
 [CosmosDocumentType("site")]
 public class SiteDocument : CoreDataCosmosDocument
 {
-    [JsonProperty("name")]
-    public string Name { get; set; }
-    
-    [JsonProperty("address")]
-    public string Address { get; set; }
-    
-    [JsonProperty("phoneNumber")]
-    public string PhoneNumber { get; set; }
-    
-    [JsonProperty("region")]
-    public string Region { get; set; }
-    
-    [JsonProperty("integratedCareBoard")]
-    public string IntegratedCareBoard { get; set; }
-    
-    [JsonProperty("location")]
-    public Location Location { get; set; }
+    [JsonProperty("name")] public string Name { get; set; }
 
-    [JsonProperty("attributeValues")]
-    public AttributeValue[] AttributeValues { get; set; }
+    [JsonProperty("odsCode")] public string OdsCode { get; set; }
 
-    [JsonProperty("referenceNumberGroup")]
-    public int ReferenceNumberGroup { get; set; }
+    [JsonProperty("address")] public string Address { get; set; }
+
+    [JsonProperty("phoneNumber")] public string PhoneNumber { get; set; }
+
+    [JsonProperty("region")] public string Region { get; set; }
+
+    [JsonProperty("integratedCareBoard")] public string IntegratedCareBoard { get; set; }
+
+    [JsonProperty("location")] public Location Location { get; set; }
+
+    [JsonProperty("attributeValues")] public AttributeValue[] AttributeValues { get; set; }
+
+    [JsonProperty("referenceNumberGroup")] public int ReferenceNumberGroup { get; set; }
 }
-
-

--- a/src/api/Nhs.Appointments.Persistance/Models/SiteDocument.cs
+++ b/src/api/Nhs.Appointments.Persistance/Models/SiteDocument.cs
@@ -8,11 +8,11 @@ public class SiteDocument : CoreDataCosmosDocument
 {
     [JsonProperty("name")] public string Name { get; set; }
 
-    [JsonProperty("odsCode")] public string OdsCode { get; set; }
-
     [JsonProperty("address")] public string Address { get; set; }
 
     [JsonProperty("phoneNumber")] public string PhoneNumber { get; set; }
+
+    [JsonProperty("odsCode")] public string OdsCode { get; set; }
 
     [JsonProperty("region")] public string Region { get; set; }
 

--- a/src/client/src/app/home-page.test.tsx
+++ b/src/client/src/app/home-page.test.tsx
@@ -15,13 +15,13 @@ describe('Home Page', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Site Alpha' })).toHaveAttribute(
       'href',
-      `/site/1001`,
+      `/site/34e990af-5dc9-43a6-8895-b9123216d699`,
     );
 
     expect(screen.getByRole('link', { name: 'Site Beta' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Site Beta' })).toHaveAttribute(
       'href',
-      `/site/1002`,
+      `/site/95e4ca69-da15-45f5-9ec7-6b2ea50f07c8`,
     );
 
     expect(
@@ -29,7 +29,7 @@ describe('Home Page', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Site Gamma' })).toHaveAttribute(
       'href',
-      `/site/1003`,
+      `/site/d79bec60-8968-4101-b553-67dec04e1019`,
     );
   });
 });

--- a/src/client/src/app/lib/components/nhs-page.test.tsx
+++ b/src/client/src/app/lib/components/nhs-page.test.tsx
@@ -64,9 +64,10 @@ describe('Nhs Page', () => {
       emailAddress: 'test@nhs.net',
       availableSites: [
         {
-          id: 'TEST',
+          id: '6877d86e-c2df-4def-8508-e1eccf0ea6be',
           name: 'Test site',
           address: '',
+          odsCode: 'K12',
           integratedCareBoard: 'ICB2',
           region: 'R2',
         },
@@ -173,9 +174,10 @@ describe('Nhs Page', () => {
       title: 'Test title',
       children: null,
       site: {
-        id: 'TEST',
+        id: '6877d86e-c2df-4def-8508-e1eccf0ea6be',
         name: 'Test site',
         address: '',
+        odsCode: 'K12',
         integratedCareBoard: '',
         region: '',
       },
@@ -184,7 +186,9 @@ describe('Nhs Page', () => {
     });
     render(jsx);
 
-    expect(fetchPermissionsMock).toHaveBeenCalledWith('TEST');
+    expect(fetchPermissionsMock).toHaveBeenCalledWith(
+      '6877d86e-c2df-4def-8508-e1eccf0ea6be',
+    );
 
     expect(
       screen.getByRole('navigation', { name: 'Primary navigation' }),
@@ -204,20 +208,26 @@ describe('Nhs Page', () => {
     expect(viewAvailabilityLink).toBeVisible();
     expect(viewAvailabilityLink).toHaveAttribute(
       'href',
-      '/site/TEST/view-availability',
+      '/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/view-availability',
     );
 
     expect(createAvailabilityLink).toBeVisible();
     expect(createAvailabilityLink).toHaveAttribute(
       'href',
-      '/site/TEST/create-availability',
+      '/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/create-availability',
     );
 
     expect(manageSiteLink).toBeVisible();
-    expect(manageSiteLink).toHaveAttribute('href', '/site/TEST/details');
+    expect(manageSiteLink).toHaveAttribute(
+      'href',
+      '/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/details',
+    );
 
     expect(viewUsersLink).toBeVisible();
-    expect(viewUsersLink).toHaveAttribute('href', '/site/TEST/users');
+    expect(viewUsersLink).toHaveAttribute(
+      'href',
+      '/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/users',
+    );
   });
 
   it('Does not request permissions if not site is provided', async () => {
@@ -239,9 +249,10 @@ describe('Nhs Page', () => {
       title: 'Test title',
       children: null,
       site: {
-        id: 'TEST',
+        id: '6877d86e-c2df-4def-8508-e1eccf0ea6be',
         name: 'Test site',
         address: '',
+        odsCode: 'K12',
         integratedCareBoard: '',
         region: '',
       },
@@ -250,7 +261,9 @@ describe('Nhs Page', () => {
     });
     render(jsx);
 
-    expect(fetchPermissionsMock).toHaveBeenCalledWith('TEST');
+    expect(fetchPermissionsMock).toHaveBeenCalledWith(
+      '6877d86e-c2df-4def-8508-e1eccf0ea6be',
+    );
 
     expect(
       screen.queryByRole('navigation', { name: 'Primary navigation' }),
@@ -275,9 +288,10 @@ describe('Nhs Page', () => {
       title: 'Test title',
       children: null,
       site: {
-        id: 'TEST',
+        id: '6877d86e-c2df-4def-8508-e1eccf0ea6be',
         name: 'Test site',
         address: '',
+        odsCode: 'K12',
         integratedCareBoard: '',
         region: '',
       },
@@ -312,9 +326,10 @@ describe('Nhs Page', () => {
       title: 'Test title',
       children: null,
       site: {
-        id: 'TEST',
+        id: '6877d86e-c2df-4def-8508-e1eccf0ea6be',
         name: 'Test site',
         address: '',
+        odsCode: 'K12',
         integratedCareBoard: '',
         region: '',
       },

--- a/src/client/src/app/lib/components/site-list.test.tsx
+++ b/src/client/src/app/lib/components/site-list.test.tsx
@@ -6,16 +6,18 @@ describe('<SiteList>', () => {
   it('renders a link for each available site', async () => {
     const testSites: Site[] = [
       {
-        id: '1000',
+        id: '34e990af-5dc9-43a6-8895-b9123216d699',
         name: 'Site Alpha',
         address: 'Alpha Street',
+        odsCode: '1000',
         integratedCareBoard: 'ICB0',
         region: 'R0',
       },
       {
-        id: '1001',
+        id: '95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
         name: 'Site Beta',
         address: 'Beta Street',
+        odsCode: '1002',
         integratedCareBoard: 'ICB1',
         region: 'R1',
       },
@@ -28,30 +30,34 @@ describe('<SiteList>', () => {
   it('renders sites in ascending alphabetical order', async () => {
     const testSites: Site[] = [
       {
-        id: '1001',
+        id: '34e990af-5dc9-43a6-8895-b9123216d699',
         name: 'Site Zulu',
         address: 'Zulu Street',
+        odsCode: '1001',
         integratedCareBoard: 'ICB1',
         region: 'R1',
       },
       {
-        id: '1002',
+        id: '95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
         name: 'Site Lima',
         address: 'Lima Street',
+        odsCode: '1002',
         integratedCareBoard: 'ICB2',
         region: 'R2',
       },
       {
-        id: '1003',
+        id: 'd79bec60-8968-4101-b553-67dec04e1019',
         name: 'Site November',
         address: 'November Street',
+        odsCode: '1003',
         integratedCareBoard: 'ICB3',
         region: 'R3',
       },
       {
-        id: '1004',
+        id: '90a9c1f2-83d0-4c40-9c7c-080d91c56e79',
         name: 'Site Beta',
         address: 'Beta Street',
+        odsCode: '1004',
         integratedCareBoard: 'ICB4',
         region: 'R4',
       },
@@ -68,9 +74,10 @@ describe('<SiteList>', () => {
   it('links to the correct page', async () => {
     const testSites: Site[] = [
       {
-        id: '1000',
+        id: '95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
         name: 'Site Alpha',
         address: 'Alpha Street',
+        odsCode: '1000',
         integratedCareBoard: 'ICB0',
         region: 'R0',
       },
@@ -78,7 +85,7 @@ describe('<SiteList>', () => {
     render(<SiteList sites={testSites} />);
     expect(screen.getByRole('link', { name: 'Site Alpha' })).toHaveAttribute(
       'href',
-      '/site/1000',
+      '/site/95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
     );
   });
 });

--- a/src/client/src/app/lib/services/siteService.ts
+++ b/src/client/src/app/lib/services/siteService.ts
@@ -15,7 +15,7 @@ export const mapSiteSummaryData = (
     title: 'Address',
     value: site.address.match(/[^,]+,|[^,]+$/g) || [], // Match each word followed by a comma, or the last word without a comma
   });
-  items.push({ title: 'ODS code', value: site.id });
+  items.push({ title: 'ODS code', value: site.odsCode });
   items.push({
     title: 'ICB',
     value:

--- a/src/client/src/app/lib/types/index.tsx
+++ b/src/client/src/app/lib/types/index.tsx
@@ -121,6 +121,7 @@ type Site = {
   id: string;
   name: string;
   address: string;
+  odsCode: string;
   integratedCareBoard: string;
   region: string;
 };

--- a/src/client/src/app/site/[site]/availability/edit/confirmed/edit-session-confirmed.test.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/confirmed/edit-session-confirmed.test.tsx
@@ -46,7 +46,7 @@ describe('Cancellation Confirmed Page', () => {
       screen.getByRole('link', { name: 'Cancel appointments' }),
     ).toHaveAttribute(
       'href',
-      '/site/1001/view-availability/daily-appointments?date=2025-01-15&page=1&tab=2',
+      '/site/34e990af-5dc9-43a6-8895-b9123216d699/view-availability/daily-appointments?date=2025-01-15&page=1&tab=2',
     );
   });
 });

--- a/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.test.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.test.tsx
@@ -87,7 +87,7 @@ describe('Edit Session Time And Capacity Form', () => {
     expect(editSessionMock).toHaveBeenCalledTimes(1);
     expect(editSessionMock).toHaveBeenCalledWith({
       date: '2024-06-10 07:00:00',
-      site: '1001',
+      site: '34e990af-5dc9-43a6-8895-b9123216d699',
       mode: 'Edit',
       sessions: [
         {

--- a/src/client/src/app/site/[site]/users/remove/remove-user-page.test.tsx
+++ b/src/client/src/app/site/[site]/users/remove/remove-user-page.test.tsx
@@ -40,7 +40,9 @@ describe('Remove User Page', () => {
     const cancelButton = screen.getByRole('button', { name: 'Cancel' });
     await user.click(cancelButton);
 
-    expect(mockReplace).toHaveBeenCalledWith('/site/1001/users');
+    expect(mockReplace).toHaveBeenCalledWith(
+      '/site/34e990af-5dc9-43a6-8895-b9123216d699/users',
+    );
   });
 
   it('calls the save function when saved', async () => {
@@ -53,7 +55,7 @@ describe('Remove User Page', () => {
     );
 
     expect(mockSaveUserRoleAssignments).toHaveBeenCalledWith(
-      '1001',
+      '34e990af-5dc9-43a6-8895-b9123216d699',
       'mock.user@nhs.net',
     );
   });

--- a/src/client/src/app/testing/data.ts
+++ b/src/client/src/app/testing/data.ts
@@ -66,30 +66,34 @@ const mockAssignments = [
 
 const mockSites: Site[] = [
   {
-    id: '1001',
+    id: '34e990af-5dc9-43a6-8895-b9123216d699',
     name: 'Site Alpha',
     address: 'Alpha Street',
+    odsCode: '1001',
     integratedCareBoard: 'ICB1',
     region: 'R1',
   },
   {
-    id: '1002',
+    id: '95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
     name: 'Site Beta',
     address: 'Beta Street',
+    odsCode: '1002',
     integratedCareBoard: 'ICB2',
     region: 'R2',
   },
   {
-    id: '1003',
+    id: 'd79bec60-8968-4101-b553-67dec04e1019',
     name: 'Site Gamma',
     address: 'Gamma Street',
+    odsCode: '1003',
     integratedCareBoard: 'ICB3',
     region: 'R3',
   },
   {
-    id: '1004',
+    id: '90a9c1f2-83d0-4c40-9c7c-080d91c56e79',
     name: 'Site Delta',
     address: 'Delta Street, London',
+    odsCode: '1004',
     integratedCareBoard: 'ICB4',
     region: 'R4',
   },
@@ -244,6 +248,7 @@ const mockSiteWithAttributes: SiteWithAttributes = {
   id: mockSites[0].id,
   address: mockSites[0].address,
   name: mockSites[0].name,
+  odsCode: mockSites[0].odsCode,
   integratedCareBoard: mockSites[0].integratedCareBoard,
   region: mockSites[0].region,
   attributeValues: [

--- a/src/client/testing/create-and-remove-user.spec.ts
+++ b/src/client/testing/create-and-remove-user.spec.ts
@@ -39,7 +39,7 @@ test.beforeEach(async ({ page }) => {
   await siteSelectionPage.selectSite('Robin Lane Medical Centre');
   await sitePage.userManagementCard.click();
 
-  await page.waitForURL('**/site/ABC01/users');
+  await page.waitForURL('**/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users');
 });
 
 // TODO: Maybe something like this to clear up all the users created along the way?
@@ -93,7 +93,9 @@ test('Cannot create a user without any roles', async ({ newUserName }) => {
   await userManagementPage.selectRole('Availability manager');
 
   await userManagementPage.confirmAndSaveButton.click();
-  await userManagementPage.page.waitForURL('**/site/ABC01/users');
+  await userManagementPage.page.waitForURL(
+    '**/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users',
+  );
   await userManagementPage.userExists(newUserName);
 });
 
@@ -106,7 +108,9 @@ test('Can remove a user', async ({ newUserName }) => {
   await userManagementPage.selectRole('Availability manager');
 
   await userManagementPage.confirmAndSaveButton.click();
-  await userManagementPage.page.waitForURL('**/site/ABC01/users');
+  await userManagementPage.page.waitForURL(
+    '**/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users',
+  );
   await userManagementPage.userExists(newUserName);
 
   await userManagementPage.page
@@ -124,7 +128,9 @@ test('Can remove a user', async ({ newUserName }) => {
   ).toBeVisible();
 
   await confirmRemoveUserPage.confirmRemoveButton.click();
-  await confirmRemoveUserPage.page.waitForURL('**/site/ABC01/users');
+  await confirmRemoveUserPage.page.waitForURL(
+    '**/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users',
+  );
 
   await userManagementPage.userDoesNotExist(newUserName);
 });
@@ -138,7 +144,9 @@ test('Displays a notification banner after removing a user, which disappears whe
   await userManagementPage.searchUserButton.click();
   await userManagementPage.selectRole('Appointment manager');
   await userManagementPage.confirmAndSaveButton.click();
-  await userManagementPage.page.waitForURL('**/site/ABC01/users');
+  await userManagementPage.page.waitForURL(
+    '**/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users',
+  );
 
   await userManagementPage.page
     .getByRole('row')
@@ -155,14 +163,16 @@ test('Displays a notification banner after removing a user, which disappears whe
   ).toBeVisible();
 
   await confirmRemoveUserPage.confirmRemoveButton.click();
-  await confirmRemoveUserPage.page.waitForURL('**/site/ABC01/users');
+  await confirmRemoveUserPage.page.waitForURL(
+    '**/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users',
+  );
 
   await userManagementPage.userDoesNotExist(newUserName);
 });
 
 test('Receives 403 error when trying to remove self', async ({ page }) => {
   await page.goto(
-    `/manage-your-appointments/site/ABC01/users/remove?user=zzz_test_user_1@nhs.net`,
+    `/manage-your-appointments/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users/remove?user=zzz_test_user_1@nhs.net`,
   );
 
   await expect(notAuthorizedPage.title).toBeVisible();
@@ -170,7 +180,7 @@ test('Receives 403 error when trying to remove self', async ({ page }) => {
 
 test('Receives 404 when trying to remove an invalid user', async ({ page }) => {
   await page.goto(
-    `/manage-your-appointments/site/ABC01/users/remove?user=not-a-user`,
+    `/manage-your-appointments/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users/remove?user=not-a-user`,
   );
 
   await expect(notFoundPage.title).toBeVisible();
@@ -179,7 +189,7 @@ test('Receives 404 when trying to remove an invalid user', async ({ page }) => {
 
 test('Receives 403 error when trying to edit self', async ({ page }) => {
   await page.goto(
-    `/manage-your-appointments/site/ABC01/users/manage?user=zzz_test_user_1@nhs.net`,
+    `/manage-your-appointments/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users/manage?user=zzz_test_user_1@nhs.net`,
   );
 
   await expect(notAuthorizedPage.title).toBeVisible();

--- a/src/client/testing/create-availability.spec.ts
+++ b/src/client/testing/create-availability.spec.ts
@@ -27,7 +27,9 @@ test.beforeEach(async ({ page }) => {
   await oAuthPage.signIn();
   await siteSelectionPage.selectSite('Church Lane Pharmacy');
   await sitePage.createAvailabilityCard.click();
-  await page.waitForURL('**/site/ABC02/create-availability');
+  await page.waitForURL(
+    '**/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/create-availability',
+  );
 });
 
 test('A user can navigate to the Create Availability flow from the site page', async () => {

--- a/src/client/testing/tests/change-site-details-tests/edit-access-need.spec.ts
+++ b/src/client/testing/tests/change-site-details-tests/edit-access-need.spec.ts
@@ -29,10 +29,12 @@ test.beforeEach(async ({ page }) => {
   await oAuthPage.signIn(TEST_USERS.testUser1);
   await siteSelectionPage.selectSite('Church Lane Pharmacy');
   await sitePage.siteManagementCard.click();
-  await page.waitForURL('**/site/ABC02/details');
+  await page.waitForURL('**/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/details');
   await siteDetailsPage.editSiteAttributesButton.click();
 
-  await page.waitForURL('**/site/ABC02/details/edit-attributes');
+  await page.waitForURL(
+    '**/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/details/edit-attributes',
+  );
 });
 
 test('Update access attributes for a site', async ({ page }) => {
@@ -48,14 +50,18 @@ test('Update access attributes for a site', async ({ page }) => {
 
   // Go back into edit UI to assert on checkbox state:
   await siteDetailsPage.editSiteAttributesButton.click();
-  await page.waitForURL('**/site/ABC02/details/edit-attributes');
+  await page.waitForURL(
+    '**/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/details/edit-attributes',
+  );
 
   await editAccessNeedstPage.attributeChecked('Accessible toilet');
   await editAccessNeedstPage.attributeNotChecked('Step free access');
 
   // Reload page
   await editAccessNeedstPage.page.reload();
-  await page.waitForURL('**/site/ABC02/details/edit-attributes');
+  await page.waitForURL(
+    '**/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/details/edit-attributes',
+  );
 
   // Check selected attributes are still correctly toggled after page reload
   await editAccessNeedstPage.verifyAccessNeedsCheckedOrUnchecked(

--- a/src/client/testing/tests/change-site-details-tests/edit-citizen-information.spec.ts
+++ b/src/client/testing/tests/change-site-details-tests/edit-citizen-information.spec.ts
@@ -29,9 +29,11 @@ test.beforeEach(async ({ page }) => {
   await oAuthPage.signIn(TEST_USERS.testUser1);
   await siteSelectionPage.selectSite('Church Lane Pharmacy');
   await sitePage.siteManagementCard.click();
-  await page.waitForURL('**/site/ABC02/details');
+  await page.waitForURL('**/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/details');
   await siteDetailsPage.editInformationCitizenButton.click();
-  await page.waitForURL('**/site/ABC02/details/edit-information-for-citizens');
+  await page.waitForURL(
+    '**/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/details/edit-information-for-citizens',
+  );
 });
 
 test('Update information for citizen', async () => {

--- a/src/client/testing/tests/change-site-details-tests/site-details.spec.ts
+++ b/src/client/testing/tests/change-site-details-tests/site-details.spec.ts
@@ -26,7 +26,7 @@ test.beforeEach(async ({ page }) => {
   await oAuthPage.signIn(TEST_USERS.testUser1);
   await siteSelectionPage.selectSite('Church Lane Pharmacy');
   await sitePage.siteManagementCard.click();
-  await page.waitForURL('**/site/ABC02/details');
+  await page.waitForURL('**/site/6877d86e-c2df-4def-8508-e1eccf0ea6be/details');
 });
 
 test('Verify information on site page', async () => {

--- a/src/client/testing/user-management-permissions.spec.ts
+++ b/src/client/testing/user-management-permissions.spec.ts
@@ -66,7 +66,9 @@ test('Navigating straight to the user management page works as expected', async 
   await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser1);
 
-  await page.goto('/manage-your-appointments/site/ABC01/users');
+  await page.goto(
+    '/manage-your-appointments/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users',
+  );
   await expect(usersPage.title).toBeVisible();
 });
 
@@ -77,11 +79,15 @@ test('Navigating straight to the user management page displays an appropriate er
   await rootPage.pageContentLogInButton.click();
   await oAuthPage.signIn(TEST_USERS.testUser3);
 
-  await page.goto('/manage-your-appointments/site/ABC01/users');
+  await page.goto(
+    '/manage-your-appointments/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users',
+  );
   await expect(usersPage.emailColumn).not.toBeVisible();
   await expect(notAuthorizedPage.title).toBeVisible();
 
-  await page.goto('/manage-your-appointments/site/ABC01/users/manage');
+  await page.goto(
+    '/manage-your-appointments/site/5914b64a-66bb-4ee2-ab8a-94958c1fdfcb/users/manage',
+  );
   await expect(userManagementPage.emailInput).not.toBeVisible();
   await expect(notAuthorizedPage.title).toBeVisible();
 });

--- a/tests/CsvDataTool.UnitTests/CsvProcessorTests.cs
+++ b/tests/CsvDataTool.UnitTests/CsvProcessorTests.cs
@@ -1,41 +1,47 @@
-using FluentAssertions;
 using System.Text;
-using Nhs.Appointments.Persistance.Models;
+using FluentAssertions;
 using Moq;
 using Nhs.Appointments.Core;
+using Nhs.Appointments.Persistance.Models;
 
 namespace CsvDataTool.UnitTests;
 
 public class CsvProcessorTests
 {
+    private const string SitesHeader =
+        "OdsCode,Name,Address,PhoneNumber,Longitude,Latitude,ICB,Region,Site type,accessible_toilet,braille_translation_service,disabled_car_parking,car_parking,induction_loop,sign_language_service,step_free_access,text_relay,wheelchair_access";
+
+    private const string UsersHeader = "User,Site";
+    private const string ApiUserHeader = "ClientId,ApiSigningKey";
+
     [Fact]
     public async Task CanReadUserData()
     {
         string[] inputRows =
-            [
+        [
             "test1@nhs.net,ABC01",
             "test1@nhs.net,ABC02",
             "test2@nhs.net,ABC01",
             "test2@nhs.net,ABC03",
-            ];
+        ];
 
         var expectedUserDocuments = new UserDocument[]
         {
             new()
             {
                 Id = "test1@nhs.net",
-                DocumentType = "user",                
+                DocumentType = "user",
                 LatestAcceptedEulaVersion = DateOnly.MinValue,
                 RoleAssignments =
                 [
-                    new() {Role = "canned:user-manager", Scope = "site:ABC01"},
-                    new() {Role = "canned:site-details-manager", Scope = "site:ABC01"},
-                    new() {Role = "canned:availability-manager", Scope = "site:ABC01"},
-                    new() {Role = "canned:appointment-manager", Scope = "site:ABC01"},
-                    new() {Role = "canned:user-manager", Scope = "site:ABC02"},
-                    new() {Role = "canned:site-details-manager", Scope = "site:ABC02"},
-                    new() {Role = "canned:availability-manager", Scope = "site:ABC02"},
-                    new() {Role = "canned:appointment-manager", Scope = "site:ABC02"}
+                    new() { Role = "canned:user-manager", Scope = "site:ABC01" },
+                    new() { Role = "canned:site-details-manager", Scope = "site:ABC01" },
+                    new() { Role = "canned:availability-manager", Scope = "site:ABC01" },
+                    new() { Role = "canned:appointment-manager", Scope = "site:ABC01" },
+                    new() { Role = "canned:user-manager", Scope = "site:ABC02" },
+                    new() { Role = "canned:site-details-manager", Scope = "site:ABC02" },
+                    new() { Role = "canned:availability-manager", Scope = "site:ABC02" },
+                    new() { Role = "canned:appointment-manager", Scope = "site:ABC02" }
                 ]
             },
             new()
@@ -45,42 +51,42 @@ public class CsvProcessorTests
                 LatestAcceptedEulaVersion = DateOnly.MinValue,
                 RoleAssignments =
                 [
-                    new() {Role = "canned:user-manager", Scope = "site:ABC01"},
-                    new() {Role = "canned:site-details-manager", Scope = "site:ABC01"},
-                    new() {Role = "canned:availability-manager", Scope = "site:ABC01"},
-                    new() {Role = "canned:appointment-manager", Scope = "site:ABC01"},
-                    new() {Role = "canned:user-manager", Scope = "site:ABC03"},
-                    new() {Role = "canned:site-details-manager", Scope = "site:ABC03"},
-                    new() {Role = "canned:availability-manager", Scope = "site:ABC03"},
-                    new() {Role = "canned:appointment-manager", Scope = "site:ABC03"}
-
+                    new() { Role = "canned:user-manager", Scope = "site:ABC01" },
+                    new() { Role = "canned:site-details-manager", Scope = "site:ABC01" },
+                    new() { Role = "canned:availability-manager", Scope = "site:ABC01" },
+                    new() { Role = "canned:appointment-manager", Scope = "site:ABC01" },
+                    new() { Role = "canned:user-manager", Scope = "site:ABC03" },
+                    new() { Role = "canned:site-details-manager", Scope = "site:ABC03" },
+                    new() { Role = "canned:availability-manager", Scope = "site:ABC03" },
+                    new() { Role = "canned:appointment-manager", Scope = "site:ABC03" }
                 ]
             }
         };
-        
+
         var input = BuildInputCsv(UsersHeader, inputRows);
         var actualUserDocuments = new List<UserDocument>();
         var mockFileOperations = new Mock<IFileOperations>();
         mockFileOperations.Setup(x => x.OpenText(It.IsAny<FileInfo>())).Returns(new StringReader(input));
-        mockFileOperations.Setup(x => x.WriteDocument<UserDocument>(It.IsAny<UserDocument>(), It.IsAny<string>())).Callback<UserDocument, string>((doc, path) => actualUserDocuments.Add(doc));
+        mockFileOperations.Setup(x => x.WriteDocument<UserDocument>(It.IsAny<UserDocument>(), It.IsAny<string>()))
+            .Callback<UserDocument, string>((doc, path) => actualUserDocuments.Add(doc));
 
         var sut = new UserDataImportHandler(mockFileOperations.Object);
         var report = await sut.ProcessFile(new FileInfo("test.csv"), new DirectoryInfo("/out"));
 
         actualUserDocuments.Should().BeEquivalentTo(expectedUserDocuments);
-        
+
         report.Count().Should().Be(4);
-        report.Any(r => !r.Success).Should().BeFalse();        
+        report.Any(r => !r.Success).Should().BeFalse();
     }
-    
+
     [Fact]
     public async Task CanReadApiUserData()
     {
         string[] inputRows =
-            [
+        [
             "test1,ABC123",
             "test2,DEF345"
-            ];
+        ];
 
         var expectedUserDocuments = new UserDocument[]
         {
@@ -92,56 +98,57 @@ public class CsvProcessorTests
                 LatestAcceptedEulaVersion = DateOnly.MinValue,
                 RoleAssignments =
                 [
-                    new() {Role = "system:api-user", Scope = "global"}
+                    new() { Role = "system:api-user", Scope = "global" }
                 ]
             },
             new()
             {
                 Id = "api@test2",
-                DocumentType = "user",   
+                DocumentType = "user",
                 ApiSigningKey = "DEF345",
                 LatestAcceptedEulaVersion = DateOnly.MinValue,
                 RoleAssignments =
                 [
-                    new() {Role = "system:api-user", Scope = "global"}
+                    new() { Role = "system:api-user", Scope = "global" }
                 ]
             }
         };
-        
+
         var input = BuildInputCsv(ApiUserHeader, inputRows);
         var actualUserDocuments = new List<UserDocument>();
         var mockFileOperations = new Mock<IFileOperations>();
         mockFileOperations.Setup(x => x.OpenText(It.IsAny<FileInfo>())).Returns(new StringReader(input));
-        mockFileOperations.Setup(x => x.WriteDocument<UserDocument>(It.IsAny<UserDocument>(), It.IsAny<string>())).Callback<UserDocument, string>((doc, path) => actualUserDocuments.Add(doc));
+        mockFileOperations.Setup(x => x.WriteDocument<UserDocument>(It.IsAny<UserDocument>(), It.IsAny<string>()))
+            .Callback<UserDocument, string>((doc, path) => actualUserDocuments.Add(doc));
 
         var sut = new ApiUserDataImportHandler(mockFileOperations.Object);
         var report = await sut.ProcessFile(new FileInfo("test.csv"), new DirectoryInfo("/out"));
 
         actualUserDocuments.Should().BeEquivalentTo(expectedUserDocuments);
-        
+
         report.Count().Should().Be(2);
-        report.Any(r => !r.Success).Should().BeFalse();        
+        report.Any(r => !r.Success).Should().BeFalse();
     }
 
     [Fact]
-    public async Task  CanReadSiteData()
-    {         
+    public async Task CanReadSiteData()
+    {
         string[] inputRows =
-            [
+        [
             "site1,\"test site 1\",\"123 test street\",\"01234 567890\",\"1.0\",\"60.0\",\"test icb1\",\"Yorkshire\",,true,True,False,false,\"YES\",no,true,true,NO",
             "site2,\"test site 2\",\"123 test street\",\"01234 567890\",1.0,60.0,\"test icb2\",\"Yorkshire\",,true,True,False,false,\"YES\",no,true,true,NO",
             "site3,\"test site 3\",\"123 test street\",\"01234 567890\",1.0,60.0,\"test icb3\",\"Yorkshire\",,true,,False,\"oranges\",\"YES\",no,true,true,NO",
-            ];
+        ];
 
         var expectedSites = new SiteDocument[]
         {
             new()
             {
-                Id = "site1",
+                OdsCode = "site1",
                 Name = "test site 1",
                 Address = "123 test street",
                 PhoneNumber = "01234 567890",
-                Location = new Nhs.Appointments.Core.Location("Point", [1.0, 60.0]),
+                Location = new Location("Point", [1.0, 60.0]),
                 DocumentType = "site",
                 ReferenceNumberGroup = 0,
                 IntegratedCareBoard = "test icb1",
@@ -161,11 +168,11 @@ public class CsvProcessorTests
             },
             new()
             {
-                Id = "site2",
+                OdsCode = "site2",
                 Name = "test site 2",
                 Address = "123 test street",
                 PhoneNumber = "01234 567890",
-                Location = new Nhs.Appointments.Core.Location("Point", [1.0, 60.0]),
+                Location = new Location("Point", [1.0, 60.0]),
                 DocumentType = "site",
                 ReferenceNumberGroup = 0,
                 IntegratedCareBoard = "test icb2",
@@ -185,11 +192,11 @@ public class CsvProcessorTests
             },
             new()
             {
-                Id = "site3",
+                OdsCode = "site3",
                 Name = "test site 3",
                 Address = "123 test street",
                 PhoneNumber = "01234 567890",
-                Location = new Nhs.Appointments.Core.Location("Point", [1.0, 60.0]),
+                Location = new Location("Point", [1.0, 60.0]),
                 DocumentType = "site",
                 ReferenceNumberGroup = 0,
                 IntegratedCareBoard = "test icb3",
@@ -213,12 +220,16 @@ public class CsvProcessorTests
         var actualSiteDocuments = new List<SiteDocument>();
         var mockFileOperations = new Mock<IFileOperations>();
         mockFileOperations.Setup(x => x.OpenText(It.IsAny<FileInfo>())).Returns(new StringReader(input));
-        mockFileOperations.Setup(x => x.WriteDocument<SiteDocument>(It.IsAny<SiteDocument>(), It.IsAny<string>())).Callback<SiteDocument, string>((doc, path) => actualSiteDocuments.Add(doc));
+        mockFileOperations.Setup(x => x.WriteDocument<SiteDocument>(It.IsAny<SiteDocument>(), It.IsAny<string>()))
+            .Callback<SiteDocument, string>((doc, path) => actualSiteDocuments.Add(doc));
 
         var sut = new SiteDataImportHandler(mockFileOperations.Object);
         var report = await sut.ProcessFile(new FileInfo("test.csv"), new DirectoryInfo("out"));
 
-        actualSiteDocuments.Should().BeEquivalentTo(expectedSites);
+        actualSiteDocuments.Should().BeEquivalentTo(expectedSites, opt => opt.Excluding(x => x.Id));
+
+        //assert each site got a new distinct ID of type GUID
+        actualSiteDocuments.Select(x => Guid.Parse(x.Id)).Distinct().Should().HaveCount(3);
 
         report.Count().Should().Be(3);
         report.Any(r => !r.Success).Should().BeFalse();
@@ -235,8 +246,4 @@ public class CsvProcessorTests
 
         return result.ToString();
     }
-
-    private const string SitesHeader = "ID,Name,Address,PhoneNumber,Longitude,Latitude,ICB,Region,Site type,accessible_toilet,braille_translation_service,disabled_car_parking,car_parking,induction_loop,sign_language_service,step_free_access,text_relay,wheelchair_access";
-    private const string UsersHeader = "User,Site";
-    private const string ApiUserHeader = "ClientId,ApiSigningKey";
 }

--- a/tests/CsvDataTool.UnitTests/CsvProcessorTests.cs
+++ b/tests/CsvDataTool.UnitTests/CsvProcessorTests.cs
@@ -19,10 +19,10 @@ public class CsvProcessorTests
     {
         string[] inputRows =
         [
-            "test1@nhs.net,ABC01",
-            "test1@nhs.net,ABC02",
-            "test2@nhs.net,ABC01",
-            "test2@nhs.net,ABC03",
+            "test1@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test1@nhs.net,308d515c-2002-450e-b248-4ba36f6667bb",
+            "test2@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test2@nhs.net,9a06bacd-e916-4c10-8263-21451ca751b8",
         ];
 
         var expectedUserDocuments = new UserDocument[]
@@ -34,14 +34,14 @@ public class CsvProcessorTests
                 LatestAcceptedEulaVersion = DateOnly.MinValue,
                 RoleAssignments =
                 [
-                    new() { Role = "canned:user-manager", Scope = "site:ABC01" },
-                    new() { Role = "canned:site-details-manager", Scope = "site:ABC01" },
-                    new() { Role = "canned:availability-manager", Scope = "site:ABC01" },
-                    new() { Role = "canned:appointment-manager", Scope = "site:ABC01" },
-                    new() { Role = "canned:user-manager", Scope = "site:ABC02" },
-                    new() { Role = "canned:site-details-manager", Scope = "site:ABC02" },
-                    new() { Role = "canned:availability-manager", Scope = "site:ABC02" },
-                    new() { Role = "canned:appointment-manager", Scope = "site:ABC02" }
+                    new() { Role = "canned:user-manager", Scope = "site:d3793464-b421-41f3-9bfa-53b06e7b3d19" },
+                    new() { Role = "canned:site-details-manager", Scope = "site:d3793464-b421-41f3-9bfa-53b06e7b3d19" },
+                    new() { Role = "canned:availability-manager", Scope = "site:d3793464-b421-41f3-9bfa-53b06e7b3d19" },
+                    new() { Role = "canned:appointment-manager", Scope = "site:d3793464-b421-41f3-9bfa-53b06e7b3d19" },
+                    new() { Role = "canned:user-manager", Scope = "site:308d515c-2002-450e-b248-4ba36f6667bb" },
+                    new() { Role = "canned:site-details-manager", Scope = "site:308d515c-2002-450e-b248-4ba36f6667bb" },
+                    new() { Role = "canned:availability-manager", Scope = "site:308d515c-2002-450e-b248-4ba36f6667bb" },
+                    new() { Role = "canned:appointment-manager", Scope = "site:308d515c-2002-450e-b248-4ba36f6667bb" }
                 ]
             },
             new()
@@ -51,14 +51,14 @@ public class CsvProcessorTests
                 LatestAcceptedEulaVersion = DateOnly.MinValue,
                 RoleAssignments =
                 [
-                    new() { Role = "canned:user-manager", Scope = "site:ABC01" },
-                    new() { Role = "canned:site-details-manager", Scope = "site:ABC01" },
-                    new() { Role = "canned:availability-manager", Scope = "site:ABC01" },
-                    new() { Role = "canned:appointment-manager", Scope = "site:ABC01" },
-                    new() { Role = "canned:user-manager", Scope = "site:ABC03" },
-                    new() { Role = "canned:site-details-manager", Scope = "site:ABC03" },
-                    new() { Role = "canned:availability-manager", Scope = "site:ABC03" },
-                    new() { Role = "canned:appointment-manager", Scope = "site:ABC03" }
+                    new() { Role = "canned:user-manager", Scope = "site:d3793464-b421-41f3-9bfa-53b06e7b3d19" },
+                    new() { Role = "canned:site-details-manager", Scope = "site:d3793464-b421-41f3-9bfa-53b06e7b3d19" },
+                    new() { Role = "canned:availability-manager", Scope = "site:d3793464-b421-41f3-9bfa-53b06e7b3d19" },
+                    new() { Role = "canned:appointment-manager", Scope = "site:d3793464-b421-41f3-9bfa-53b06e7b3d19" },
+                    new() { Role = "canned:user-manager", Scope = "site:9a06bacd-e916-4c10-8263-21451ca751b8" },
+                    new() { Role = "canned:site-details-manager", Scope = "site:9a06bacd-e916-4c10-8263-21451ca751b8" },
+                    new() { Role = "canned:availability-manager", Scope = "site:9a06bacd-e916-4c10-8263-21451ca751b8" },
+                    new() { Role = "canned:appointment-manager", Scope = "site:9a06bacd-e916-4c10-8263-21451ca751b8" }
                 ]
             }
         };

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -426,7 +426,9 @@ public abstract partial class BaseFeatureSteps : Feature
         _ => throw new ArgumentOutOfRangeException(nameof(bookingType)),
     };
 
-    protected string GetSiteId(string siteDesignation = "A") => $"{_testId}-{siteDesignation}";
+    protected string GetSiteId(string siteDesignation = "beeae4e0-dd4a-4e3a-8f4d-738f9418fb51") =>
+        $"{_testId}-{siteDesignation}";
+
     protected string GetUserId(string userId) => $"{userId}@{_testId}.com";
 
     private async Task SetUpRoles()

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -103,7 +103,7 @@ public abstract partial class BaseFeatureSteps : Feature
     [And("the following sessions")]
     public Task SetupSessions(DataTable dataTable)
     {
-        return SetupSessions("A", dataTable);
+        return SetupSessions("beeae4e0-dd4a-4e3a-8f4d-738f9418fb51", dataTable);
     }
 
     [Given(@"the following sessions for site '(\w)'")]
@@ -227,7 +227,7 @@ public abstract partial class BaseFeatureSteps : Feature
     [And("the following bookings have been made")]
     public Task SetupBookings(DataTable dataTable)
     {
-        return SetupBookings("A", dataTable);
+        return SetupBookings("beeae4e0-dd4a-4e3a-8f4d-738f9418fb51", dataTable);
     }
 
     [And(@"the following bookings have been made for site '(\w)'")]
@@ -240,30 +240,30 @@ public abstract partial class BaseFeatureSteps : Feature
     [And("the following recent bookings have been made")]
     public Task SetupRecentBookings(DataTable dataTable)
     {
-        return SetupBookings("A", dataTable, BookingType.Recent);
+        return SetupBookings("beeae4e0-dd4a-4e3a-8f4d-738f9418fb51", dataTable, BookingType.Recent);
     }
 
     [Given("the following provisional bookings have been made")]
     [And("the following provisional bookings have been made")]
     public Task SetupProvisionalBookings(DataTable dataTable)
     {
-        return SetupBookings("A", dataTable, BookingType.Provisional);
+        return SetupBookings("beeae4e0-dd4a-4e3a-8f4d-738f9418fb51", dataTable, BookingType.Provisional);
     }
 
     [Given("the following expired provisional bookings have been made")]
     [And("the following expired provisional bookings have been made")]
     public Task SetupExpiredProvisionalBookings(DataTable dataTable)
     {
-        return SetupBookings("A", dataTable, BookingType.ExpiredProvisional);
+        return SetupBookings("beeae4e0-dd4a-4e3a-8f4d-738f9418fb51", dataTable, BookingType.ExpiredProvisional);
     }
 
     [Given("the following cancelled bookings have been made")]
     [And("the following cancelled bookings have been made")]
     public Task SetupCancelledBookings(DataTable dataTable) =>
-        SetupBookings("A", dataTable, BookingType.Cancelled);
+        SetupBookings("beeae4e0-dd4a-4e3a-8f4d-738f9418fb51", dataTable, BookingType.Cancelled);
 
     [And("the following orphaned bookings exist")]
-    public Task SetupOrphanedBookings(DataTable dataTable) => SetupBookings("A", dataTable, BookingType.Orphaned);
+    public Task SetupOrphanedBookings(DataTable dataTable) => SetupBookings("beeae4e0-dd4a-4e3a-8f4d-738f9418fb51", dataTable, BookingType.Orphaned);
 
     protected async Task SetupBookings(string siteDesignation, DataTable dataTable, BookingType bookingType)
     {

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteByIdFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteByIdFeatureSteps.cs
@@ -1,11 +1,12 @@
-﻿using System.Drawing;
-using System.Linq;
+﻿using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Gherkin.Ast;
 using Nhs.Appointments.Api.Json;
 using Nhs.Appointments.Core;
 using Xunit.Gherkin.Quick;
+using Location = Nhs.Appointments.Core.Location;
 
 namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement;
 
@@ -20,7 +21,7 @@ public sealed class GetSiteByIdFeatureSteps : SiteManagementBaseFeatureSteps
     }
 
     [Then("the correct site is returned")]
-    public async Task Assert(Gherkin.Ast.DataTable dataTable)
+    public async Task Assert(DataTable dataTable)
     {
         var row = dataTable.Rows.ElementAt(1);
         var expectedSite = new Site(
@@ -28,15 +29,17 @@ public sealed class GetSiteByIdFeatureSteps : SiteManagementBaseFeatureSteps
             Name: row.Cells.ElementAt(1).Value,
             Address: row.Cells.ElementAt(2).Value,
             PhoneNumber: row.Cells.ElementAt(3).Value,
-            Region: row.Cells.ElementAt(4).Value,
-            IntegratedCareBoard: row.Cells.ElementAt(5).Value,
-            AttributeValues: ParseAttributes(row.Cells.ElementAt(6).Value),
+            OdsCode: row.Cells.ElementAt(4).Value,
+            Region: row.Cells.ElementAt(5).Value,
+            IntegratedCareBoard: row.Cells.ElementAt(6).Value,
+            AttributeValues: ParseAttributes(row.Cells.ElementAt(7).Value),
             Location: new Location(
                 Type: "Point",
-                Coordinates: [double.Parse(row.Cells.ElementAt(7).Value), double.Parse(row.Cells.ElementAt(8).Value)])
+                Coordinates: [double.Parse(row.Cells.ElementAt(8).Value), double.Parse(row.Cells.ElementAt(9).Value)])
         );
         Response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (_, ActualResponse) = await JsonRequestReader.ReadRequestAsync<Site>(await Response.Content.ReadAsStreamAsync());
+        (_, ActualResponse) =
+            await JsonRequestReader.ReadRequestAsync<Site>(await Response.Content.ReadAsStreamAsync());
         ActualResponse.Should().BeEquivalentTo(expectedSite);
     }
 }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteBySiteId.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteBySiteId.feature
@@ -1,24 +1,31 @@
 ﻿Feature: Get site details using site id
-  
-  Scenario: Retrieve site information by using site id 
+
+  Scenario: Retrieve site information by using site id
     Given The following sites exist in the system
-      | Site | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes            | Longitude | Latitude |
-      | A    | Site-A | 1A Site Lane | 0113 1111111 | R1     | ICB1 | def_one/attr_one=true | -60       | -60      |
-    When I request site details for site 'A' with the scope '*'
+      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | Attributes            | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A Site Lane | 0113 1111111 | 15N     | R1     | ICB1 | def_one/attr_one=true | -60       | -60      |
+    When I request site details for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51' with the scope '*'
     Then the correct site is returned
-      | Site | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes            | Longitude | Latitude |
-      | A    | Site-A | 1A Site Lane | 0113 1111111 | R1     | ICB1 | def_one/attr_one=true | -60       | -60      |
+      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | Attributes            | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A Site Lane | 0113 1111111 | 15N     | R1     | ICB1 | def_one/attr_one=true | -60       | -60      |
 
   Scenario: Returns site not found message when site does not exist
     Given The site 'zero' does not exist in the system
     When I request site details for site 'zero' with the scope '*'
     Then a message is returned saying the site is not found
 
+  Scenario: Returns site not found message when querying by ODS code
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | Attributes            | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A Site Lane | 0113 1111111 | 15N     | R1     | ICB1 | def_one/attr_one=true | -60       | -60      |
+    When I request site details for site '15N' with the scope '*'
+    Then a message is returned saying the site is not found
+
   Scenario: Returns site with filtered attributes
     Given The following sites exist in the system
-      | Site | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes                                      | Longitude | Latitude |
-      | A    | Site-A | 1A Site Lane | 0113 1234567 | R1     | ICB1 | def_one/attr_one=true, test_scope/attr_two=test | -60       | -60      |
-    When I request site details for site 'A' with the scope 'test_scope'
+      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | Attributes                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A Site Lane | 0113 1234567 | 15N     | R1     | ICB1 | def_one/attr_one=true, test_scope/attr_two=test | -60       | -60      |
+    When I request site details for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51' with the scope 'test_scope'
     Then the correct site is returned
-      | Site | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes               | Longitude | Latitude |
-      | A    | Site-A | 1A Site Lane | 0113 1234567 | R1     | ICB1 | test_scope/attr_two=test | -60       | -60      |
+      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | Attributes               | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A Site Lane | 0113 1234567 | 15N     | R1     | ICB1 | test_scope/attr_two=test | -60       | -60      |

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteMetaData.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteMetaData.feature
@@ -1,17 +1,17 @@
 ﻿Feature: Get site meta data using site id
-  
-  Scenario: Retrieve site meta data by using site id 
+
+  Scenario: Retrieve site meta data by using site id
     Given The following sites exist in the system
-      | Site | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes                                     | Longitude | Latitude |
-      | A    | Site-A | 1A Site Lane | 0113 1111111 | R1     | ICB1 | site_details/info_for_citizen=test information | -60       | -60      |
-    When I request site meta data for site 'A'
+      | Site                                 | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes                                     | Longitude | Latitude |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-A | 1A Site Lane | 0113 1111111 | R1     | ICB1 | site_details/info_for_citizen=test information | -60       | -60      |
+    When I request site meta data for site '6877d86e-c2df-4def-8508-e1eccf0ea6be'
     Then the correct site meta data is returned
-      | Site   | AdditionalInformation |
-      | Site-A | test information      |
+      | SiteName | AdditionalInformation |
+      | Site-A   | test information      |
 
   Scenario: Retrieve site meta data when it hasn't been set
     Given The following sites exist in the system
-      | Site | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes             | Longitude | Latitude |
-      | A    | Site-A | 1A Site Lane | 0113 1111111 | R1     | ICB1 | def_one/attr_one=false | -60       | -60      |
-    When I request site meta data for site 'A'
+      | Site                                 | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes             | Longitude | Latitude |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-A | 1A Site Lane | 0113 1111111 | R1     | ICB1 | def_one/attr_one=false | -60       | -60      |
+    When I request site meta data for site '6877d86e-c2df-4def-8508-e1eccf0ea6be'
     Then no site meta data is returned

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteMetaData.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteMetaData.feature
@@ -2,8 +2,8 @@
 
   Scenario: Retrieve site meta data by using site id
     Given The following sites exist in the system
-      | Site                                 | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes                                     | Longitude | Latitude |
-      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-A | 1A Site Lane | 0113 1111111 | R1     | ICB1 | site_details/info_for_citizen=test information | -60       | -60      |
+      | Site                                 | Name   | Address      | PhoneNumber  | ODSCode | Region | ICB  | Attributes                                     | Longitude | Latitude |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-A | 1A Site Lane | 0113 1111111 | J12     | R1     | ICB1 | site_details/info_for_citizen=test information | -60       | -60      |
     When I request site meta data for site '6877d86e-c2df-4def-8508-e1eccf0ea6be'
     Then the correct site meta data is returned
       | SiteName | AdditionalInformation |
@@ -11,7 +11,7 @@
 
   Scenario: Retrieve site meta data when it hasn't been set
     Given The following sites exist in the system
-      | Site                                 | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes             | Longitude | Latitude |
-      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-A | 1A Site Lane | 0113 1111111 | R1     | ICB1 | def_one/attr_one=false | -60       | -60      |
+      | Site                                 | Name   | Address      | PhoneNumber  | ODSCode | Region | ICB  | Attributes             | Longitude | Latitude |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-A | 1A Site Lane | 0113 1111111 | J12     | R1     | ICB1 | def_one/attr_one=false | -60       | -60      |
     When I request site meta data for site '6877d86e-c2df-4def-8508-e1eccf0ea6be'
     Then no site meta data is returned

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteMetaDataFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/GetSiteMetaDataFeatureSteps.cs
@@ -1,10 +1,10 @@
-﻿using FluentAssertions;
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
 using Gherkin.Ast;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Json;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 using Xunit.Gherkin.Quick;
 
 namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement
@@ -29,7 +29,9 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement
                 AdditionalInformation: row.Cells.ElementAt(1).Value);
 
             Response.StatusCode.Should().Be(HttpStatusCode.OK);
-            var (_, actualResponse) = await JsonRequestReader.ReadRequestAsync<GetSiteMetaDataResponse>(await Response.Content.ReadAsStreamAsync());
+            var (_, actualResponse) =
+                await JsonRequestReader.ReadRequestAsync<GetSiteMetaDataResponse>(
+                    await Response.Content.ReadAsStreamAsync());
             actualResponse.Should().BeEquivalentTo(expectedSite);
         }
 
@@ -37,7 +39,9 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement
         public async Task AssertEmpty()
         {
             Response.StatusCode.Should().Be(HttpStatusCode.OK);
-            var (_, actualResponse) = await JsonRequestReader.ReadRequestAsync<GetSiteMetaDataResponse>(await Response.Content.ReadAsStreamAsync());
+            var (_, actualResponse) =
+                await JsonRequestReader.ReadRequestAsync<GetSiteMetaDataResponse>(
+                    await Response.Content.ReadAsStreamAsync());
             actualResponse.AdditionalInformation.Should().BeEmpty();
         }
     }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteManagementBaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteManagementBaseFeatureSteps.cs
@@ -4,11 +4,13 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Gherkin.Ast;
 using Nhs.Appointments.Api.Json;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
 using Xunit.Gherkin.Quick;
+using Location = Nhs.Appointments.Core.Location;
 
 namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement;
 
@@ -23,44 +25,49 @@ public abstract class SiteManagementBaseFeatureSteps : BaseFeatureSteps
     {
         return Task.CompletedTask;
     }
-    
+
     [Given("The following sites exist in the system")]
-    public async Task SetUpSites(Gherkin.Ast.DataTable dataTable)
+    public async Task SetUpSites(DataTable dataTable)
     {
         var sites = dataTable.Rows.Skip(1).Select(
-            row => new SiteDocument()
+            row => new SiteDocument
             {
                 Id = GetSiteId(row.Cells.ElementAt(0).Value),
                 Name = row.Cells.ElementAt(1).Value,
                 Address = row.Cells.ElementAt(2).Value,
                 PhoneNumber = row.Cells.ElementAt(3).Value,
-                Region = row.Cells.ElementAt(4).Value,
-                IntegratedCareBoard = row.Cells.ElementAt(5).Value,
+                OdsCode = row.Cells.ElementAt(4).Value,
+                Region = row.Cells.ElementAt(5).Value,
+                IntegratedCareBoard = row.Cells.ElementAt(6).Value,
                 DocumentType = "site",
-                AttributeValues = ParseAttributes(row.Cells.ElementAt(6).Value),
-                Location = new Location("Point", new[] { double.Parse(row.Cells.ElementAt(7).Value), double.Parse(row.Cells.ElementAt(8).Value) }),
+                AttributeValues = ParseAttributes(row.Cells.ElementAt(7).Value),
+                Location = new Location("Point",
+                    new[] { double.Parse(row.Cells.ElementAt(8).Value), double.Parse(row.Cells.ElementAt(9).Value) }),
             });
-        
+
         foreach (var site in sites)
         {
             await Client.GetContainer("appts", "core_data").UpsertItemAsync(site);
         }
     }
-    
+
     [Then("a message is returned saying the site is not found")]
     public async Task Assert()
     {
         Response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (_, ErrorResponse) = await JsonRequestReader.ReadRequestAsync<ErrorMessageResponseItem>(await Response.Content.ReadAsStreamAsync());
+        (_, ErrorResponse) =
+            await JsonRequestReader.ReadRequestAsync<ErrorMessageResponseItem>(
+                await Response.Content.ReadAsStreamAsync());
         ErrorResponse.Message.Should().Be("The specified site was not found.");
     }
-    
+
     protected static AttributeValue[] ParseAttributes(string attributes)
     {
         if (attributes == "__empty__")
         {
             return Array.Empty<AttributeValue>();
         }
+
         var pairs = attributes.Split(",");
         return pairs.Select(p => p.Trim().Split("=")).Select(kvp => new AttributeValue(kvp[0], kvp[1])).ToArray();
     }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
@@ -2,43 +2,43 @@ Feature: Site search
 
   Scenario: Retrieve all sites within a designated distance
     Given The following sites exist in the system
-      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude   | Latitude  |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-1 | 1 Roadside | 0113 1111111 | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
-      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-2 | 2 Roadside | 0113 2222222 | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
-      | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-3 | 3 Roadside | 0113 3333333 | R3     | ICB3 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
-      | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-4 | 4 Roadside | 0113 4444444 | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | Attributes                   | Longitude   | Latitude  |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
+      | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     When I make the following request without access needs
       | Max Records | Search Radius | Longitude | Latitude |
       | 50          | 6000          | 0.082     | 51.5     |
     Then the following sites and distances are returned
-      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude   | Latitude  | Distance |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-1 | 1 Roadside | 0113 1111111 | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
-      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-2 | 2 Roadside | 0113 2222222 | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
-      | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-4 | 4 Roadside | 0113 4444444 | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | Attributes                   | Longitude   | Latitude  | Distance |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
+      | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
 
   Scenario: Only return the number of sites requested
     Given The following sites exist in the system
-      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude    | Latitude   |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-5 | 5 Roadside | 0113 5555555 | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 |
-      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-6 | 6 Roadside | 0113 6666666 | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 |
-      | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-7 | 7 Roadside | 0113 7777777 | R7     | ICB7 | accessibility/attr_one=true  | 0.13086317   | -51.583479 |
-      | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-8 | 8 Roadside | 0113 8888888 | R8     | ICB8 | accessibility/attr_one=false | -0.040992272 | -51.455788 |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | Attributes                   | Longitude    | Latitude   |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-5 | 5 Roadside | 0113 5555555 | J12     | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-6 | 6 Roadside | 0113 6666666 | K12     | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 |
+      | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-7 | 7 Roadside | 0113 7777777 | L12     | R7     | ICB7 | accessibility/attr_one=true  | 0.13086317   | -51.583479 |
+      | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-8 | 8 Roadside | 0113 8888888 | M12     | R8     | ICB8 | accessibility/attr_one=false | -0.040992272 | -51.455788 |
     When I make the following request without access needs
       | Max Records | Search Radius | Longitude | Latitude |
       | 2           | 100000        | -0.082    | -51.5    |
     Then the following sites and distances are returned
-      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude    | Latitude   | Distance |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-5 | 5 Roadside | 0113 5555555 | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 | 662      |
-      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-6 | 6 Roadside | 0113 6666666 | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 | 4819     |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | Attributes                   | Longitude    | Latitude   | Distance |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-5 | 5 Roadside | 0113 5555555 | J12     | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 | 662      |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-6 | 6 Roadside | 0113 6666666 | K12     | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 | 4819     |
 
   Scenario: Only return sites with requested access needs
     Given The following sites exist in the system
-      | Site                                 | Name    | Address     | PhoneNumber  | Region | ICB   | Attributes                                               | Longitude | Latitude |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-9  | 9 Roadside  | 0113 9999999 | R9     | ICB9  | accessibility/attr_one=true,accessibility/attr_two=true  | -0.0827   | -51.5    |
-      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-10 | 10 Roadside | 0113 1010101 | R10    | ICB10 | accessibility/attr_one=true,accessibility/attr_two=false | -0.0827   | -51.5    |
+      | Site                                 | Name    | Address     | PhoneNumber  | OdsCode | Region | ICB   | Attributes                                               | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-9  | 9 Roadside  | 0113 9999999 | J12     | R9     | ICB9  | accessibility/attr_one=true,accessibility/attr_two=true  | -0.0827   | -51.5    |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-10 | 10 Roadside | 0113 1010101 | K12     | R10    | ICB10 | accessibility/attr_one=true,accessibility/attr_two=false | -0.0827   | -51.5    |
     When I make the following request with access needs
       | Max Records | Search Radius | Longitude | Latitude | AccessNeeds       |
       | 50          | 100000        | -0.082    | -51.5    | attr_one,attr_two |
     Then the following sites and distances are returned
-      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                                              | Longitude | Latitude | Distance |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-9 | 9 Roadside | 0113 9999999 | R9     | ICB9 | accessibility/attr_one=true,accessibility/attr_two=true | -0.0827   | -51.5    | 48       |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | Attributes                                              | Longitude | Latitude | Distance |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-9 | 9 Roadside | 0113 9999999 | J12     | R9     | ICB9 | accessibility/attr_one=true,accessibility/attr_two=true | -0.0827   | -51.5    | 48       |

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
@@ -1,44 +1,44 @@
 Feature: Site search
-  
+
   Scenario: Retrieve all sites within a designated distance
     Given The following sites exist in the system
-      | Site | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude   | Latitude  |
-      | 1    | Site-1 | 1 Roadside | 0113 1111111 | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
-      | 2    | Site-2 | 2 Roadside | 0113 2222222 | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
-      | 3    | Site-3 | 3 Roadside | 0113 3333333 | R3     | ICB3 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
-      | 4    | Site-4 | 4 Roadside | 0113 4444444 | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude   | Latitude  |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-1 | 1 Roadside | 0113 1111111 | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-2 | 2 Roadside | 0113 2222222 | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-3 | 3 Roadside | 0113 3333333 | R3     | ICB3 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
+      | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-4 | 4 Roadside | 0113 4444444 | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     When I make the following request without access needs
       | Max Records | Search Radius | Longitude | Latitude |
       | 50          | 6000          | 0.082     | 51.5     |
     Then the following sites and distances are returned
-      | Site | Name   | Address    |  PhoneNumber  | Region | ICB  | Attributes                   | Longitude   | Latitude  | Distance |
-      | 1    | Site-1 | 1 Roadside |  0113 1111111 | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
-      | 2    | Site-2 | 2 Roadside |  0113 2222222 | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
-      | 4    | Site-4 | 4 Roadside |  0113 4444444 | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
+      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude   | Latitude  | Distance |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-1 | 1 Roadside | 0113 1111111 | R1     | ICB1 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-2 | 2 Roadside | 0113 2222222 | R2     | ICB2 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
+      | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-4 | 4 Roadside | 0113 4444444 | R4     | ICB4 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
 
   Scenario: Only return the number of sites requested
     Given The following sites exist in the system
-      | Site | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude    | Latitude   |
-      | 5    | Site-5 | 5 Roadside | 0113 5555555 | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 |
-      | 6    | Site-6 | 6 Roadside | 0113 6666666 | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 |
-      | 7    | Site-7 | 7 Roadside | 0113 7777777 | R7     | ICB7 | accessibility/attr_one=true  | 0.13086317   | -51.583479 |
-      | 8    | Site-8 | 8 Roadside | 0113 8888888 | R8     | ICB8 | accessibility/attr_one=false | -0.040992272 | -51.455788 |
+      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude    | Latitude   |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-5 | 5 Roadside | 0113 5555555 | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-6 | 6 Roadside | 0113 6666666 | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 |
+      | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-7 | 7 Roadside | 0113 7777777 | R7     | ICB7 | accessibility/attr_one=true  | 0.13086317   | -51.583479 |
+      | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-8 | 8 Roadside | 0113 8888888 | R8     | ICB8 | accessibility/attr_one=false | -0.040992272 | -51.455788 |
     When I make the following request without access needs
       | Max Records | Search Radius | Longitude | Latitude |
       | 2           | 100000        | -0.082    | -51.5    |
     Then the following sites and distances are returned
-      | Site | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude    | Latitude   | Distance |
-      | 5    | Site-5 | 5 Roadside | 0113 5555555 | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 | 662      |
-      | 6    | Site-6 | 6 Roadside | 0113 6666666 | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 | 4819     |
+      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                   | Longitude    | Latitude   | Distance |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-5 | 5 Roadside | 0113 5555555 | R5     | ICB5 | accessibility/attr_one=true  | -0.082750916 | -51.494056 | 662      |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-6 | 6 Roadside | 0113 6666666 | R6     | ICB6 | accessibility/attr_one=false | -0.14566747  | -51.482472 | 4819     |
 
   Scenario: Only return sites with requested access needs
     Given The following sites exist in the system
-      | Site  | Name    | Address     | PhoneNumber  | Region | ICB   | Attributes                                               | Longitude | Latitude |
-      | 9     | Site-9  | 9 Roadside  | 0113 9999999 | R9     | ICB9  | accessibility/attr_one=true,accessibility/attr_two=true  | -0.0827   | -51.5    |
-      | 10    | Site-10 | 10 Roadside | 0113 1010101 | R10    | ICB10 | accessibility/attr_one=true,accessibility/attr_two=false | -0.0827   | -51.5    |
+      | Site                                 | Name    | Address     | PhoneNumber  | Region | ICB   | Attributes                                               | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-9  | 9 Roadside  | 0113 9999999 | R9     | ICB9  | accessibility/attr_one=true,accessibility/attr_two=true  | -0.0827   | -51.5    |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-10 | 10 Roadside | 0113 1010101 | R10    | ICB10 | accessibility/attr_one=true,accessibility/attr_two=false | -0.0827   | -51.5    |
     When I make the following request with access needs
       | Max Records | Search Radius | Longitude | Latitude | AccessNeeds       |
-      | 50          | 100000        | -0.082   | -51.5    | attr_one,attr_two |
+      | 50          | 100000        | -0.082    | -51.5    | attr_one,attr_two |
     Then the following sites and distances are returned
-      | Site | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                                              | Longitude | Latitude | Distance |
-      | 9    | Site-9 | 9 Roadside | 0113 9999999 | R9     | ICB9 | accessibility/attr_one=true,accessibility/attr_two=true | -0.0827   | -51.5    | 48       |
+      | Site                                 | Name   | Address    | PhoneNumber  | Region | ICB  | Attributes                                              | Longitude | Latitude | Distance |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-9 | 9 Roadside | 0113 9999999 | R9     | ICB9 | accessibility/attr_one=true,accessibility/attr_two=true | -0.0827   | -51.5    | 48       |

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
@@ -5,68 +5,23 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Gherkin.Ast;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Linq;
 using Nhs.Appointments.Api.Json;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
 using Xunit.Gherkin.Quick;
+using Location = Nhs.Appointments.Core.Location;
 
 namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement;
 
 [FeatureFile("./Scenarios/SiteManagement/SiteSearch.feature")]
 public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDisposable
 {
+    private IEnumerable<SiteWithDistance> _actualResponse;
     private HttpResponseMessage _response;
     private HttpStatusCode _statusCode;
-    private IEnumerable<SiteWithDistance> _actualResponse;
-
-    [When("I make the following request with access needs")]
-    public async Task RequestSitesWithAccessNeeds(Gherkin.Ast.DataTable dataTable)
-    {
-        var row = dataTable.Rows.ElementAt(1);
-        var maxRecords = row.Cells.ElementAt(0).Value;
-        var searchRadiusNumber = row.Cells.ElementAt(1).Value;
-        var longitude = row.Cells.ElementAt(2).Value;
-        var latitude = row.Cells.ElementAt(3).Value;
-        var accessNeeds = row.Cells.ElementAt(4).Value;
-        _response = await Http.GetAsync($"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&accessNeeds={accessNeeds}&ignoreCache=true");
-        _statusCode = _response.StatusCode;
-        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(await _response.Content.ReadAsStreamAsync());
-    }
-
-    [When("I make the following request without access needs")]
-    public async Task RequestSitesWithoutAccessNeeds(Gherkin.Ast.DataTable dataTable)
-    {
-        var row = dataTable.Rows.ElementAt(1);
-        var maxRecords = row.Cells.ElementAt(0).Value;
-        var searchRadiusNumber = row.Cells.ElementAt(1).Value;
-        var longitude = row.Cells.ElementAt(2).Value;
-        var latitude = row.Cells.ElementAt(3).Value;
-        _response = await Http.GetAsync($"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&ignoreCache=true");
-        _statusCode = _response.StatusCode;
-        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(await _response.Content.ReadAsStreamAsync());
-    }
-
-    [Then("the following sites and distances are returned")]
-    public void Assert(Gherkin.Ast.DataTable dataTable)
-    {
-        var expectedSites = dataTable.Rows.Skip(1).Select(row => new SiteWithDistance(
-            new Site(
-                Id: GetSiteId(row.Cells.ElementAt(0).Value),
-                Name: row.Cells.ElementAt(1).Value,
-                Address: row.Cells.ElementAt(2).Value,
-                PhoneNumber: row.Cells.ElementAt(3).Value,
-                Region: row.Cells.ElementAt(4).Value,
-                IntegratedCareBoard: row.Cells.ElementAt(5).Value,
-                AttributeValues: ParseAttributes(row.Cells.ElementAt(6).Value),
-                Location: new Location(Type: "Point", Coordinates: new[] { double.Parse(row.Cells.ElementAt(7).Value), double.Parse(row.Cells.ElementAt(8).Value) })
-                ), Distance: int.Parse(row.Cells.ElementAt(9).Value)
-            )).ToList();
-
-        _statusCode.Should().Be(HttpStatusCode.OK);
-        _actualResponse.Should().BeEquivalentTo(expectedSites);
-    }
 
     public void Dispose()
     {
@@ -74,11 +29,70 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         DeleteSiteData(Client, testId).GetAwaiter().GetResult();
     }
 
+    [When("I make the following request with access needs")]
+    public async Task RequestSitesWithAccessNeeds(DataTable dataTable)
+    {
+        var row = dataTable.Rows.ElementAt(1);
+        var maxRecords = row.Cells.ElementAt(0).Value;
+        var searchRadiusNumber = row.Cells.ElementAt(1).Value;
+        var longitude = row.Cells.ElementAt(2).Value;
+        var latitude = row.Cells.ElementAt(3).Value;
+        var accessNeeds = row.Cells.ElementAt(4).Value;
+        _response = await Http.GetAsync(
+            $"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&accessNeeds={accessNeeds}&ignoreCache=true");
+        _statusCode = _response.StatusCode;
+        (_, _actualResponse) =
+            await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(
+                await _response.Content.ReadAsStreamAsync());
+    }
+
+    [When("I make the following request without access needs")]
+    public async Task RequestSitesWithoutAccessNeeds(DataTable dataTable)
+    {
+        var row = dataTable.Rows.ElementAt(1);
+        var maxRecords = row.Cells.ElementAt(0).Value;
+        var searchRadiusNumber = row.Cells.ElementAt(1).Value;
+        var longitude = row.Cells.ElementAt(2).Value;
+        var latitude = row.Cells.ElementAt(3).Value;
+        _response = await Http.GetAsync(
+            $"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&ignoreCache=true");
+        _statusCode = _response.StatusCode;
+        (_, _actualResponse) =
+            await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(
+                await _response.Content.ReadAsStreamAsync());
+    }
+
+    [Then("the following sites and distances are returned")]
+    public void Assert(DataTable dataTable)
+    {
+        var expectedSites = dataTable.Rows.Skip(1).Select(row => new SiteWithDistance(
+            new Site(
+                Id: GetSiteId(row.Cells.ElementAt(0).Value),
+                Name: row.Cells.ElementAt(1).Value,
+                Address: row.Cells.ElementAt(2).Value,
+                PhoneNumber: row.Cells.ElementAt(3).Value,
+                OdsCode: row.Cells.ElementAt(4).Value,
+                Region: row.Cells.ElementAt(5).Value,
+                IntegratedCareBoard: row.Cells.ElementAt(6).Value,
+                AttributeValues: ParseAttributes(row.Cells.ElementAt(7).Value),
+                Location: new Location(Type: "Point",
+                    Coordinates: new[]
+                    {
+                        double.Parse(row.Cells.ElementAt(8).Value), double.Parse(row.Cells.ElementAt(9).Value)
+                    })
+            ), Distance: int.Parse(row.Cells.ElementAt(10).Value)
+        )).ToList();
+
+        _statusCode.Should().Be(HttpStatusCode.OK);
+        _actualResponse.Should().BeEquivalentTo(expectedSites);
+    }
+
     private static async Task DeleteSiteData(CosmosClient cosmosClient, string testId)
     {
         const string partitionKey = "site";
         var container = cosmosClient.GetContainer("appts", "core_data");
-        using var feed = container.GetItemLinqQueryable<SiteDocument>().Where(sd => sd.Id.Contains(testId)).ToFeedIterator();
+        using var feed = container.GetItemLinqQueryable<SiteDocument>().Where(sd => sd.Id.Contains(testId))
+            .ToFeedIterator();
         while (feed.HasMoreResults)
         {
             var documentsResponse = await feed.ReadNextAsync();

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/UpdateSiteAttributes.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/UpdateSiteAttributes.feature
@@ -2,29 +2,38 @@
 
   Scenario: Add attribute to a site
     Given The following sites exist in the system
-      | Site | Name   | Address     | PhoneNumber  | Region | ICB  | Attributes | Longitude | Latitude |
-      | A    | Site-A | 1A New Lane | 0113 1111111 | R1     | ICB1 | __empty__  | -60       | -60      |
-    When I update the attributes for site 'A'
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | Attributes | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | __empty__  | -60       | -60      |
+    When I update the attributes for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51'
       | Attributes                                                           |
       | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true |
-    Then the correct information for site 'A' is returned
-      | Site | Name   | Address     | PhoneNumber  | Region | ICB  | Attributes                                                           | Longitude | Latitude |
-      | A    | Site-A | 1A New Lane | 0113 1111111 | R1     | ICB1 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -60       | -60      |
+    Then the correct information for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51' is returned
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | Attributes                                                           | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -60       | -60      |
 
   Scenario: Switch off attributes for a site
     Given The following sites exist in the system
-      | Site | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes                                                           | Longitude | Latitude |
-      | B    | Site-B | 1B Park Lane | 0113 1111111 | R1     | ICB1 | def_one/attr_one=true, def_one/attr_two=true, def_two/attr_one=true  | -60       | -60      |
-    When I update the attributes for site 'B'
+      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | Attributes                                                          | Longitude | Latitude |
+      | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-B | 1B Park Lane | 0113 1111111 | 15N     | R1     | ICB1 | def_one/attr_one=true, def_one/attr_two=true, def_two/attr_one=true | -60       | -60      |
+    When I update the attributes for site '5914b64a-66bb-4ee2-ab8a-94958c1fdfcb'
       | Attributes                                                             |
       | def_one/attr_one=false, def_one/attr_two=false, def_two/attr_one=false |
-    Then the correct information for site 'B' is returned
-      | Site | Name   | Address      | PhoneNumber  | Region | ICB  | Attributes                                                             | Longitude | Latitude |
-      | B    | Site-B | 1B Park Lane | 0113 1111111 | R1     | ICB1 | def_one/attr_one=false, def_one/attr_two=false, def_two/attr_one=false | -60       | -60      |
+    Then the correct information for site '5914b64a-66bb-4ee2-ab8a-94958c1fdfcb' is returned
+      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | Attributes                                                             | Longitude | Latitude |
+      | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-B | 1B Park Lane | 0113 1111111 | 15N     | R1     | ICB1 | def_one/attr_one=false, def_one/attr_two=false, def_two/attr_one=false | -60       | -60      |
 
   Scenario: Returns site not found message when site does not exist
     Given The site 'zero' does not exist in the system
     When I update the attributes for site 'zero'
-      | Attributes                                                           |
+      | Attributes             |
+      | def_one/attr_one=false |
+    Then a message is returned saying the site is not found
+
+  Scenario: Returns site not found message when site update attempted with ODS code
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | Attributes            | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A Site Lane | 0113 1111111 | 15N     | R1     | ICB1 | def_one/attr_one=true | -60       | -60      |
+    When I update the attributes for site '15N'
+      | Attributes             |
       | def_one/attr_one=false |
     Then a message is returned saying the site is not found

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/UpdateSiteAttributesFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/UpdateSiteAttributesFeatureSteps.cs
@@ -3,9 +3,12 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Gherkin.Ast;
+using Microsoft.Azure.Cosmos;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
 using Xunit.Gherkin.Quick;
+using Location = Nhs.Appointments.Core.Location;
 
 namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement;
 
@@ -13,7 +16,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement;
 public sealed class UpdateSiteAttributesFeatureSteps : SiteManagementBaseFeatureSteps
 {
     [When("I update the attributes for site '(.+)'")]
-    public async Task UpdateSiteAttributes(string siteDesignation, Gherkin.Ast.DataTable dataTable)
+    public async Task UpdateSiteAttributes(string siteDesignation, DataTable dataTable)
     {
         var siteId = GetSiteId(siteDesignation);
         var row = dataTable.Rows.ElementAt(1);
@@ -23,7 +26,7 @@ public sealed class UpdateSiteAttributesFeatureSteps : SiteManagementBaseFeature
     }
 
     [Then("the correct information for site '(.+)' is returned")]
-    public async Task Assert(Gherkin.Ast.DataTable dataTable)
+    public async Task Assert(DataTable dataTable)
     {
         var row = dataTable.Rows.ElementAt(1);
         var siteId = row.Cells.ElementAt(0).Value;
@@ -32,16 +35,18 @@ public sealed class UpdateSiteAttributesFeatureSteps : SiteManagementBaseFeature
             Name: row.Cells.ElementAt(1).Value,
             Address: row.Cells.ElementAt(2).Value,
             PhoneNumber: row.Cells.ElementAt(3).Value,
-            Region: row.Cells.ElementAt(4).Value,
-            IntegratedCareBoard: row.Cells.ElementAt(5).Value,
-            AttributeValues: ParseAttributes(row.Cells.ElementAt(6).Value),
+            OdsCode: row.Cells.ElementAt(4).Value,
+            Region: row.Cells.ElementAt(5).Value,
+            IntegratedCareBoard: row.Cells.ElementAt(6).Value,
+            AttributeValues: ParseAttributes(row.Cells.ElementAt(7).Value),
             Location: new Location(
                 Type: "Point",
-                Coordinates: [double.Parse(row.Cells.ElementAt(7).Value), double.Parse(row.Cells.ElementAt(8).Value)])
+                Coordinates: [double.Parse(row.Cells.ElementAt(8).Value), double.Parse(row.Cells.ElementAt(9).Value)])
         );
         Response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var actualResult = await Client.GetContainer("appts", "core_data").ReadItemAsync<Site>(GetSiteId(siteId), new Microsoft.Azure.Cosmos.PartitionKey("site"));
+        var actualResult = await Client.GetContainer("appts", "core_data")
+            .ReadItemAsync<Site>(GetSiteId(siteId), new PartitionKey("site"));
         actualResult.Resource.Should().BeEquivalentTo(expectedSite);
     }
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetAvailabilityCreatedEventsFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetAvailabilityCreatedEventsFunctionTests.cs
@@ -1,26 +1,25 @@
 ﻿using FluentAssertions;
 using FluentValidation;
+using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
-using FluentValidation.Results;
 
 namespace Nhs.Appointments.Api.Tests.Functions;
 
 public class GetAvailabilityCreatedEventsFunctionTests
 {
-    private readonly Mock<IAvailabilityService> availabilityService = new();
-    private readonly Mock<IValidator<GetAvailabilityCreatedEventsRequest>> _validator = new();
-    private readonly Mock<IUserContextProvider> _userContextProvider = new();
     private readonly Mock<ILogger<GetAvailabilityCreatedEventsFunction>> _logger = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
     private readonly GetAvailabilityCreatedEventsFunction _sut;
+    private readonly Mock<IUserContextProvider> _userContextProvider = new();
+    private readonly Mock<IValidator<GetAvailabilityCreatedEventsRequest>> _validator = new();
+    private readonly Mock<IAvailabilityService> availabilityService = new();
 
     public GetAvailabilityCreatedEventsFunctionTests()
     {
@@ -39,7 +38,7 @@ public class GetAvailabilityCreatedEventsFunctionTests
     {
         var context = new DefaultHttpContext();
         var request = context.Request;
-        request.QueryString = new QueryString($"?site=1000&from=2000-01-01");
+        request.QueryString = new QueryString("?site=1000&from=2000-01-01");
         return request;
     }
 
@@ -47,14 +46,17 @@ public class GetAvailabilityCreatedEventsFunctionTests
     public async Task RunsAsync_Gets_Availability_Created_Events()
     {
         availabilityService.Setup(
-            x => x.GetAvailabilityCreatedEventsAsync("1000", DateOnly.FromDateTime(new DateTime(2000, 1, 1))))
-            .ReturnsAsync([new AvailabilityCreatedEvent()
-            {
-                Created = DateTime.UtcNow,
-                By = "test@test.com",
-                Site = "1000",
-                From = DateOnly.FromDateTime(DateTime.Now),
-            }]);
+                x => x.GetAvailabilityCreatedEventsAsync("2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                    DateOnly.FromDateTime(new DateTime(2000, 1, 1))))
+            .ReturnsAsync([
+                new AvailabilityCreatedEvent
+                {
+                    Created = DateTime.UtcNow,
+                    By = "test@test.com",
+                    Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                    From = DateOnly.FromDateTime(DateTime.Now),
+                }
+            ]);
 
         var testPrincipal = UserDataGenerator.CreateUserPrincipal("test@test.com");
         _userContextProvider.Setup(x => x.UserPrincipal).Returns(testPrincipal);
@@ -67,7 +69,8 @@ public class GetAvailabilityCreatedEventsFunctionTests
 
         response.Single().By.Should().Be("test@test.com");
         availabilityService.Verify(
-            x => x.GetAvailabilityCreatedEventsAsync("1000", DateOnly.FromDateTime(new DateTime(2000, 1, 1))),
+            x => x.GetAvailabilityCreatedEventsAsync("2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DateOnly.FromDateTime(new DateTime(2000, 1, 1))),
             Times.Once);
     }
 

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetAvailabilityCreatedEventsFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetAvailabilityCreatedEventsFunctionTests.cs
@@ -38,7 +38,7 @@ public class GetAvailabilityCreatedEventsFunctionTests
     {
         var context = new DefaultHttpContext();
         var request = context.Request;
-        request.QueryString = new QueryString("?site=1000&from=2000-01-01");
+        request.QueryString = new QueryString("?site=2de5bb57-060f-4cb5-b14d-16587d0c2e8f&from=2000-01-01");
         return request;
     }
 

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSiteMetaDataFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSiteMetaDataFunctionTests.cs
@@ -65,7 +65,7 @@ public class GetSiteMetaDataFunctionTests
         var response = await ReadResponseAsync<GetSiteMetaDataResponse>(result.Content);
 
         response.AdditionalInformation.Should().Be(expectedInformation);
-        response.SiteName.Should().Be("Test 123");
+        response.Site.Should().Be("Test 123");
     }
 
     private static HttpRequest CreateRequest()

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSiteMetaDataFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSiteMetaDataFunctionTests.cs
@@ -3,28 +3,28 @@ using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
+using Newtonsoft.Json;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Nhs.Appointments.Api.Auth;
 
 namespace Nhs.Appointments.Api.Tests.Functions;
 
 public class GetSiteMetaDataFunctionTests
 {
-    private readonly GetSiteMetaDataFunction _sut;
-    private readonly Mock<ISiteService> _siteService = new();
-    private readonly Mock<IValidator<SiteBasedResourceRequest>> _validator = new();
-    private readonly Mock<IUserContextProvider> _userContextProvider = new();
     private readonly Mock<ILogger<GetSiteMetaDataFunction>> _logger = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
+    private readonly Mock<ISiteService> _siteService = new();
+    private readonly GetSiteMetaDataFunction _sut;
+    private readonly Mock<IUserContextProvider> _userContextProvider = new();
+    private readonly Mock<IValidator<SiteBasedResourceRequest>> _validator = new();
 
     public GetSiteMetaDataFunctionTests()
     {
-        _sut = new GetSiteMetaDataFunction(_siteService.Object, _validator.Object, _userContextProvider.Object, _logger.Object, _metricsRecorder.Object);
+        _sut = new GetSiteMetaDataFunction(_siteService.Object, _validator.Object, _userContextProvider.Object,
+            _logger.Object, _metricsRecorder.Object);
         _validator
             .Setup(x => x.ValidateAsync(It.IsAny<SiteBasedResourceRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
@@ -43,13 +43,14 @@ public class GetSiteMetaDataFunctionTests
     [InlineData("attr_one/test_attr", "Another test", "")]
     public async Task RunAsync_ReturnsInformationForCitizen(string attrId, string attrVal, string expectedInformation)
     {
-        _siteService.Setup(x => x.GetSiteByIdAsync("123", "site_details"))
+        _siteService.Setup(x => x.GetSiteByIdAsync("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "site_details"))
             .ReturnsAsync(new Site
             (
-                Id: "123",
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                 Name: "Test 123",
                 Address: "1 Test Street",
                 PhoneNumber: "0113 1111111",
+                OdsCode: "15N",
                 Region: "R1",
                 IntegratedCareBoard: "ICB1",
                 AttributeValues: [new(attrId, attrVal)],
@@ -64,14 +65,14 @@ public class GetSiteMetaDataFunctionTests
         var response = await ReadResponseAsync<GetSiteMetaDataResponse>(result.Content);
 
         response.AdditionalInformation.Should().Be(expectedInformation);
-        response.Site.Should().Be("Test 123");
+        response.SiteName.Should().Be("Test 123");
     }
 
     private static HttpRequest CreateRequest()
     {
         var context = new DefaultHttpContext();
         var request = context.Request;
-        request.QueryString = new QueryString($"?site=123");
+        request.QueryString = new QueryString("?site=6877d86e-c2df-4def-8508-e1eccf0ea6ba");
         request.Headers.Append("Authorization", "Test 123");
         return request;
     }

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesByAreaFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesByAreaFunctionTests.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
@@ -15,16 +14,17 @@ namespace Nhs.Appointments.Api.Tests.Functions;
 
 public class GetSitesByAreaFunctionTests
 {
-    private readonly Mock<ISiteService> _siteService = new();    
-    private readonly Mock<IValidator<GetSitesByAreaRequest>> _validator = new();
-    private readonly Mock<IUserContextProvider> _userContextProvider = new();
     private readonly Mock<ILogger<GetSitesByAreaFunction>> _logger = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
+    private readonly Mock<ISiteService> _siteService = new();
     private readonly GetSitesByAreaFunction _sut;
+    private readonly Mock<IUserContextProvider> _userContextProvider = new();
+    private readonly Mock<IValidator<GetSitesByAreaRequest>> _validator = new();
 
     public GetSitesByAreaFunctionTests()
     {
-        _sut = new GetSitesByAreaFunction(_siteService.Object, _validator.Object, _userContextProvider.Object, _logger.Object, _metricsRecorder.Object);
+        _sut = new GetSitesByAreaFunction(_siteService.Object, _validator.Object, _userContextProvider.Object,
+            _logger.Object, _metricsRecorder.Object);
         _validator
             .Setup(x => x.ValidateAsync(It.IsAny<GetSitesByAreaRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
@@ -51,25 +51,30 @@ public class GetSitesByAreaFunctionTests
         const int searchRadius = 100000;
         const int maxRecords = 50;
         const string accessNeeds = "attr_1";
-        var sites = new List<SiteWithDistance>()
+        var sites = new List<SiteWithDistance>
         {
-            new (
+            new(
                 new Site(
-                    Id: "1",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                     Name: "Alpha",
                     Address: "somewhere",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "15N",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
-                    AttributeValues: new [] {new AttributeValue(Id: "accessibility/attr_1", Value: "true")},
+                    AttributeValues: new[] { new AttributeValue(Id: "accessibility/attr_1", Value: "true") },
                     Location: new Location("point", [0.1, 10])),
                 Distance: 100)
         };
-        _siteService.Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false)).ReturnsAsync(sites);
+        _siteService
+            .Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false))
+            .ReturnsAsync(sites);
         var request = CreateRequest(longitude, latitude, searchRadius, maxRecords, true, accessNeeds);
         var result = await _sut.RunAsync(request) as ContentResult;
         result?.StatusCode.Should().Be(200);
-        _siteService.Verify(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false), Times.Once());
+        _siteService.Verify(
+            x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false),
+            Times.Once());
     }
 
     [Fact]
@@ -79,34 +84,44 @@ public class GetSitesByAreaFunctionTests
         const double latitude = 2.1;
         const int searchRadius = 50000;
         const int maxRecords = 50;
-        var sites = new List<SiteWithDistance>()
+        var sites = new List<SiteWithDistance>
         {
-            new (
+            new(
                 new Site(
-                    Id: "1",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                     Name: "Alpha",
                     Address: "somewhere",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "15N",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
-                    AttributeValues: new [] {new AttributeValue(Id: "accessibility/attr_1", Value: "true")},
+                    AttributeValues: new[] { new AttributeValue(Id: "accessibility/attr_1", Value: "true") },
                     Location: new Location("point", [0.1, 10])),
                 Distance: 100)
         };
-        _siteService.Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false)).ReturnsAsync(sites);
+        _siteService
+            .Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false))
+            .ReturnsAsync(sites);
         var request = CreateRequest(longitude, latitude, searchRadius, maxRecords, false);
         var result = await _sut.RunAsync(request) as ContentResult;
         result?.StatusCode.Should().Be(200);
-        _siteService.Verify(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false), Times.Once());
+        _siteService.Verify(
+            x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false),
+            Times.Once());
     }
 
 
-    private static HttpRequest CreateRequest(double longitude, double latitude, int searchRadius, int maxRecords, bool includeAccessNeedsWhenEmpty, params string[] accessNeeds)
+    private static HttpRequest CreateRequest(double longitude, double latitude, int searchRadius, int maxRecords,
+        bool includeAccessNeedsWhenEmpty, params string[] accessNeeds)
     {
         var context = new DefaultHttpContext();
-        var queryString = $"?long={longitude}&lat={latitude}&searchRadius={searchRadius}&maxRecords={maxRecords}&ignoreCache=false";
+        var queryString =
+            $"?long={longitude}&lat={latitude}&searchRadius={searchRadius}&maxRecords={maxRecords}&ignoreCache=false";
         if (accessNeeds.Any() || includeAccessNeedsWhenEmpty)
+        {
             queryString += $"&accessNeeds={string.Join(",", accessNeeds)}";
+        }
+
         var request = context.Request;
         request.QueryString = new QueryString(queryString);
         return request;

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetUserProfileFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetUserProfileFunctionTests.cs
@@ -1,41 +1,41 @@
-﻿using FluentAssertions;
+﻿using System.Security.Principal;
+using FluentAssertions;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
-using System.Security.Principal;
 
 namespace Nhs.Appointments.Api.Tests.Functions
 {
     public class GetUserProfileFunctionTests
     {
-        private readonly Mock<ISiteService> _siteSearchService = new();
-        private readonly Mock<IUserService> _userSiteAssignmentService = new();
-        private readonly Mock<IValidator<EmptyRequest>> _validator = new();
-        private readonly Mock<IUserContextProvider> _userContextProvider = new();
         private readonly Mock<ILogger<GetUserProfileFunction>> _logger = new();
         private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
-        private GetUserProfileFunction _sut;
+        private readonly Mock<ISiteService> _siteSearchService = new();
+        private readonly Mock<IUserContextProvider> _userContextProvider = new();
+        private readonly Mock<IUserService> _userSiteAssignmentService = new();
+        private readonly Mock<IValidator<EmptyRequest>> _validator = new();
+        private readonly GetUserProfileFunction _sut;
 
         public GetUserProfileFunctionTests()
         {
-            _sut = new GetUserProfileFunction(_siteSearchService.Object, _userSiteAssignmentService.Object, _validator.Object, _userContextProvider.Object, _logger.Object, _metricsRecorder.Object);
+            _sut = new GetUserProfileFunction(_siteSearchService.Object, _userSiteAssignmentService.Object,
+                _validator.Object, _userContextProvider.Object, _logger.Object, _metricsRecorder.Object);
         }
 
         [Fact]
         public async Task RunsAsync_GetsRoleAssignments_ForSignedInUser()
-        {            
+        {
             var testPrincipal = UserDataGenerator.CreateUserPrincipal("test@test.com");
             _userContextProvider.Setup(x => x.UserPrincipal).Returns(testPrincipal);
             var context = new DefaultHttpContext();
             var request = context.Request;
-            
+
             await _sut.RunAsync(request);
 
             _userSiteAssignmentService.Verify(x => x.GetUserAsync("test@test.com"), Times.Once());
@@ -49,10 +49,9 @@ namespace Nhs.Appointments.Api.Tests.Functions
             var context = new DefaultHttpContext();
             var request = context.Request;
 
-            _userSiteAssignmentService.Setup(x => x.GetUserAsync("test@test.com")).ReturnsAsync(new User()
+            _userSiteAssignmentService.Setup(x => x.GetUserAsync("test@test.com")).ReturnsAsync(new User
             {
-                Id = "test@test.com",
-                RoleAssignments = [],
+                Id = "test@test.com", RoleAssignments = [],
             });
 
             var response = await _sut.RunAsync(request) as ContentResult;
@@ -67,40 +66,46 @@ namespace Nhs.Appointments.Api.Tests.Functions
             _userContextProvider.Setup(x => x.UserPrincipal).Returns(testPrincipal);
             var context = new DefaultHttpContext();
             var request = context.Request;
-            RoleAssignment[] roleAssignments = [
-                new() { Role = "Role1", Scope = "site:1" },
-                new() { Role = "Role2", Scope = "site:1" },
-                new() { Role = "Role1", Scope = "site:2" },
-                new() { Role = "Role2", Scope = "site:2" }
+            RoleAssignment[] roleAssignments =
+            [
+                new() { Role = "Role1", Scope = "site:6877d86e-c2df-4def-8508-e1eccf0ea6ba" },
+                new() { Role = "Role2", Scope = "site:6877d86e-c2df-4def-8508-e1eccf0ea6ba" },
+                new() { Role = "Role1", Scope = "site:6877d86e-c2df-4def-8508-e1eccf0ea6bb" },
+                new() { Role = "Role2", Scope = "site:6877d86e-c2df-4def-8508-e1eccf0ea6bb" }
             ];
 
-            _userSiteAssignmentService.Setup(x => x.GetUserAsync("test@test.com")).ReturnsAsync(new User()
+            _userSiteAssignmentService.Setup(x => x.GetUserAsync("test@test.com")).ReturnsAsync(new User
             {
-                Id = "test@test.com",
-                RoleAssignments = roleAssignments,
+                Id = "test@test.com", RoleAssignments = roleAssignments,
             });
 
             var siteDetails = new[]
             {
-                new Site("1", "Alpha", "somewhere", "0113 1111111", "R1", "ICB1",new [] {new AttributeValue(Id: "Attribute 1", Value: "true")}, new Location("point", new []{0.1, 10})),
-                new Site("2", "Beta", "elsewhere", "0113 1111111", "R1", "ICB1",new [] {new AttributeValue(Id: "Attribute 2", Value: "false")}, new Location("point", new []{-0.1, -10}))
-            };
-            
-            var expectedUserProfileSiteDetails = new[]
-            {
-                new UserProfileSite("1", "Alpha", "somewhere"),
-                new UserProfileSite("2", "Beta", "elsewhere")
+                new Site("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "Alpha", "somewhere", "0113 1111111", "15N", "R1",
+                    "ICB1", new[] { new AttributeValue(Id: "Attribute 1", Value: "true") },
+                    new Location("point", new[] { 0.1, 10 })),
+                new Site("6877d86e-c2df-4def-8508-e1eccf0ea6bb", "Beta", "elsewhere", "0113 1111111", "15N", "R1",
+                    "ICB1", new[] { new AttributeValue(Id: "Attribute 2", Value: "false") },
+                    new Location("point", new[] { -0.1, -10 }))
             };
 
-            _siteSearchService.Setup(x => x.GetSiteByIdAsync("1", "*")).ReturnsAsync(siteDetails[0]);
-            _siteSearchService.Setup(x => x.GetSiteByIdAsync("2", "*")).ReturnsAsync(siteDetails[1]);
-            
+            var expectedUserProfileSiteDetails = new[]
+            {
+                new UserProfileSite("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "Alpha", "somewhere"),
+                new UserProfileSite("6877d86e-c2df-4def-8508-e1eccf0ea6bb", "Beta", "elsewhere")
+            };
+
+            _siteSearchService.Setup(x => x.GetSiteByIdAsync("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "*"))
+                .ReturnsAsync(siteDetails[0]);
+            _siteSearchService.Setup(x => x.GetSiteByIdAsync("6877d86e-c2df-4def-8508-e1eccf0ea6bb", "*"))
+                .ReturnsAsync(siteDetails[1]);
+
             var result = await _sut.RunAsync(request) as ContentResult;
 
             var actualResponse = await ReadResponseAsync<UserProfile>(result.Content);
             actualResponse.AvailableSites.Should().BeEquivalentTo(expectedUserProfileSiteDetails);
         }
-        
+
         [Fact]
         public async Task RunAsync_IgnoresScopesNotPrefixedWithSite_ForSignedInUser()
         {
@@ -109,35 +114,38 @@ namespace Nhs.Appointments.Api.Tests.Functions
             var context = new DefaultHttpContext();
             var request = context.Request;
 
-            RoleAssignment[] roleAssignments = [
+            RoleAssignment[] roleAssignments =
+            [
                 new() { Role = "Role1", Scope = "global" },
-                new() { Role = "Role1", Scope = "site:1" }
+                new() { Role = "Role1", Scope = "site:6877d86e-c2df-4def-8508-e1eccf0ea6ba" }
             ];
 
-            _userSiteAssignmentService.Setup(x => x.GetUserAsync("test@test.com")).ReturnsAsync(new User()
+            _userSiteAssignmentService.Setup(x => x.GetUserAsync("test@test.com")).ReturnsAsync(new User
             {
-                Id = "test@test.com",
-                RoleAssignments = roleAssignments,
+                Id = "test@test.com", RoleAssignments = roleAssignments,
             });
 
             var siteDetails = new[]
             {
-                new Site("1", "Alpha", "somewhere", "0113 1111111", "R1", "ICB1",new [] {new AttributeValue(Id: "Attribute 1", Value: "true")}, new Location("point", new []{0.1, 10}))
-            };
-            
-            var expectedUserProfileSiteDetails = new[]
-            {
-                new UserProfileSite("1", "Alpha", "somewhere")
+                new Site("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "Alpha", "somewhere", "0113 1111111", "15N", "R1",
+                    "ICB1", new[] { new AttributeValue(Id: "Attribute 1", Value: "true") },
+                    new Location("point", new[] { 0.1, 10 }))
             };
 
-            _siteSearchService.Setup(x => x.GetSiteByIdAsync("1", "*")).ReturnsAsync(siteDetails[0]);
-            
+            var expectedUserProfileSiteDetails = new[]
+            {
+                new UserProfileSite("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "Alpha", "somewhere")
+            };
+
+            _siteSearchService.Setup(x => x.GetSiteByIdAsync("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "*"))
+                .ReturnsAsync(siteDetails[0]);
+
             var result = await _sut.RunAsync(request) as ContentResult;
 
             var actualResponse = await ReadResponseAsync<UserProfile>(result.Content);
             actualResponse.AvailableSites.Should().BeEquivalentTo(expectedUserProfileSiteDetails);
         }
-        
+
         private static async Task<TRequest> ReadResponseAsync<TRequest>(string response)
         {
             var body = await new StringReader(response).ReadToEndAsync();

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetUserRoleAssignmentsFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetUserRoleAssignmentsFunctionTests.cs
@@ -38,15 +38,15 @@ public class GetUserRoleAssignmentsFunctionTests
             new()
             {
                 Id = "test1@test.com",
-                RoleAssignments = [new RoleAssignment { Role = "Role1", Scope = "site:1000" }]
+                RoleAssignments = [new RoleAssignment { Role = "Role1", Scope = "site:2de5bb57-060f-4cb5-b14d-16587d0c2e8f" }]
             },
             new()
             {
                 Id = "test2@test.com",
                 RoleAssignments =
                 [
-                    new RoleAssignment { Role = "Role1", Scope = "site:1000" },
-                    new RoleAssignment { Role = "Role1", Scope = "site:1001" }
+                    new RoleAssignment { Role = "Role1", Scope = "site:2de5bb57-060f-4cb5-b14d-16587d0c2e8f" },
+                    new RoleAssignment { Role = "Role1", Scope = "site:308d515c-2002-450e-b248-4ba36f6667bb" }
                 ]
             }
         };
@@ -55,12 +55,12 @@ public class GetUserRoleAssignmentsFunctionTests
             new()
             {
                 Id = "test1@test.com",
-                RoleAssignments = [new RoleAssignment { Role = "Role1", Scope = "site:1000" }]
+                RoleAssignments = [new RoleAssignment { Role = "Role1", Scope = "site:2de5bb57-060f-4cb5-b14d-16587d0c2e8f" }]
             },
             new()
             {
                 Id = "test2@test.com",
-                RoleAssignments = [new RoleAssignment { Role = "Role1", Scope = "site:1000" }]
+                RoleAssignments = [new RoleAssignment { Role = "Role1", Scope = "site:2de5bb57-060f-4cb5-b14d-16587d0c2e8f" }]
             }
         };
         _userService.Setup(x => x.GetUsersAsync("2de5bb57-060f-4cb5-b14d-16587d0c2e8f")).ReturnsAsync(users);
@@ -75,7 +75,7 @@ public class GetUserRoleAssignmentsFunctionTests
     {
         var context = new DefaultHttpContext();
         var request = context.Request;
-        request.QueryString = new QueryString("?site=1000");
+        request.QueryString = new QueryString("?site=2de5bb57-060f-4cb5-b14d-16587d0c2e8f");
         return request;
     }
 

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetUserRoleAssignmentsFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetUserRoleAssignmentsFunctionTests.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
@@ -15,16 +14,17 @@ namespace Nhs.Appointments.Api.Tests.Functions;
 
 public class GetUserRoleAssignmentsFunctionTests
 {
-    private readonly Mock<IUserService> _userService = new();
-    private readonly Mock<IValidator<SiteBasedResourceRequest>> _validator = new();
-    private readonly Mock<IUserContextProvider> _userContextProvider = new();
     private readonly Mock<ILogger<GetUserRoleAssignmentsFunction>> _logger = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
     private readonly GetUserRoleAssignmentsFunction _sut;
+    private readonly Mock<IUserContextProvider> _userContextProvider = new();
+    private readonly Mock<IUserService> _userService = new();
+    private readonly Mock<IValidator<SiteBasedResourceRequest>> _validator = new();
 
     public GetUserRoleAssignmentsFunctionTests()
     {
-        _sut = new GetUserRoleAssignmentsFunction(_userService.Object, _validator.Object, _userContextProvider.Object, _logger.Object, _metricsRecorder.Object);
+        _sut = new GetUserRoleAssignmentsFunction(_userService.Object, _validator.Object, _userContextProvider.Object,
+            _logger.Object, _metricsRecorder.Object);
         _validator
             .Setup(x => x.ValidateAsync(It.IsAny<SiteBasedResourceRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
@@ -35,21 +35,35 @@ public class GetUserRoleAssignmentsFunctionTests
     {
         var users = new User[]
         {
-            new(){ Id = "test1@test.com", RoleAssignments = [new RoleAssignment 
-                { Role = "Role1", Scope = "site:1000" } ] },
-            new(){ Id = "test2@test.com", RoleAssignments = [new RoleAssignment 
-                    { Role = "Role1", Scope = "site:1000" }, new RoleAssignment 
-                    { Role = "Role1", Scope = "site:1001" } 
-            ]}
+            new()
+            {
+                Id = "test1@test.com",
+                RoleAssignments = [new RoleAssignment { Role = "Role1", Scope = "site:1000" }]
+            },
+            new()
+            {
+                Id = "test2@test.com",
+                RoleAssignments =
+                [
+                    new RoleAssignment { Role = "Role1", Scope = "site:1000" },
+                    new RoleAssignment { Role = "Role1", Scope = "site:1001" }
+                ]
+            }
         };
         var expectedResult = new User[]
         {
-            new(){ Id = "test1@test.com", RoleAssignments = [new RoleAssignment 
-                { Role = "Role1", Scope = "site:1000" }] },
-            new(){ Id = "test2@test.com", RoleAssignments = [new RoleAssignment 
-                { Role = "Role1", Scope = "site:1000" }] }
+            new()
+            {
+                Id = "test1@test.com",
+                RoleAssignments = [new RoleAssignment { Role = "Role1", Scope = "site:1000" }]
+            },
+            new()
+            {
+                Id = "test2@test.com",
+                RoleAssignments = [new RoleAssignment { Role = "Role1", Scope = "site:1000" }]
+            }
         };
-        _userService.Setup(x => x.GetUsersAsync("1000")).ReturnsAsync(users);
+        _userService.Setup(x => x.GetUsersAsync("2de5bb57-060f-4cb5-b14d-16587d0c2e8f")).ReturnsAsync(users);
         var request = CreateRequest();
         var result = await _sut.RunAsync(request) as ContentResult;
         result?.StatusCode.Should().Be(200);
@@ -61,11 +75,11 @@ public class GetUserRoleAssignmentsFunctionTests
     {
         var context = new DefaultHttpContext();
         var request = context.Request;
-        request.QueryString = new QueryString($"?site=1000");
+        request.QueryString = new QueryString("?site=1000");
         return request;
     }
 
-    
+
     private static async Task<TRequest> ReadResponseAsync<TRequest>(string response)
     {
         var body = await new StringReader(response).ReadToEndAsync();

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/MakeBookingFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/MakeBookingFunctionTests.cs
@@ -42,7 +42,8 @@ public class MakeBookingFunctionTests
                 "Test Board", Enumerable.Empty<AttributeValue>(), new Location("Point", [0, 0])));
         _bookingService.Setup(x => x.MakeBooking(It.IsAny<Booking>())).ReturnsAsync((true, "TEST01"));
 
-        var request = CreateRequest("1001", "2077-01-01 10:30", "COVID", "9999999999", "FirstName", "LastName",
+        var request = CreateRequest("34e990af-5dc9-43a6-8895-b9123216d699", "2077-01-01 10:30", "COVID", "9999999999",
+            "FirstName", "LastName",
             "1958-06-08", "test@tempuri.org", "0123456789", null);
 
         var result = await _sut.RunAsync(request) as ContentResult;
@@ -56,7 +57,8 @@ public class MakeBookingFunctionTests
     {
         _siteService.Setup(x => x.GetSiteByIdAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((Site)null);
 
-        var request = CreateRequest("1001", "2077-01-01 09:30", "COVID", "9999999999", "FirstName", "LastName",
+        var request = CreateRequest("34e990af-5dc9-43a6-8895-b9123216d699", "2077-01-01 09:30", "COVID", "9999999999",
+            "FirstName", "LastName",
             "1958-06-08", "test@tempuri.org", "0123456789", null);
 
         var result = await _sut.RunAsync(request) as ContentResult;
@@ -74,7 +76,8 @@ public class MakeBookingFunctionTests
         var slots = AvailabilityHelper.CreateTestSlots(Date, new TimeOnly(10, 0), new TimeOnly(11, 0),
             TimeSpan.FromMinutes(5));
 
-        var request = CreateRequest("1001", "2077-01-01 09:30", "COVID", "9999999999", "FirstName", "LastName",
+        var request = CreateRequest("34e990af-5dc9-43a6-8895-b9123216d699", "2077-01-01 09:30", "COVID", "9999999999",
+            "FirstName", "LastName",
             "1958-06-08", "test@tempuri.org", "0123456789", null);
 
         var result = await _sut.RunAsync(request) as ContentResult;
@@ -94,11 +97,12 @@ public class MakeBookingFunctionTests
 
         _bookingService.Setup(x => x.MakeBooking(It.IsAny<Booking>())).ReturnsAsync((true, "TEST01"));
 
-        var request = CreateRequest("1001", "2077-01-01 10:30", "COVID", "9999999999", "FirstName", "LastName",
+        var request = CreateRequest("34e990af-5dc9-43a6-8895-b9123216d699", "2077-01-01 10:30", "COVID", "9999999999",
+            "FirstName", "LastName",
             "1958-06-08", "test@tempuri.org", "0123456789", null);
         var expectedBooking = new Booking
         {
-            Site = "1001",
+            Site = "34e990af-5dc9-43a6-8895-b9123216d699",
             Duration = 5,
             Service = "COVID",
             From = new DateTime(2077, 1, 1, 10, 30, 0),
@@ -154,9 +158,9 @@ public class MakeBookingFunctionTests
                     DateOfBirth = DateOnly.ParseExact(dateOfBirth, "yyyy-MM-dd")
                 },
             contactDetails = new[]
-                {
-                    new { type = "email", value = email }, new { type = "phone", value = phoneNumber }
-                },
+            {
+                new { type = "email", value = email }, new { type = "phone", value = phoneNumber }
+            },
             additionalData,
             kind = "booked"
         };

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/QueryAvailabilityFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/QueryAvailabilityFunctionTests.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
-using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Availability;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Json;
@@ -18,21 +17,21 @@ namespace Nhs.Appointments.Api.Tests.Functions;
 public class QueryAvailabilityFunctionTests
 {
     private static readonly DateOnly Date = new DateOnly(2077, 1, 1);
-    private readonly QueryAvailabilityFunction _sut;
     private readonly Mock<IAvailabilityCalculator> _availabilityCalculator = new();
-    private readonly Mock<IAvailabilityGrouperFactory> _availabilityGrouperFactory = new();
-    private readonly Mock<IValidator<QueryAvailabilityRequest>> _validator = new();
     private readonly Mock<IAvailabilityGrouper> _availabilityGrouper = new();
-    private readonly Mock<IUserContextProvider> _userContextProvider = new();
+    private readonly Mock<IAvailabilityGrouperFactory> _availabilityGrouperFactory = new();
     private readonly Mock<ILogger<QueryAvailabilityFunction>> _logger = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
+    private readonly QueryAvailabilityFunction _sut;
+    private readonly Mock<IUserContextProvider> _userContextProvider = new();
+    private readonly Mock<IValidator<QueryAvailabilityRequest>> _validator = new();
 
     public QueryAvailabilityFunctionTests()
     {
         _sut = new QueryAvailabilityFunction(
-            _availabilityCalculator.Object, 
-                _validator.Object, 
-            _availabilityGrouperFactory.Object, 
+            _availabilityCalculator.Object,
+            _validator.Object,
+            _availabilityGrouperFactory.Object,
             _userContextProvider.Object,
             _logger.Object,
             _metricsRecorder.Object);
@@ -46,47 +45,53 @@ public class QueryAvailabilityFunctionTests
     [Fact]
     public async Task RunAsync_ReturnsSuccessResponse_WhenMultipleSitesAreQueried()
     {
-        var slots = AvailabilityHelper.CreateTestSlots(Date, new TimeOnly(9, 0), new TimeOnly(10, 0), TimeSpan.FromMinutes(5));
+        var slots = AvailabilityHelper.CreateTestSlots(Date, new TimeOnly(9, 0), new TimeOnly(10, 0),
+            TimeSpan.FromMinutes(5));
         var responseBlocks = CreateAmPmResponseBlocks(12, 0);
 
         _availabilityGrouper.Setup(x => x.GroupAvailability(It.IsAny<IEnumerable<SessionInstance>>()))
             .Returns(responseBlocks);
-        _availabilityCalculator.Setup(x => x.CalculateAvailability(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+        _availabilityCalculator.Setup(x =>
+                x.CalculateAvailability(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateOnly>(),
+                    It.IsAny<DateOnly>()))
             .ReturnsAsync(slots.AsEnumerable());
-        
+
         var request = new QueryAvailabilityRequest(
-            new[] { "1000", "1001" },
+            new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "34e990af-5dc9-43a6-8895-b9123216d699" },
             "COVID",
             new DateOnly(2077, 01, 01),
             new DateOnly(2077, 01, 01),
             QueryType.Days);
 
         var httpRequest = CreateRequest(request);
-        
+
         var result = await _sut.RunAsync(httpRequest) as ContentResult;
         result.StatusCode.Should().Be(200);
         var response = await ReadResponseAsync<QueryAvailabilityResponse>(result.Content);
         response.Count.Should().Be(2);
-        response[0].site.Should().Be("1000");
-        response[1].site.Should().Be("1001");
-    }      
-    
+        response[0].site.Should().Be("2de5bb57-060f-4cb5-b14d-16587d0c2e8f");
+        response[1].site.Should().Be("34e990af-5dc9-43a6-8895-b9123216d699");
+    }
+
     [Theory]
     [InlineData(QueryType.Days)]
     [InlineData(QueryType.Hours)]
     [InlineData(QueryType.Slots)]
     public async Task RunAsync_ReturnsCorrectAvailabilityGrouper_WhenCalledWithConfiguredQueryType(QueryType queryType)
     {
-        var slots = AvailabilityHelper.CreateTestSlots(Date, new TimeOnly(9, 0), new TimeOnly(10, 0), TimeSpan.FromMinutes(5));
+        var slots = AvailabilityHelper.CreateTestSlots(Date, new TimeOnly(9, 0), new TimeOnly(10, 0),
+            TimeSpan.FromMinutes(5));
         var responseBlocks = CreateAmPmResponseBlocks(12, 0);
 
         _availabilityGrouper.Setup(x => x.GroupAvailability(It.IsAny<IEnumerable<SessionInstance>>()))
             .Returns(responseBlocks);
-        _availabilityCalculator.Setup(x => x.CalculateAvailability(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+        _availabilityCalculator.Setup(x =>
+                x.CalculateAvailability(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateOnly>(),
+                    It.IsAny<DateOnly>()))
             .ReturnsAsync(slots.AsEnumerable());
-        
+
         var request = new QueryAvailabilityRequest(
-            new[] { "1000" },
+            new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f" },
             "COVID",
             new DateOnly(2077, 01, 01),
             new DateOnly(2077, 01, 01),
@@ -101,16 +106,19 @@ public class QueryAvailabilityFunctionTests
     [Fact]
     public async Task RunAsync_ReturnsResults_ForEachDayInRequest()
     {
-        var slots = AvailabilityHelper.CreateTestSlots(Date, new TimeOnly(9, 0), new TimeOnly(10, 0), TimeSpan.FromMinutes(5));
+        var slots = AvailabilityHelper.CreateTestSlots(Date, new TimeOnly(9, 0), new TimeOnly(10, 0),
+            TimeSpan.FromMinutes(5));
         var responseBlocks = CreateAmPmResponseBlocks(12, 0);
 
         _availabilityGrouper.Setup(x => x.GroupAvailability(It.IsAny<IEnumerable<SessionInstance>>()))
             .Returns(responseBlocks);
-        _availabilityCalculator.Setup(x => x.CalculateAvailability(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+        _availabilityCalculator.Setup(x =>
+                x.CalculateAvailability(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateOnly>(),
+                    It.IsAny<DateOnly>()))
             .ReturnsAsync(slots.AsEnumerable());
 
         var request = new QueryAvailabilityRequest(
-            new[] { "1000" },
+            new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f" },
             "COVID",
             new DateOnly(2077, 01, 01),
             new DateOnly(2077, 01, 03),
@@ -132,19 +140,21 @@ public class QueryAvailabilityFunctionTests
     {
         var blocks = new[]
         {
-            new SessionInstance(new DateTime(2077,1,1,9,0,0), new DateTime(2077,1,1,9,5,0)),
-            new SessionInstance(new DateTime(2077,1,2,10,0,0), new DateTime(2077,1,2,10,5,0)),
-            new SessionInstance(new DateTime(2077,1,3,11,0,0), new DateTime(2077,1,3,11,5,0)),
+            new SessionInstance(new DateTime(2077, 1, 1, 9, 0, 0), new DateTime(2077, 1, 1, 9, 5, 0)),
+            new SessionInstance(new DateTime(2077, 1, 2, 10, 0, 0), new DateTime(2077, 1, 2, 10, 5, 0)),
+            new SessionInstance(new DateTime(2077, 1, 3, 11, 0, 0), new DateTime(2077, 1, 3, 11, 5, 0)),
         };
         var responseBlocks = CreateAmPmResponseBlocks(12, 0);
 
         _availabilityGrouper.Setup(x => x.GroupAvailability(It.IsAny<IEnumerable<SessionInstance>>()))
             .Returns(responseBlocks);
-        _availabilityCalculator.Setup(x => x.CalculateAvailability(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+        _availabilityCalculator.Setup(x =>
+                x.CalculateAvailability(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateOnly>(),
+                    It.IsAny<DateOnly>()))
             .ReturnsAsync(blocks.AsEnumerable());
 
         var request = new QueryAvailabilityRequest(
-            new[] { "1000" },
+            new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f" },
             "COVID",
             new DateOnly(2077, 01, 01),
             new DateOnly(2077, 01, 03),
@@ -153,33 +163,36 @@ public class QueryAvailabilityFunctionTests
         var httpRequest = CreateRequest(request);
 
         await _sut.RunAsync(httpRequest);
-        
-        _availabilityGrouper.Verify(x => x.GroupAvailability(It.IsAny<IEnumerable<SessionInstance>>()), Times.Exactly(3));        
+
+        _availabilityGrouper.Verify(x => x.GroupAvailability(It.IsAny<IEnumerable<SessionInstance>>()),
+            Times.Exactly(3));
     }
 
     private static HttpRequest CreateRequest(QueryAvailabilityRequest request)
     {
         return CreateRequest(request.Sites, request.From, request.Until, request.Service, request.QueryType);
     }
-    
-    private static HttpRequest CreateRequest(string[] sites, DateOnly from, DateOnly until, string service, QueryType queryType)
+
+    private static HttpRequest CreateRequest(string[] sites, DateOnly from, DateOnly until, string service,
+        QueryType queryType)
     {
-        var sitesArray = String.Join(",", sites.Select(x => $"\"{x}\""));
+        var sitesArray = string.Join(",", sites.Select(x => $"\"{x}\""));
 
         var context = new DefaultHttpContext();
         var request = context.Request;
-        var body = $"{{ sites:[{sitesArray}], \"service\": \"{service}\", \"from\":  \"{from.ToString(DateTimeFormats.DateOnly)}\", \"until\": \"{until.ToString(DateTimeFormats.DateOnly)}\", \"queryType\": \"{queryType}\" }} ";
-        request.Body =  new MemoryStream(Encoding.UTF8.GetBytes(body));
+        var body =
+            $"{{ sites:[{sitesArray}], \"service\": \"{service}\", \"from\":  \"{from.ToString(DateTimeFormats.DateOnly)}\", \"until\": \"{until.ToString(DateTimeFormats.DateOnly)}\", \"queryType\": \"{queryType}\" }} ";
+        request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
         request.Headers.Append("Authorization", "Test 123");
         return request;
-    }       
+    }
 
     private static IEnumerable<QueryAvailabilityResponseBlock> CreateAmPmResponseBlocks(int amCount, int pmCount)
     {
         return new List<QueryAvailabilityResponseBlock>
         {
-            new (new TimeOnly(0,0), new TimeOnly(11,59), amCount),
-            new (new TimeOnly(12,0), new TimeOnly(23,59), pmCount),
+            new(new TimeOnly(0, 0), new TimeOnly(11, 59), amCount),
+            new(new TimeOnly(12, 0), new TimeOnly(23, 59), pmCount),
         };
     }
 
@@ -189,9 +202,10 @@ public class QueryAvailabilityFunctionTests
         {
             Converters =
             {
-                new ShortTimeOnlyJsonConverter(), new ShortDateOnlyJsonConverter(), new NullableShortDateOnlyJsonConverter()
+                new ShortTimeOnlyJsonConverter(),
+                new ShortDateOnlyJsonConverter(),
+                new NullableShortDateOnlyJsonConverter()
             },
-
         };
         var body = await new StringReader(response).ReadToEndAsync();
         return JsonConvert.DeserializeObject<TRequest>(body, deserializerSettings);

--- a/tests/Nhs.Appointments.Api.UnitTests/Notifications/BookingNotifierTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Notifications/BookingNotifierTests.cs
@@ -8,46 +8,51 @@ namespace Nhs.Appointments.Api.Tests.Notifications;
 
 public class BookingNotifierTests
 {
-    private BookingNotifier _sut;
-    const string EmailTemplateId = "email-template";
-    const string SmsTemplateId = "sms-template";
-    const string Site = "site:some-site";
-    const string Email = "test@tempuri.org";
-    const string FirstName = "joe";
-    const string PhoneNumber = "0123456789";
-    const string Reference = "booking-ref-1234";
-    const string Service = "some-service";
-    DateOnly date = new (2050, 1, 1);
-    TimeOnly time = new (12, 15);
+    private const string EmailTemplateId = "email-template";
+    private const string SmsTemplateId = "sms-template";
+    private const string Site = "6877d86e-c2df-4def-8508-e1eccf0ea6ba";
+    private const string Email = "test@tempuri.org";
+    private const string FirstName = "joe";
+    private const string PhoneNumber = "0123456789";
+    private const string Reference = "booking-ref-1234";
+    private const string Service = "some-service";
+    private readonly Mock<ILogger<BookingNotifier>> _logger = new();
 
-    private Mock<ISendNotifications> _notificationClient = new();
-    private Mock<ISiteService> _siteService = new();
-    private Mock<INotificationConfigurationService> _notificationConfigurationService = new();
-    private Mock<ILogger<BookingNotifier>> _logger = new();
+    private readonly Mock<ISendNotifications> _notificationClient = new();
+    private readonly Mock<INotificationConfigurationService> _notificationConfigurationService = new();
+    private readonly Mock<ISiteService> _siteService = new();
+    private readonly BookingNotifier _sut;
+    private readonly DateOnly date = new(2050, 1, 1);
+    private readonly TimeOnly time = new(12, 15);
 
     public BookingNotifierTests()
     {
-       _sut = new BookingNotifier(_notificationClient.Object, _notificationConfigurationService.Object, _siteService.Object, new PrivacyUtil(), _logger.Object);
+        _sut = new BookingNotifier(_notificationClient.Object, _notificationConfigurationService.Object,
+            _siteService.Object, new PrivacyUtil(), _logger.Object);
     }
 
     [Fact]
     public async Task PassesValuesToGovNotifyService()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
+        _notificationConfigurationService
+            .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
+                new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
-            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "R1", "ICB1",null, null)));
+            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
+                "R1", "ICB1", null, null)));
 
         _notificationClient.Setup(x => x.SendEmailAsync(Email, EmailTemplateId, It.Is<Dictionary<string, dynamic>>(
-            dic => 
-            dic.ContainsKey("firstName") &&
-            dic.ContainsKey("siteName") &&
-            dic.ContainsKey("date") &&
-            dic.ContainsKey("time") &&
-            dic.ContainsKey("address") &&
-            dic.ContainsKey("reference")
-            ))).Verifiable();
+            dic =>
+                dic.ContainsKey("firstName") &&
+                dic.ContainsKey("siteName") &&
+                dic.ContainsKey("date") &&
+                dic.ContainsKey("time") &&
+                dic.ContainsKey("address") &&
+                dic.ContainsKey("reference")
+        ))).Verifiable();
 
-        await _sut.Notify(nameof(BookingMade), Service, Reference, Site, FirstName, date, time, NotificationType.Email, Email);
+        await _sut.Notify(nameof(BookingMade), Service, Reference, Site, FirstName, date, time, NotificationType.Email,
+            Email);
         _notificationClient.Verify();
     }
 
@@ -55,22 +60,34 @@ public class BookingNotifierTests
     [Fact]
     public async Task GetsNameOfSite()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
-        _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>())).Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "R1", "ICB1",Array.Empty<AttributeValue>(), new Location("point", [0, 0])))).Verifiable();
-        _notificationClient.Setup(x => x.SendEmailAsync(Email, EmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+        _notificationConfigurationService
+            .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
+                new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
+        _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>())).Returns(
+            Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N", "R1", "ICB1",
+                Array.Empty<AttributeValue>(), new Location("point", [0, 0])))).Verifiable();
+        _notificationClient.Setup(
+            x => x.SendEmailAsync(Email, EmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
 
-        await _sut.Notify(nameof(BookingMade), Service, Reference, Site, FirstName, date, time, NotificationType.Email, Email);
+        await _sut.Notify(nameof(BookingMade), Service, Reference, Site, FirstName, date, time, NotificationType.Email,
+            Email);
         _siteService.Verify();
     }
 
     [Fact]
     public async Task GetsCorrectNotificationConfiguration()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
-        _siteService.Setup(x => x.GetSiteByIdAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "R1", "ICB1",Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
-        _notificationClient.Setup(x => x.SendEmailAsync(Email, EmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
+        _notificationConfigurationService
+            .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
+                new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
+        _siteService.Setup(x => x.GetSiteByIdAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(
+            Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N", "R1", "ICB1",
+                Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
+        _notificationClient.Setup(
+            x => x.SendEmailAsync(Email, EmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
 
-        await _sut.Notify(nameof(BookingMade), Service, Reference, Site, FirstName, date, time, NotificationType.Email, Email);
+        await _sut.Notify(nameof(BookingMade), Service, Reference, Site, FirstName, date, time, NotificationType.Email,
+            Email);
         _notificationConfigurationService.Verify();
     }
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Notifications/UserRolesChangedNotifierTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Notifications/UserRolesChangedNotifierTests.cs
@@ -3,35 +3,41 @@ using Moq;
 using Nhs.Appointments.Api.Notifications;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Core.Messaging.Events;
-using static System.Runtime.InteropServices.JavaScript.JSType;
-using System.Security.Cryptography.Xml;
 
 namespace Nhs.Appointments.Api.Tests.Notifications;
 
 public class UserRolesChangedNotifierTests
 {
-    private UserRolesChangedNotifier _sut;
-    private Mock<ISendNotifications> _notificationClient = new ();
-    private Mock<IRolesStore> _rolesStore = new ();
-    private Mock<ISiteService> _siteService = new();
-    private Mock<INotificationConfigurationService> _notificationConfigurationService = new ();
     private const string TemplateId = "my-template";
     private const string Email = "test@user";
-    private const string Site = "site1";
+    private const string Site = "6877d86e-c2df-4def-8508-e1eccf0ea6ba";
+    private readonly Mock<ISendNotifications> _notificationClient = new();
+    private readonly Mock<INotificationConfigurationService> _notificationConfigurationService = new();
+    private readonly Mock<IRolesStore> _rolesStore = new();
+    private readonly Mock<ISiteService> _siteService = new();
+    private readonly UserRolesChangedNotifier _sut;
+
     public UserRolesChangedNotifierTests()
     {
-        _sut = new UserRolesChangedNotifier(_notificationClient.Object, _notificationConfigurationService.Object, _rolesStore.Object,  _siteService.Object);
+        _sut = new UserRolesChangedNotifier(_notificationClient.Object, _notificationConfigurationService.Object,
+            _rolesStore.Object, _siteService.Object);
     }
 
     [Fact]
     public async Task PassesValuesToGovNotifyService()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>())).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
-        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }]));
+        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>()))
+            .ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
+        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([
+            new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }
+        ]));
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
-            .Returns(Task.FromResult(new Site (Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "R1", "ICB1",Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
+            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
+                "R1", "ICB1", Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
 
-        _notificationClient.Setup(x => x.SendEmailAsync(Email, TemplateId, It.Is<Dictionary<string, dynamic>>(dic => dic.ContainsKey("rolesAdded") && dic.ContainsKey("rolesRemoved")))).Verifiable();
+        _notificationClient.Setup(x => x.SendEmailAsync(Email, TemplateId,
+            It.Is<Dictionary<string, dynamic>>(dic =>
+                dic.ContainsKey("rolesAdded") && dic.ContainsKey("rolesRemoved")))).Verifiable();
 
         await _sut.Notify(nameof(UserRolesChanged), Email, Site, ["newRole"], ["removedRole"]);
         _notificationClient.Verify();
@@ -40,9 +46,14 @@ public class UserRolesChangedNotifierTests
     [Fact]
     public async Task GetsNameOfSite()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>())).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
-        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }]));
-        _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>())).Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "R1", "ICB1",Array.Empty<AttributeValue>(), new Location("point", [0, 0])))).Verifiable();
+        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>()))
+            .ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
+        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([
+            new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }
+        ]));
+        _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>())).Returns(
+            Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N", "R1", "ICB1",
+                Array.Empty<AttributeValue>(), new Location("point", [0, 0])))).Verifiable();
 
         await _sut.Notify(nameof(UserRolesChanged), Email, Site, ["newRole"], ["removedRole"]);
         _siteService.Verify();
@@ -51,10 +62,14 @@ public class UserRolesChangedNotifierTests
     [Fact]
     public async Task GetsNamesOfRoles()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>())).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
-        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }])).Verifiable();
+        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>()))
+            .ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
+        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([
+            new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }
+        ])).Verifiable();
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
-            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street","0113 1111111", "R1", "ICB1",Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
+            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
+                "R1", "ICB1", Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
 
         await _sut.Notify(nameof(UserRolesChanged), Email, Site, ["newRole"], ["removedRole"]);
         _rolesStore.Verify();
@@ -63,26 +78,37 @@ public class UserRolesChangedNotifierTests
     [Fact]
     public async Task DoesNotSendNotificationIfNoChanges()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>())).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
-        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }]));
+        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>()))
+            .ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
+        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([
+            new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }
+        ]));
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
-            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street","0113 1111111", "R1", "ICB1",Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
+            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
+                "R1", "ICB1", Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
 
         await _sut.Notify(nameof(UserRolesChanged), Email, Site, [], []);
-        _notificationClient.Verify(x => 
-            x.SendEmailAsync(Email, TemplateId, It.IsAny<Dictionary<string, dynamic>>()),
+        _notificationClient.Verify(x =>
+                x.SendEmailAsync(Email, TemplateId, It.IsAny<Dictionary<string, dynamic>>()),
             Times.Never());
     }
 
     [Fact]
     public async Task UsesFriendlyNamesForRoles()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>())).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
-        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }]));
+        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>()))
+            .ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
+        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([
+            new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }
+        ]));
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
-            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "R1", "ICB1",Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
+            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
+                "R1", "ICB1", Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
 
-        _notificationClient.Setup(x => x.SendEmailAsync(Email, TemplateId, It.Is<Dictionary<string, dynamic>>(dic => GetValue(dic, "rolesAdded").Contains("New Role") && GetValue(dic, "rolesRemoved").Contains("Removed Role")))).Verifiable();
+        _notificationClient.Setup(x => x.SendEmailAsync(Email, TemplateId,
+            It.Is<Dictionary<string, dynamic>>(dic =>
+                GetValue(dic, "rolesAdded").Contains("New Role") &&
+                GetValue(dic, "rolesRemoved").Contains("Removed Role")))).Verifiable();
 
         await _sut.Notify(nameof(UserRolesChanged), Email, Site, ["newRole"], ["removedRole"]);
         _notificationClient.Verify();
@@ -91,12 +117,19 @@ public class UserRolesChangedNotifierTests
     [Fact]
     public async Task GetsFriendlyRoleNameWhenIdContainsScopePrefixButDatabaseValuesDont()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>())).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
-        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }]));
+        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>()))
+            .ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId });
+        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([
+            new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }
+        ]));
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
-            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "R1", "ICB1",Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
+            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
+                "R1", "ICB1", Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
 
-        _notificationClient.Setup(x => x.SendEmailAsync(Email, TemplateId, It.Is<Dictionary<string, dynamic>>(dic => GetValue(dic, "rolesAdded").Contains("New Role") && GetValue(dic, "rolesRemoved").Contains("Removed Role")))).Verifiable();
+        _notificationClient.Setup(x => x.SendEmailAsync(Email, TemplateId,
+            It.Is<Dictionary<string, dynamic>>(dic =>
+                GetValue(dic, "rolesAdded").Contains("New Role") &&
+                GetValue(dic, "rolesRemoved").Contains("Removed Role")))).Verifiable();
 
         await _sut.Notify(nameof(UserRolesChanged), Email, Site, ["canned:newRole"], ["canned:removedRole"]);
         _notificationClient.Verify();
@@ -106,10 +139,14 @@ public class UserRolesChangedNotifierTests
     [Fact]
     public async Task GetsCorrectNotificationConfiguration()
     {
-        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync("UserRolesChanged")).ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId }).Verifiable();
-        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }]));
+        _notificationConfigurationService.Setup(x => x.GetNotificationConfigurationsAsync("UserRolesChanged"))
+            .ReturnsAsync(new NotificationConfiguration { EmailTemplateId = TemplateId }).Verifiable();
+        _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult<IEnumerable<Role>>([
+            new Role { Id = "newRole", Name = "New Role" }, new Role { Id = "removedRole", Name = "Removed Role" }
+        ]));
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
-            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "R1", "ICB1",Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
+            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
+                "R1", "ICB1", Array.Empty<AttributeValue>(), new Location("point", [0, 0]))));
 
         await _sut.Notify(nameof(UserRolesChanged), Email, Site, ["newRole"], ["removedRole"]);
         _notificationConfigurationService.Verify();

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/ApplyAvailabilityTemplateValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/ApplyAvailabilityTemplateValidatorTests.cs
@@ -24,7 +24,7 @@ public class ApplyAvailabilityTemplateValidatorTests
     public void Validate_ReturnsValidResult_WhenAllFieldsAreValid()
     {
         var request = new ApplyAvailabilityTemplateRequest(
-            Site: "ABC01",
+            Site: "9a06bacd-e916-4c10-8263-21451ca751b8",
             From: new DateOnly(2077, 01, 01),
             Until: new DateOnly(2077, 01, 01),
             Template: new Template()
@@ -84,7 +84,7 @@ public class ApplyAvailabilityTemplateValidatorTests
     public void Validate_ReturnsError_WhenFromDateIsTodayOrEarlier()
     {
         var request = new ApplyAvailabilityTemplateRequest(
-            Site: "ABC01",
+            Site: "9a06bacd-e916-4c10-8263-21451ca751b8",
             From: new DateOnly(2076, 12, 31),
             Until: new DateOnly(2077, 02, 01),
             Template: new Template()
@@ -115,7 +115,7 @@ public class ApplyAvailabilityTemplateValidatorTests
     public void Validate_ReturnsError_WhenUntilDateIsMoreThanOneYearInTheFuture()
     {
         var request = new ApplyAvailabilityTemplateRequest(
-            Site: "ABC01",
+            Site: "9a06bacd-e916-4c10-8263-21451ca751b8",
             From: new DateOnly(2077, 01, 02),
             Until: new DateOnly(2078, 01, 03),
             Template: new Template()
@@ -146,7 +146,7 @@ public class ApplyAvailabilityTemplateValidatorTests
     public void Validate_ReturnsError_WhenTemplateIsInvalid()
     {
         var request = new ApplyAvailabilityTemplateRequest(
-            Site: "ABC01",
+            Site: "9a06bacd-e916-4c10-8263-21451ca751b8",
             From: new DateOnly(2077, 01, 01),
             Until: new DateOnly(2077, 01, 01),
             Template: new Template()
@@ -175,7 +175,7 @@ public class ApplyAvailabilityTemplateValidatorTests
     public void Validate_ReturnsError_WhenTemplateIsNull()
     {
         var request = new ApplyAvailabilityTemplateRequest(
-            Site: "ABC01",
+            Site: "9a06bacd-e916-4c10-8263-21451ca751b8",
             From: new DateOnly(2077, 01, 01),
             Until: new DateOnly(2077, 01, 01),
             Template: null,

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetAvailabilityCreatedEventsRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetAvailabilityCreatedEventsRequestValidatorTests.cs
@@ -31,7 +31,7 @@ public class GetAvailabilityCreatedEventsRequestValidatorTests
     [Fact]
     public void Validate_ReturnsError_WhenFromIsBlank()
     {
-        var testRequest = new GetAvailabilityCreatedEventsRequest("ABC02", "");
+        var testRequest = new GetAvailabilityCreatedEventsRequest("cb5596bc-ef41-42c9-a8f1-57d713d6cc91", "");
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -41,7 +41,7 @@ public class GetAvailabilityCreatedEventsRequestValidatorTests
     [Fact]
     public void Validate_ReturnsError_WhenFromIsNull()
     {
-        var testRequest = new GetAvailabilityCreatedEventsRequest("ABC02", null);
+        var testRequest = new GetAvailabilityCreatedEventsRequest("cb5596bc-ef41-42c9-a8f1-57d713d6cc91", null);
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -51,7 +51,7 @@ public class GetAvailabilityCreatedEventsRequestValidatorTests
     [Fact]
     public void Validate_ReturnsError_WhenFromIsInWrongFormat()
     {
-        var testRequest = new GetAvailabilityCreatedEventsRequest("ABC02", "20:01:2031");
+        var testRequest = new GetAvailabilityCreatedEventsRequest("cb5596bc-ef41-42c9-a8f1-57d713d6cc91", "20:01:2031");
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -61,7 +61,7 @@ public class GetAvailabilityCreatedEventsRequestValidatorTests
     [Fact]
     public void Validate_ReturnsSuccess_WhenRequestIsValid()
     {
-        var testRequest = new GetAvailabilityCreatedEventsRequest("ABC02", "2020-01-01");
+        var testRequest = new GetAvailabilityCreatedEventsRequest("cb5596bc-ef41-42c9-a8f1-57d713d6cc91", "2020-01-01");
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeTrue();
         result.Errors.Should().HaveCount(0);

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/MakeBookingRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/MakeBookingRequestValidatorTests.cs
@@ -24,7 +24,7 @@ public class MakeBookingRequestValidatorTests
             null,
             BookingKind.Booked
         );
-        
+
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -38,7 +38,7 @@ public class MakeBookingRequestValidatorTests
     public void Validate_ReturnsError_WhenDurationIsOutOfRange(int duration)
     {
         var request = new MakeBookingRequest(
-            "1000",
+            "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
             new DateTime(2077, 01, 01, 09, 0, 0),
             duration,
             "COVID",
@@ -52,15 +52,15 @@ public class MakeBookingRequestValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.Duration));
-    }       
-    
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData(null)]
     public void Validate_ReturnsError_WhenServiceIsNullOrEmpty(string service)
     {
         var request = new MakeBookingRequest(
-            "1000",
+            "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
             new DateTime(2077, 01, 01, 09, 0, 0),
             5,
             service,
@@ -69,18 +69,18 @@ public class MakeBookingRequestValidatorTests
             null,
             BookingKind.Booked
         );
-        
+
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.Service));
     }
-        
+
     [Fact]
     public void Validate_ReturnsError_WhenAttendeeDetailsIsNull()
     {
         var request = new MakeBookingRequest(
-            "1000",
+            "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
             new DateTime(2077, 01, 01, 09, 0, 0),
             5,
             "COVID",
@@ -89,18 +89,18 @@ public class MakeBookingRequestValidatorTests
             null,
             BookingKind.Booked
         );
-        
+
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(MakeBookingRequest.AttendeeDetails));
-    }            
+    }
 
     [Fact]
     public void Validate_ReturnsError_WhenRequestIsEmpty()
     {
         MakeBookingRequest request = null;
-        
+
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -110,7 +110,7 @@ public class MakeBookingRequestValidatorTests
     public void Validate_ReturnsSuccess_WhenRequestIsValid()
     {
         var request = new MakeBookingRequest(
-            "1000",
+            "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
             new DateTime(2077, 01, 01, 09, 0, 0),
             5,
             "COVID",
@@ -121,12 +121,13 @@ public class MakeBookingRequestValidatorTests
         );
         var result = _sut.Validate(request);
         result.IsValid.Should().BeTrue();
-        result.Errors.Should().HaveCount(0);            
+        result.Errors.Should().HaveCount(0);
     }
 
     private AttendeeDetails GetAttendeeDetails()
     {
-        var attendeeDetails = new AttendeeDetails {
+        var attendeeDetails = new AttendeeDetails
+        {
             NhsNumber = "1234567890",
             FirstName = "FirstName",
             LastName = "LastName",
@@ -137,9 +138,10 @@ public class MakeBookingRequestValidatorTests
 
     private ContactItem[] GetContactDetails()
     {
-        return [
-            new ContactItem{ Type = ContactItemType.Email , Value = "test@tempuri.org" },
-            new ContactItem{ Type = ContactItemType.Phone, Value = "0123456789" }
-            ];
+        return
+        [
+            new ContactItem { Type = ContactItemType.Email, Value = "test@tempuri.org" },
+            new ContactItem { Type = ContactItemType.Phone, Value = "0123456789" }
+        ];
     }
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/QueryAvailabilityRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/QueryAvailabilityRequestValidatorTests.cs
@@ -14,12 +14,12 @@ public class QueryAvailabilityRequestValidatorTests
     private const string InvalidRequestBodyErrorMessage = "A request body must be provided";
     private const string InvalidQueryTypeValueMessage = "Value must be one of: Days, Hours, Slots";
     private readonly QueryAvailabilityRequestValidator _sut = new();
-    
+
     [Fact]
     public void Validate_ReturnsValidResult_WhenAllFieldsAreValid()
     {
         var request = new QueryAvailabilityRequest(
-            new [] {"1000", "1001"},
+            new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "34e990af-5dc9-43a6-8895-b9123216d699" },
             "COVID",
             new DateOnly(2077, 01, 01),
             new DateOnly(2077, 01, 01),
@@ -28,14 +28,14 @@ public class QueryAvailabilityRequestValidatorTests
         var result = _sut.TestValidate(request);
         result.IsValid.Should().BeTrue();
     }
-    
+
     [Theory]
-    [InlineData(new string[] {}, InvalidSitesArrayErrorMessage)]
+    [InlineData(new string[] { }, InvalidSitesArrayErrorMessage)]
     [InlineData(null, InvalidSitesArrayErrorMessage)]
-    [InlineData(new [] {""}, InvalidSiteIdentifierErrorMessage)]
-    [InlineData(new string[] {null}, InvalidSiteIdentifierErrorMessage)]
-    [InlineData(new [] {"1000", null}, InvalidSiteIdentifierErrorMessage)]
-    [InlineData(new [] {"", "1000"}, InvalidSiteIdentifierErrorMessage)]
+    [InlineData(new[] { "" }, InvalidSiteIdentifierErrorMessage)]
+    [InlineData(new string[] { null }, InvalidSiteIdentifierErrorMessage)]
+    [InlineData(new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f", null }, InvalidSiteIdentifierErrorMessage)]
+    [InlineData(new[] { "", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f" }, InvalidSiteIdentifierErrorMessage)]
     public void Validate_ReturnsError_WhenSitesIsNullOrEmpty(string[] sites, string message)
     {
         var request = new QueryAvailabilityRequest(
@@ -51,14 +51,14 @@ public class QueryAvailabilityRequestValidatorTests
         result.Errors.Single().PropertyName.Should().Contain(nameof(QueryAvailabilityRequest.Sites));
         result.Errors.Single().ErrorMessage.Should().Be(message);
     }
-    
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     public void Validate_ReturnsError_WhenServiceIsNullOrEmpty(string service)
     {
         var request = new QueryAvailabilityRequest(
-            new [] {"1000", "1001"},
+            new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "34e990af-5dc9-43a6-8895-b9123216d699" },
             service,
             new DateOnly(2077, 01, 01),
             new DateOnly(2077, 01, 01),
@@ -69,13 +69,13 @@ public class QueryAvailabilityRequestValidatorTests
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(QueryAvailabilityRequest.Service));
         result.Errors.Single().ErrorMessage.Should().Be(InvalidStringErrorMessage);
-    }              
-    
+    }
+
     [Fact]
     public void Validate_ReturnsError_WhenUntilDateIsBeforeFrom()
     {
         var request = new QueryAvailabilityRequest(
-            new [] {"1000", "1001"},
+            new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "34e990af-5dc9-43a6-8895-b9123216d699" },
             "COVID",
             new DateOnly(2077, 01, 01),
             new DateOnly(2076, 01, 01),
@@ -87,7 +87,7 @@ public class QueryAvailabilityRequestValidatorTests
         result.Errors.Single().PropertyName.Should().Be(nameof(QueryAvailabilityRequest.From));
         result.Errors.Single().ErrorMessage.Should().Be(InvalidFromDateRangeErrorMessage);
     }
-    
+
     [Theory]
     [InlineData(QueryType.Days)]
     [InlineData(QueryType.Hours)]
@@ -95,7 +95,7 @@ public class QueryAvailabilityRequestValidatorTests
     public void Validate_ReturnsValidResult_WhenQueryTypeIsInRange(QueryType queryType)
     {
         var request = new QueryAvailabilityRequest(
-            new [] {"1000", "1001"},
+            new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "34e990af-5dc9-43a6-8895-b9123216d699" },
             "COVID",
             new DateOnly(2077, 01, 01),
             new DateOnly(2077, 01, 01),
@@ -105,13 +105,13 @@ public class QueryAvailabilityRequestValidatorTests
         result.IsValid.Should().BeTrue();
         result.Errors.Should().HaveCount(0);
     }
-    
+
     [Theory]
     [InlineData(QueryType.NotSet)]
     public void Validate_ReturnsError_WhenQueryTypeIsNotInRange(QueryType queryType)
     {
         var request = new QueryAvailabilityRequest(
-            new [] {"1000", "1001"},
+            new[] { "2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "34e990af-5dc9-43a6-8895-b9123216d699" },
             "COVID",
             new DateOnly(2077, 01, 01),
             new DateOnly(2077, 01, 01),
@@ -121,9 +121,9 @@ public class QueryAvailabilityRequestValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(QueryAvailabilityRequest.QueryType));
-        result.Errors.Single().ErrorMessage.Should().Be(InvalidQueryTypeValueMessage);    
+        result.Errors.Single().ErrorMessage.Should().Be(InvalidQueryTypeValueMessage);
     }
-    
+
     [Fact]
     public void Validate_ReturnsError_WhenRequestBodyIsNull()
     {
@@ -132,5 +132,5 @@ public class QueryAvailabilityRequestValidatorTests
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().ErrorMessage.Should().Be(InvalidRequestBodyErrorMessage);
-    }    
+    }
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/RemoveUserRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/RemoveUserRequestValidatorTests.cs
@@ -13,12 +13,8 @@ public class RemoveUserRequestValidatorTests
     [InlineData(null)]
     public void Validate_ReturnsError_WhenSiteIsNullOrEmpty(string site)
     {
-        var request = new RemoveUserRequest()
-        {
-            User = "test.user@nhs.net",
-            Site = site
-        };
-        
+        var request = new RemoveUserRequest { User = "test.user@nhs.net", Site = site };
+
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -36,11 +32,7 @@ public class RemoveUserRequestValidatorTests
     [InlineData("@test.com")]
     public void Validate_ReturnsError_WhenUserIsNotValidEmailAddress(string user)
     {
-        var request = new RemoveUserRequest()
-        {
-            User = user,
-            Site = "1001"
-        };
+        var request = new RemoveUserRequest { User = user, Site = "34e990af-5dc9-43a6-8895-b9123216d699" };
 
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
@@ -61,10 +53,9 @@ public class RemoveUserRequestValidatorTests
     [Fact]
     public void Validate_ReturnsSuccess_WhenRequestIsValid()
     {
-        var request = new RemoveUserRequest()
+        var request = new RemoveUserRequest
         {
-            User = "test.user@nhs.net",
-            Site = "1001"
+            User = "test.user@nhs.net", Site = "34e990af-5dc9-43a6-8895-b9123216d699"
         };
 
         var result = _sut.Validate(request);

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/SetSiteAttributeValuesValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/SetSiteAttributeValuesValidatorTests.cs
@@ -16,7 +16,7 @@ public class SetSiteAttributeValuesValidatorTests
     public void Validate_ReturnSuccess_WhenRequestIsValid(string value)
     {
         var testRequest = new SetSiteAttributesRequest(
-            Site: "ABC01",
+            Site: "9a06bacd-e916-4c10-8263-21451ca751b8",
             Scope: "*",
             AttributeValues: new[]
             {
@@ -52,7 +52,7 @@ public class SetSiteAttributeValuesValidatorTests
     [Fact]
     public void Validate_ReturnsError_WhenAttributeValuesArrayIsNull()
     {
-        var request = new SetSiteAttributesRequest(Site: "ABC01", Scope: "*", AttributeValues: null);
+        var request = new SetSiteAttributesRequest(Site: "9a06bacd-e916-4c10-8263-21451ca751b8", Scope: "*", AttributeValues: null);
         var result = _sut.TestValidate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -62,7 +62,7 @@ public class SetSiteAttributeValuesValidatorTests
     [Fact]
     public void Validate_ReturnsError_WhenAttributeValuesArrayIsEmpty()
     {
-        var request = new SetSiteAttributesRequest(Site: "ABC01", Scope: "*", AttributeValues: Array.Empty<AttributeValue>());
+        var request = new SetSiteAttributesRequest(Site: "9a06bacd-e916-4c10-8263-21451ca751b8", Scope: "*", AttributeValues: Array.Empty<AttributeValue>());
         var result = _sut.TestValidate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/SetUserRoleValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/SetUserRoleValidatorTests.cs
@@ -14,7 +14,7 @@ public class SetUserRoleValidatorTests
     {
         var testRequest = new SetUserRolesRequest
         {
-            Scope = "site:1000", User = "test.one@test.com", Roles = ["Role1", "Role2"]
+            Scope = "site:2de5bb57-060f-4cb5-b14d-16587d0c2e8f", User = "test.one@test.com", Roles = ["Role1", "Role2"]
         };
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeTrue();
@@ -50,7 +50,7 @@ public class SetUserRoleValidatorTests
     [InlineData("@test.com")]
     public void Validate_ReturnError_WhenUserIsNotValidEmailAddress(string user)
     {
-        var testRequest = new SetUserRolesRequest { Scope = "site:1000", User = user, Roles = ["Role1", "Role2"] };
+        var testRequest = new SetUserRolesRequest { Scope = "site:2de5bb57-060f-4cb5-b14d-16587d0c2e8f", User = user, Roles = ["Role1", "Role2"] };
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -64,7 +64,7 @@ public class SetUserRoleValidatorTests
     [InlineData("", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")]
     public void Validate_ReturnsError_WhenRolesIsNullOrEmpty(params string[] roles)
     {
-        var testRequest = new SetUserRolesRequest { Scope = "site:1000", User = "test@test.com", Roles = roles };
+        var testRequest = new SetUserRolesRequest { Scope = "site:2de5bb57-060f-4cb5-b14d-16587d0c2e8f", User = "test@test.com", Roles = roles };
         var result = _sut.TestValidate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -76,7 +76,7 @@ public class SetUserRoleValidatorTests
     {
         var testRequest = new SetUserRolesRequest
         {
-            Scope = "site:1000", User = "test@test.com", Roles = Array.Empty<string>()
+            Scope = "site:2de5bb57-060f-4cb5-b14d-16587d0c2e8f", User = "test@test.com", Roles = Array.Empty<string>()
         };
         var result = _sut.TestValidate(testRequest);
         result.IsValid.Should().BeFalse();

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/SetUserRoleValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/SetUserRoleValidatorTests.cs
@@ -12,37 +12,33 @@ public class SetUserRoleValidatorTests
     [Fact]
     public void Validate_ReturnSuccess_WhenRequestIsValid()
     {
-        var testRequest = new SetUserRolesRequest()
+        var testRequest = new SetUserRolesRequest
         {
-            Scope = "site:1000", 
-            User = "test.one@test.com", 
-            Roles = ["Role1", "Role2"]
+            Scope = "site:1000", User = "test.one@test.com", Roles = ["Role1", "Role2"]
         };
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeTrue();
     }
-    
+
     [Theory]
     [InlineData("", "")]
     [InlineData(null, null)]
-    [InlineData("", "1000")]
-    [InlineData("site", "1000")]
-    [InlineData(":", "1000")]
+    [InlineData("", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")]
+    [InlineData("site", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")]
+    [InlineData(":", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")]
     [InlineData("site:", "")]
     public void Validate_ReturnError_WhenScopeIsNotValid(string prefix, string site)
     {
-        var testRequest = new SetUserRolesRequest()
+        var testRequest = new SetUserRolesRequest
         {
-            Scope = prefix + site, 
-            User = "test@test.com", 
-            Roles = ["Role1", "Role2"]
+            Scope = prefix + site, User = "test@test.com", Roles = ["Role1", "Role2"]
         };
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(SetUserRolesRequest.Scope));
     }
-    
+
     [Theory]
     [InlineData("")]
     [InlineData(null)]
@@ -54,45 +50,33 @@ public class SetUserRoleValidatorTests
     [InlineData("@test.com")]
     public void Validate_ReturnError_WhenUserIsNotValidEmailAddress(string user)
     {
-        var testRequest = new SetUserRolesRequest()
-        {
-            Scope = "site:1000", 
-            User = user, 
-            Roles = ["Role1", "Role2"]
-        };
+        var testRequest = new SetUserRolesRequest { Scope = "site:1000", User = user, Roles = ["Role1", "Role2"] };
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Be(nameof(SetUserRolesRequest.User));
     }
-    
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    [InlineData("1000", null)]
-    [InlineData("", "1000")]
+    [InlineData("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", null)]
+    [InlineData("", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")]
     public void Validate_ReturnsError_WhenRolesIsNullOrEmpty(params string[] roles)
     {
-        var testRequest = new SetUserRolesRequest()
-        {
-            Scope = "site:1000",
-            User = "test@test.com",
-            Roles = roles
-        };
+        var testRequest = new SetUserRolesRequest { Scope = "site:1000", User = "test@test.com", Roles = roles };
         var result = _sut.TestValidate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
         result.Errors.Single().PropertyName.Should().Contain(nameof(SetUserRolesRequest.Roles));
     }
-    
+
     [Fact]
     public void Validate_ReturnsError_WhenRolesArrayIsEmpty()
     {
-        var testRequest = new SetUserRolesRequest()
+        var testRequest = new SetUserRolesRequest
         {
-            Scope = "site:1000",
-            User = "test@test.com",
-            Roles = Array.Empty<string>()
+            Scope = "site:1000", User = "test@test.com", Roles = Array.Empty<string>()
         };
         var result = _sut.TestValidate(testRequest);
         result.IsValid.Should().BeFalse();

--- a/tests/Nhs.Appointments.Core.UnitTests/AvailabilityCalculatorTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/AvailabilityCalculatorTests.cs
@@ -19,8 +19,8 @@ public class AvailabilityCalculatorTests
         {
             CreateSessionInstance(new DateTime(2077,1,1,9,0,0), new DateTime(2077,1,1,10,0,0), "COVID")
         };
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        var results = await _sut.CalculateAvailability("ABC01", "FLU", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "FLU", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
         results.Should().BeEmpty();
     }
 
@@ -31,8 +31,8 @@ public class AvailabilityCalculatorTests
         {
             CreateSessionInstance(new DateTime(2077,1,1,9,0,0), new DateTime(2077,1,1,10,0,0), 15, 1, "COVID")
         };
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        var results = await _sut.CalculateAvailability("ABC01", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
 
         var expectedResults = new[]
         {
@@ -53,8 +53,8 @@ public class AvailabilityCalculatorTests
             CreateSessionInstance(new DateTime(2077,1,1,9,0,0), new DateTime(2077,1,1,10,0,0), 15, 1, "COVID"),
             CreateSessionInstance(new DateTime(2077,1,1,9,30,0), new DateTime(2077,1,1,10,30,0), 15, 1, "COVID")
         };
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        var results = await _sut.CalculateAvailability("ABC01", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
 
         var expectedResults = new[]
         {
@@ -79,8 +79,8 @@ public class AvailabilityCalculatorTests
             CreateSessionInstance(new DateTime(2077,1,1,9,0,0), new DateTime(2077,1,1,10,0,0), 15, 1, "COVID"),
             CreateSessionInstance(new DateTime(2077,1,1,9,0,0), new DateTime(2077,1,1,10,0,0), 15, 1, "FLU")
         };
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        var results = await _sut.CalculateAvailability("ABC01", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
 
         var expectedResults = new[]
         {
@@ -103,13 +103,13 @@ public class AvailabilityCalculatorTests
 
         var bookings = new[]
         {
-            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01")
+            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")
         };
 
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "ABC01")).ReturnsAsync(bookings);
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")).ReturnsAsync(bookings);
 
-        var results = await _sut.CalculateAvailability("ABC01", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
 
         var expectedResults = new[]
         {
@@ -132,13 +132,13 @@ public class AvailabilityCalculatorTests
 
         var bookings = new[]
         {
-            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01", AppointmentStatus.Cancelled)
+            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f", AppointmentStatus.Cancelled)
         };
 
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "ABC01")).ReturnsAsync(bookings);
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")).ReturnsAsync(bookings);
 
-        var results = await _sut.CalculateAvailability("ABC01", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
 
         var expectedResults = new[]
         {
@@ -163,13 +163,13 @@ public class AvailabilityCalculatorTests
 
         var bookings = new[]
         {
-            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01", AppointmentStatus.Provisional, DateTime.Now.AddMinutes(-6))
+            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f", AppointmentStatus.Provisional, DateTime.Now.AddMinutes(-6))
         };
 
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "ABC01")).ReturnsAsync(bookings);
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")).ReturnsAsync(bookings);
 
-        var results = await _sut.CalculateAvailability("ABC01", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
 
         var expectedResults = new[]
         {
@@ -192,14 +192,14 @@ public class AvailabilityCalculatorTests
 
         var bookings = new[]
         {
-            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01"),
-            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01")
+            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f"),
+            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")
         };
 
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "ABC01")).ReturnsAsync(bookings);
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")).ReturnsAsync(bookings);
 
-        var results = await _sut.CalculateAvailability("ABC01", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
 
         var expectedResults = new[]
         {            
@@ -222,13 +222,13 @@ public class AvailabilityCalculatorTests
 
         var bookings = new[]
         {
-            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "ABC01"),
+            CreateTestBooking(new DateTime(2077, 1, 1, 9, 0, 0), 15, "COVID", "2de5bb57-060f-4cb5-b14d-16587d0c2e8f"),
         };
 
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "ABC01")).ReturnsAsync(bookings);
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        _bookingDocumentStore.Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), "2de5bb57-060f-4cb5-b14d-16587d0c2e8f")).ReturnsAsync(bookings);
 
-        var results = await _sut.CalculateAvailability("ABC01", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "COVID", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
 
         var expectedResults = new[]
         {
@@ -252,8 +252,8 @@ public class AvailabilityCalculatorTests
             CreateSessionInstance(new DateTime(2077,1,1,9,0,0), new DateTime(2077,1,1,10,0,0), 15, 1, "FLU"),
             CreateSessionInstance(new DateTime(2077,1,1,9,0,0), new DateTime(2077,1,1,10,0,0), 15, 1, "RSV")
         };
-        _availabilityDocumentStore.Setup(x => x.GetSessions("ABC01", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
-        var results = await _sut.CalculateAvailability("ABC01", "*", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
+        _availabilityDocumentStore.Setup(x => x.GetSessions("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", It.IsAny<DateOnly>(), It.IsAny<DateOnly>())).ReturnsAsync(sessions);
+        var results = await _sut.CalculateAvailability("2de5bb57-060f-4cb5-b14d-16587d0c2e8f", "*", new DateOnly(2077, 1, 1), new DateOnly(2077, 1, 2));
 
         var expectedResults = new[]
         {

--- a/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/AvailabilityServiceTests.cs
@@ -42,7 +42,7 @@ public class AvailabilityServiceTests
     [Fact]
     public async Task ApplyTemplateAsync_ThrowsArgumentException_IfTemplateIsNull()
     {
-        const string site = "ABC01";
+        const string site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f";
         const string user = "mock.user@nhs.net";
         var from = new DateOnly(2025, 01, 06);
         var until = new DateOnly(2025, 01, 12);
@@ -55,7 +55,7 @@ public class AvailabilityServiceTests
     [Fact]
     public async Task ApplyTemplateAsync_ThrowsArgumentException_IfFromDateIsAfterUntilDate()
     {
-        const string site = "ABC01";
+        const string site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f";
         const string user = "mock.user@nhs.net";
         var from = new DateOnly(2025, 01, 02);
         var until = new DateOnly(2025, 01, 01);
@@ -81,7 +81,7 @@ public class AvailabilityServiceTests
     [Fact]
     public async Task ApplyTemplateAsync_ThrowsArgumentException_IfNoDaysAreSpecified()
     {
-        const string site = "ABC01";
+        const string site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f";
         const string user = "mock.user@nhs.net";
         var from = new DateOnly(2025, 01, 06);
         var until = new DateOnly(2025, 01, 12);
@@ -107,7 +107,7 @@ public class AvailabilityServiceTests
     [Fact]
     public async Task ApplyTemplateAsync_ThrowsArgumentException_IfTemplateContainsNoSessions()
     {
-        const string site = "ABC01";
+        const string site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f";
         const string user = "mock.user@nhs.net";
         var from = new DateOnly(2025, 01, 06);
         var until = new DateOnly(2025, 01, 12);
@@ -123,7 +123,7 @@ public class AvailabilityServiceTests
     [Fact]
     public async Task ApplyTemplateAsync_CallsAvailabilityStore_WithDatesForRequestedDays()
     {
-        const string site = "ABC01";
+        const string site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f";
         const string user = "mock.user@nhs.net";
         var from = new DateOnly(2025, 01, 06);
         var until = new DateOnly(2025, 01, 12);
@@ -164,7 +164,7 @@ public class AvailabilityServiceTests
     [Fact]
     public async Task ApplyTemplateAsync_CallsBookingServiceToRecalculateAppointmentStatuses_WithDatesForRequestedDays()
     {
-        const string site = "ABC01";
+        const string site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f";
         const string user = "mock.user@nhs.net";
         var from = new DateOnly(2025, 01, 06);
         var until = new DateOnly(2025, 01, 8);
@@ -200,7 +200,7 @@ public class AvailabilityServiceTests
     [Fact]
     public async Task ApplySingleDateSessionAsync_CallsAvailabilityCreatedEventStore()
     {
-        const string site = "ABC01";
+        const string site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f";
         const string user = "mock.user@nhs.net";
         var date = new DateOnly(2024, 10, 10);
 
@@ -226,7 +226,7 @@ public class AvailabilityServiceTests
     [Fact]
     public async Task ApplySingleDateSessionAsync_CallsBookingServiceToRecalculateAppointmentStatuses()
     {
-        const string site = "ABC01";
+        const string site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f";
         const string user = "mock.user@nhs.net";
         var date = new DateOnly(2024, 10, 10);
 

--- a/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
@@ -1,12 +1,13 @@
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Nhs.Appointments.Core.UnitTests;
+
 public class SiteServiceTests
 {
-    private readonly SiteService _sut;
-    private readonly Mock<ISiteStore> _siteStore = new();
-    private readonly Mock<IMemoryCache> _memoryCache = new();    
     private readonly Mock<ICacheEntry> _cacheEntry = new();
+    private readonly Mock<IMemoryCache> _memoryCache = new();
+    private readonly Mock<ISiteStore> _siteStore = new();
+    private readonly SiteService _sut;
 
     public SiteServiceTests()
     {
@@ -17,71 +18,95 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_ReturnsSitesOrderedByDistance_InAscendingOrder()
     {
-        var sites = new List<Site>()
+        var sites = new List<Site>
         {
-            new (
-                    Id: "ABC02",
-                    Name: "Site 2",
-                    Address: "2 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [.507, 65]),
-                    AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")}),                
-            new (
-                    Id: "ABC03",
-                    Name: "Site 3",
-                    Address: "3 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [.506, 65]),
-                AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")}),                
-            new (
-                    Id: "ABC01",
-                    Name: "Site 1",
-                    Address: "1 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [.505, 65]),
-                AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")})                
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
+                Name: "Site 2",
+                Address: "2 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC02",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [.507, 65]),
+                AttributeValues: new List<AttributeValue>
+                {
+                    new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                }),
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bc",
+                Name: "Site 3",
+                Address: "3 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC03",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [.506, 65]),
+                AttributeValues: new List<AttributeValue>
+                {
+                    new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                }),
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
+                Name: "Site 1",
+                Address: "1 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC01",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [.505, 65]),
+                AttributeValues: new List<AttributeValue>
+                {
+                    new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                })
         };
 
-        var expectedSites = new List<SiteWithDistance>()
+        var expectedSites = new List<SiteWithDistance>
         {
             new SiteWithDistance(new Site(
-                    Id: "ABC01",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                     Name: "Site 1",
                     Address: "1 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC01",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.505, 65.0]),
-                AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 234),
             new SiteWithDistance(new Site(
-                    Id: "ABC03",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bc",
                     Name: "Site 3",
                     Address: "3 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC03",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [.506, 65.0]),
-                AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 281),
             new SiteWithDistance(new Site(
-                    Id: "ABC02",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
                     Name: "Site 2",
                     Address: "2 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC02",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [.507, 65.0]),
-                    AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 328)
         };
-        
+
         _siteStore.Setup(x => x.GetAllSites()).ReturnsAsync(sites);
 
         var result = await _sut.FindSitesByArea(0.5, 65, 50000, 50, []);
@@ -91,61 +116,81 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_ReturnsRequestedNumberOfSites()
     {
-        var sites = new List<Site>()
+        var sites = new List<Site>
         {
-            new (
-                    Id: "ABC02",
-                    Name: "Site 2",
-                    Address: "2 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [.507, 65]),
-                    AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")}),
-            new (
-                    Id: "ABC03",
-                    Name: "Site 3",
-                    Address: "3 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [.506, 65]),
-                AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")}),
-            new (
-                    Id: "ABC01",
-                    Name: "Site 1",
-                    Address: "1 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [.505, 65]),
-                AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")})
-        };
-
-        var expectedSites = new List<SiteWithDistance>()
-        {
-            new SiteWithDistance(new Site(
-                Id: "ABC01",
-                Name: "Site 1",
-                Address: "1 Park Row",
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
+                Name: "Site 2",
+                Address: "2 Park Row",
                 PhoneNumber: "0113 1111111",
+                OdsCode: "ABC02",
                 Region: "R1",
                 IntegratedCareBoard: "ICB1",
-                Location: new Location(Type: "Point", Coordinates: [.505, 65.0]),
-                AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")}),
-                Distance: 234),
-            new SiteWithDistance(new Site(
-                Id: "ABC03",
+                Location: new Location(Type: "Point", Coordinates: [.507, 65]),
+                AttributeValues: new List<AttributeValue>
+                {
+                    new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                }),
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bc",
                 Name: "Site 3",
                 Address: "3 Park Row",
                 PhoneNumber: "0113 1111111",
+                OdsCode: "ABC03",
                 Region: "R1",
                 IntegratedCareBoard: "ICB1",
-                Location: new Location(Type: "Point", Coordinates: [.506, 65.0]),
-                AttributeValues: new List<AttributeValue>() {new AttributeValue(Id: "accessibility/access_need_1", Value: "true")}),
+                Location: new Location(Type: "Point", Coordinates: [.506, 65]),
+                AttributeValues: new List<AttributeValue>
+                {
+                    new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                }),
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
+                Name: "Site 1",
+                Address: "1 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC01",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [.505, 65]),
+                AttributeValues: new List<AttributeValue>
+                {
+                    new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                })
+        };
+
+        var expectedSites = new List<SiteWithDistance>
+        {
+            new SiteWithDistance(new Site(
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
+                    Name: "Site 1",
+                    Address: "1 Park Row",
+                    PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC01",
+                    Region: "R1",
+                    IntegratedCareBoard: "ICB1",
+                    Location: new Location(Type: "Point", Coordinates: [.505, 65.0]),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                    }),
+                Distance: 234),
+            new SiteWithDistance(new Site(
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bc",
+                    Name: "Site 3",
+                    Address: "3 Park Row",
+                    PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC03",
+                    Region: "R1",
+                    IntegratedCareBoard: "ICB1",
+                    Location: new Location(Type: "Point", Coordinates: [.506, 65.0]),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new AttributeValue(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 281)
         };
-        
+
         _siteStore.Setup(x => x.GetAllSites()).ReturnsAsync(sites);
 
         var result = await _sut.FindSitesByArea(0.5, 65, 50000, 2, []);
@@ -155,39 +200,45 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_ReturnsSites_WithRequestedAccessNeeds()
     {
-        var sites = new List<Site>()
+        var sites = new List<Site>
         {
-            new (
-                    Id: "ABC01",
-                    Name: "Site 1",
-                    Address: "1 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [.505, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "true")}),                
-            new (
-                    Id: "ABC02",
-                    Name: "Site 2",
-                    Address: "2 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [.506, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "false")}),                
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
+                Name: "Site 1",
+                Address: "1 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC01",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [.505, 50.0]),
+                AttributeValues: new List<AttributeValue> { new(Id: "accessibility/access_need_1", Value: "true") }),
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
+                Name: "Site 2",
+                Address: "2 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC02",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [.506, 50.0]),
+                AttributeValues: new List<AttributeValue> { new(Id: "accessibility/access_need_1", Value: "false") }),
         };
 
-        var expectedSites = new List<SiteWithDistance>()
+        var expectedSites = new List<SiteWithDistance>
         {
-            new (new Site(
-                    Id: "ABC01",
+            new(new Site(
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                     Name: "Site 1",
                     Address: "1 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC01",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.505, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 357),
         };
 
@@ -200,26 +251,34 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_ReturnsNoSites_IfNoAccessNeedMatchesAreFound()
     {
-        var sites = new List<Site>()
+        var sites = new List<Site>
         {
-            new (
-                    Id: "ABC01",
-                    Name: "Site 1",
-                    Address: "1 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [0.0, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/accessibility/access_need_1", Value: "false")}),                
-            new (
-                    Id: "ABC02",
-                    Name: "Site 2",
-                    Address: "2 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [.05, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/accessibility/access_need_1", Value: "false")}),
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
+                Name: "Site 1",
+                Address: "1 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC01",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [0.0, 50.0]),
+                AttributeValues: new List<AttributeValue>
+                {
+                    new(Id: "accessibility/accessibility/access_need_1", Value: "false")
+                }),
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
+                Name: "Site 2",
+                Address: "2 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC02",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [.05, 50.0]),
+                AttributeValues: new List<AttributeValue>
+                {
+                    new(Id: "accessibility/accessibility/access_need_1", Value: "false")
+                }),
         };
 
         _siteStore.Setup(x => x.GetAllSites()).ReturnsAsync(sites);
@@ -231,27 +290,35 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_ReturnSitesBasedOnDistanceAndMaxRecords_IfNoAccessNeedsAreRequested()
     {
-        var sites = new List<SiteWithDistance>()
+        var sites = new List<SiteWithDistance>
         {
             new SiteWithDistance(new Site(
-                    Id: "ABC01",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                     Name: "Site 1",
                     Address: "1 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC01",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.04, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 2858),
             new SiteWithDistance(new Site(
-                    Id: "ABC02",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
                     Name: "Site 2",
                     Address: "2 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC02",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.05, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_2", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_2", Value: "true")
+                    }),
                 Distance: 3573),
         };
 
@@ -263,38 +330,44 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_DoesNotReturnSitesWithNoAttributeValues_IfAccessNeedsAreRequested()
     {
-        var sites = new List<Site>()
+        var sites = new List<Site>
         {
             new(
-                    Id: "ABC01",
-                    Name: "Site 1",
-                    Address: "1 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [0.0, 50.0]),
-                    AttributeValues: Array.Empty<AttributeValue>()),
-            new (
-                    Id: "ABC02",
-                    Name: "Site 2",
-                    Address: "2 Park Row",
-                    PhoneNumber: "0113 1111111",
-                    Region: "R1",
-                    IntegratedCareBoard: "ICB1",
-                    Location: new Location(Type: "Point", Coordinates: [0.1, 50.1]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_2", Value: "true")})            
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
+                Name: "Site 1",
+                Address: "1 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC01",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [0.0, 50.0]),
+                AttributeValues: Array.Empty<AttributeValue>()),
+            new(
+                Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
+                Name: "Site 2",
+                Address: "2 Park Row",
+                PhoneNumber: "0113 1111111",
+                OdsCode: "ABC02",
+                Region: "R1",
+                IntegratedCareBoard: "ICB1",
+                Location: new Location(Type: "Point", Coordinates: [0.1, 50.1]),
+                AttributeValues: new List<AttributeValue> { new(Id: "accessibility/access_need_2", Value: "true") })
         };
-        var expectedSites = new List<SiteWithDistance>()
+        var expectedSites = new List<SiteWithDistance>
         {
-            new (new Site(
-                    Id: "ABC02",
+            new(new Site(
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
                     Name: "Site 2",
                     Address: "2 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC02",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.1, 50.1]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_2", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_2", Value: "true")
+                    }),
                 Distance: 13213),
         };
         _siteStore.Setup(x => x.GetAllSites()).ReturnsAsync(sites);
@@ -305,27 +378,35 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_ReturnsSites_IfRequestedAccessNeedsAreEmpty()
     {
-        var sites = new List<SiteWithDistance>()
+        var sites = new List<SiteWithDistance>
         {
             new SiteWithDistance(new Site(
-                    Id: "ABC01",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                     Name: "Site 1",
                     Address: "1 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC01",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.04, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 2858),
             new SiteWithDistance(new Site(
-                    Id: "ABC02",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
                     Name: "Site 2",
                     Address: "2 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC02",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.05, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "false")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "false")
+                    }),
                 Distance: 3573),
         };
         _siteStore.Setup(x => x.GetAllSites()).ReturnsAsync(sites.Select(s => s.Site));
@@ -345,27 +426,35 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_ReadsFromCache_WhenPresent()
     {
-        var sites = new List<SiteWithDistance>()
+        var sites = new List<SiteWithDistance>
         {
             new SiteWithDistance(new Site(
-                    Id: "ABC01",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                     Name: "Site 1",
                     Address: "1 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC01",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.04, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 2858),
             new SiteWithDistance(new Site(
-                    Id: "ABC02",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
                     Name: "Site 2",
                     Address: "2 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC02",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.05, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "false")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "false")
+                    }),
                 Distance: 3573),
         };
         object? outSites = sites.Select(s => s.Site);
@@ -378,27 +467,35 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_IgnoresCache_WhenRequiredTo()
     {
-        var sites = new List<SiteWithDistance>()
+        var sites = new List<SiteWithDistance>
         {
             new SiteWithDistance(new Site(
-                    Id: "ABC01",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                     Name: "Site 1",
                     Address: "1 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC01",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.04, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 2858),
             new SiteWithDistance(new Site(
-                    Id: "ABC02",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
                     Name: "Site 2",
                     Address: "2 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC02",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.05, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "false")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "false")
+                    }),
                 Distance: 3573),
         };
         object? outSites = sites.Take(1).Select(s => s.Site);
@@ -413,27 +510,35 @@ public class SiteServiceTests
     [Fact]
     public async Task FindSitesByArea_WritesToCache_AfterCacheMiss()
     {
-        var sites = new List<SiteWithDistance>()
+        var sites = new List<SiteWithDistance>
         {
             new SiteWithDistance(new Site(
-                    Id: "ABC01",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6ba",
                     Name: "Site 1",
                     Address: "1 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC01",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.04, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "true")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "true")
+                    }),
                 Distance: 2858),
             new SiteWithDistance(new Site(
-                    Id: "ABC02",
+                    Id: "6877d86e-c2df-4def-8508-e1eccf0ea6bb",
                     Name: "Site 2",
                     Address: "2 Park Row",
                     PhoneNumber: "0113 1111111",
+                    OdsCode: "ABC02",
                     Region: "R1",
                     IntegratedCareBoard: "ICB1",
                     Location: new Location(Type: "Point", Coordinates: [0.05, 50.0]),
-                    AttributeValues: new List<AttributeValue>() {new (Id: "accessibility/access_need_1", Value: "false")}),
+                    AttributeValues: new List<AttributeValue>
+                    {
+                        new(Id: "accessibility/access_need_1", Value: "false")
+                    }),
                 Distance: 3573),
         };
         object? outSites = null;
@@ -449,27 +554,29 @@ public class SiteServiceTests
     [Fact]
     public async Task GetSiteByIdAsync_ReturnsRequestedSite()
     {
-        const string siteId = "ABC01";
+        const string siteId = "6877d86e-c2df-4def-8508-e1eccf0ea6ba";
         var site = new Site(
             Id: siteId,
             Name: "Site 1",
             Address: "1 Park Row",
             PhoneNumber: "0113 1111111",
+            OdsCode: "ABC01",
             Region: "R1",
             IntegratedCareBoard: "ICB1",
             Location: new Location(Type: "Point", Coordinates: [2.0, 70.0]),
-            AttributeValues: new List<AttributeValue>() { new AttributeValue(Id: "Attribute 1", Value: "true") });
+            AttributeValues: new List<AttributeValue> { new AttributeValue(Id: "Attribute 1", Value: "true") });
 
         var expectedSite = new Site(
             Id: siteId,
             Name: "Site 1",
             Address: "1 Park Row",
             PhoneNumber: "0113 1111111",
+            OdsCode: "ABC01",
             Region: "R1",
             IntegratedCareBoard: "ICB1",
             Location: new Location(Type: "Point", Coordinates: [2.0, 70.0]),
-            AttributeValues: new List<AttributeValue>() { new AttributeValue(Id: "Attribute 1", Value: "true") });
-        _siteStore.Setup(x => x.GetSiteById("ABC01")).ReturnsAsync(site);
+            AttributeValues: new List<AttributeValue> { new AttributeValue(Id: "Attribute 1", Value: "true") });
+        _siteStore.Setup(x => x.GetSiteById("6877d86e-c2df-4def-8508-e1eccf0ea6ba")).ReturnsAsync(site);
 
         var result = await _sut.GetSiteByIdAsync(siteId);
         result.Should().BeEquivalentTo(expectedSite);
@@ -478,16 +585,18 @@ public class SiteServiceTests
     [Fact]
     public async Task GetSiteByIdAsync_ReturnsRequestedSite_AndFiltersAttributesByScope()
     {
-        const string siteId = "ABC01";
+        const string siteId = "6877d86e-c2df-4def-8508-e1eccf0ea6ba";
         var site = new Site(
             Id: siteId,
             Name: "Site 1",
             Address: "1 Park Row",
             PhoneNumber: "0113 1111111",
+            OdsCode: "ABC01",
             Region: "R1",
             IntegratedCareBoard: "ICB1",
             Location: new Location(Type: "Point", Coordinates: [2.0, 70.0]),
-            AttributeValues: [
+            AttributeValues:
+            [
                 new AttributeValue(Id: "test_scope/Attribute 1", Value: "true"),
                 new AttributeValue(Id: "Attribute 2", Value: "true"),
                 new AttributeValue(Id: "test_scope/Attribute 3", Value: "true"),
@@ -497,14 +606,17 @@ public class SiteServiceTests
             Id: siteId,
             Name: "Site 1",
             Address: "1 Park Row",
-            PhoneNumber: "0113 1111111", Region: "R1",
+            PhoneNumber: "0113 1111111",
+            Region: "R1",
+            OdsCode: "ABC01",
             IntegratedCareBoard: "ICB1",
             Location: new Location(Type: "Point", Coordinates: [2.0, 70.0]),
-            AttributeValues: [
+            AttributeValues:
+            [
                 new AttributeValue(Id: "test_scope/Attribute 1", Value: "true"),
                 new AttributeValue(Id: "test_scope/Attribute 3", Value: "true"),
             ]);
-        _siteStore.Setup(x => x.GetSiteById("ABC01")).ReturnsAsync(site);
+        _siteStore.Setup(x => x.GetSiteById("6877d86e-c2df-4def-8508-e1eccf0ea6ba")).ReturnsAsync(site);
 
         var result = await _sut.GetSiteByIdAsync(siteId, "test_scope");
 

--- a/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
@@ -628,7 +628,7 @@ public class SiteServiceTests
     [InlineData("site_details")]
     public async Task GetSiteByIdAsync_ReturnsDefault_WhenSiteIsNotFound(string scope)
     {
-        const string siteId = "ABC01";
+        const string siteId = "9a06bacd-e916-4c10-8263-21451ca751b8";
         _siteStore.Setup(x => x.GetSiteById(siteId)).ReturnsAsync((Site)null!);
 
         var result = await _sut.GetSiteByIdAsync(siteId, scope);

--- a/tests/Nhs.Appointments.Persistance.UnitTests/BookingCosmosDocumentStoreTests.cs
+++ b/tests/Nhs.Appointments.Persistance.UnitTests/BookingCosmosDocumentStoreTests.cs
@@ -6,72 +6,171 @@ namespace Nhs.Appointments.Persistance.UnitTests;
 
 public class BookingCosmosDocumentStoreTests
 {
-    private readonly BookingCosmosDocumentStore _sut;
     private readonly Mock<ITypedDocumentCosmosStore<BookingDocument>> _bookingStore = new();
     private readonly Mock<ITypedDocumentCosmosStore<BookingIndexDocument>> _indexStore = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
+    private readonly BookingCosmosDocumentStore _sut;
     private readonly Mock<TimeProvider> _timeProvider = new();
 
     public BookingCosmosDocumentStoreTests()
     {
-        _sut = new BookingCosmosDocumentStore(_bookingStore.Object, _indexStore.Object, _metricsRecorder.Object, _timeProvider.Object);
+        _sut = new BookingCosmosDocumentStore(_bookingStore.Object, _indexStore.Object, _metricsRecorder.Object,
+            _timeProvider.Object);
     }
-    
+
     [Fact]
     public async Task GetByNhsNumberAsync_CallsRunQueryAsync_WhenBookingCountIsGreaterThanPointReadLimit()
     {
         var bookingIndexDocuments = new List<BookingIndexDocument>
         {
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "01-76-000001", NhsNumber = "9999999999", Reference = "01-76-000001", Status = AppointmentStatus.Booked },
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "01-76-000002", NhsNumber = "9999999999", Reference = "01-76-000002", Status = AppointmentStatus.Booked },
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "01-76-000003", NhsNumber = "9999999999", Reference = "01-76-000003", Status = AppointmentStatus.Booked },
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "02-76-000004", NhsNumber = "9999999999", Reference = "02-76-000004", Status = AppointmentStatus.Booked },
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "01-76-000001",
+                NhsNumber = "9999999999",
+                Reference = "01-76-000001",
+                Status = AppointmentStatus.Booked
+            },
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "01-76-000002",
+                NhsNumber = "9999999999",
+                Reference = "01-76-000002",
+                Status = AppointmentStatus.Booked
+            },
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "01-76-000003",
+                NhsNumber = "9999999999",
+                Reference = "01-76-000003",
+                Status = AppointmentStatus.Booked
+            },
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "02-76-000004",
+                NhsNumber = "9999999999",
+                Reference = "02-76-000004",
+                Status = AppointmentStatus.Booked
+            },
         };
 
-        _indexStore.Setup(x => 
+        _indexStore.Setup(x =>
                 x.RunQueryAsync<BookingIndexDocument>(It.IsAny<Expression<Func<BookingIndexDocument, bool>>>()))
             .ReturnsAsync(bookingIndexDocuments);
-        
+
         await _sut.GetByNhsNumberAsync("9999999999");
-        _bookingStore.Verify(x => x.RunQueryAsync<Booking>(It.IsAny<Expression<Func<BookingDocument, bool>>>()), Times.Once);
+        _bookingStore.Verify(x => x.RunQueryAsync<Booking>(It.IsAny<Expression<Func<BookingDocument, bool>>>()),
+            Times.Once);
     }
-    
+
     [Fact]
     public async Task GetByNhsNumberAsync_CallsGetDocument_WhenBookingCountIsLessThanPointReadLimit()
     {
         var bookingIndexDocuments = new List<BookingIndexDocument>
         {
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "01-76-000001", NhsNumber = "9999999999", Reference = "01-76-000001", Status = AppointmentStatus.Booked },
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "01-76-000002", NhsNumber = "9999999999", Reference = "01-76-000002", Status = AppointmentStatus.Booked },
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "01-76-000001",
+                NhsNumber = "9999999999",
+                Reference = "01-76-000001",
+                Status = AppointmentStatus.Booked
+            },
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "01-76-000002",
+                NhsNumber = "9999999999",
+                Reference = "01-76-000002",
+                Status = AppointmentStatus.Booked
+            },
         };
 
-        _indexStore.Setup(x => 
+        _indexStore.Setup(x =>
                 x.RunQueryAsync<BookingIndexDocument>(It.IsAny<Expression<Func<BookingIndexDocument, bool>>>()))
             .ReturnsAsync(bookingIndexDocuments);
-        
+
         await _sut.GetByNhsNumberAsync("9999999999");
         _bookingStore.Verify(x => x.GetDocument<Booking>(It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(2));
     }
-    
+
     [Fact]
     public async Task GetByNhsNumberAsync_GroupsSitesAndCallsCorrectMethod_WhenThereAreBookingForMultipleSites()
     {
         var bookingIndexDocuments = new List<BookingIndexDocument>
         {
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "01-76-000001", NhsNumber = "9999999999", Reference = "01-76-000001", Status = AppointmentStatus.Booked },
-            new BookingIndexDocument {Site = "1001", DocumentType = "booking_index", Id = "02-76-000001", NhsNumber = "9999999999", Reference = "02-76-000001", Status = AppointmentStatus.Booked },
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "01-76-000002", NhsNumber = "9999999999", Reference = "01-76-000002", Status = AppointmentStatus.Booked },
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "01-76-000003", NhsNumber = "9999999999", Reference = "01-76-000003" , Status = AppointmentStatus.Booked},
-            new BookingIndexDocument {Site = "1000", DocumentType = "booking_index", Id = "02-76-000004", NhsNumber = "9999999999", Reference = "02-76-000004" , Status = AppointmentStatus.Booked},
-            new BookingIndexDocument {Site = "1001", DocumentType = "booking_index", Id = "02-76-000002", NhsNumber = "9999999999", Reference = "02-76-000002" , Status = AppointmentStatus.Booked},
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "01-76-000001",
+                NhsNumber = "9999999999",
+                Reference = "01-76-000001",
+                Status = AppointmentStatus.Booked
+            },
+            new BookingIndexDocument
+            {
+                Site = "34e990af-5dc9-43a6-8895-b9123216d699",
+                DocumentType = "booking_index",
+                Id = "02-76-000001",
+                NhsNumber = "9999999999",
+                Reference = "02-76-000001",
+                Status = AppointmentStatus.Booked
+            },
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "01-76-000002",
+                NhsNumber = "9999999999",
+                Reference = "01-76-000002",
+                Status = AppointmentStatus.Booked
+            },
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "01-76-000003",
+                NhsNumber = "9999999999",
+                Reference = "01-76-000003",
+                Status = AppointmentStatus.Booked
+            },
+            new BookingIndexDocument
+            {
+                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                DocumentType = "booking_index",
+                Id = "02-76-000004",
+                NhsNumber = "9999999999",
+                Reference = "02-76-000004",
+                Status = AppointmentStatus.Booked
+            },
+            new BookingIndexDocument
+            {
+                Site = "34e990af-5dc9-43a6-8895-b9123216d699",
+                DocumentType = "booking_index",
+                Id = "02-76-000002",
+                NhsNumber = "9999999999",
+                Reference = "02-76-000002",
+                Status = AppointmentStatus.Booked
+            },
         };
 
-        _indexStore.Setup(x => 
+        _indexStore.Setup(x =>
                 x.RunQueryAsync<BookingIndexDocument>(It.IsAny<Expression<Func<BookingIndexDocument, bool>>>()))
             .ReturnsAsync(bookingIndexDocuments);
-        
+
         await _sut.GetByNhsNumberAsync("9999999999");
-        _bookingStore.Verify(x => x.RunQueryAsync<Booking>(It.IsAny<Expression<Func<BookingDocument, bool>>>()), Times.Once);
+        _bookingStore.Verify(x => x.RunQueryAsync<Booking>(It.IsAny<Expression<Func<BookingDocument, bool>>>()),
+            Times.Once);
         _bookingStore.Verify(x => x.GetDocument<Booking>(It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(2));
     }
 }


### PR DESCRIPTION
_Decision was made that the Site model needs updating to facilitate the non-negotiable requirement of editable ODS codes for sites within MYA (they are currently the single internal identifier within the system). Decision made to update the model now before the 'bad' structure makes it any further as edits to ODS need to be possible without having large downstream effects._

**Dev Changes**

- New Id field provided to CSVProcessor should be a randomly generated GUID string for each site. This can be maintained and used by operations onboarding to also apply bulk users to this controlled GUID.
- Update CSVProcessor to move ODSCode onto new field. 
- Add ODSCode field onto SiteDocument CosmosDB document and Site DTO.
- Integration tests updated with new format of ID (for dev consistency) and with new ODS code field.
- Local CosmosDB seeder data updated to match the new ID format (for dev consistency)

- Front end change to use the new OdsCode field for displaying the ODS value in the site details
- Front end tests updated with ODS code change
- Front end tests updated with new ID format (for dev consistency)

**KNOCK-ON EFFECTS**

- The CSVProcessor change impacts the importing data process. The site ID will be new and unique on every run - so huge care needs to be impressed upon operations as possible Site duplicates could leak through with this design change, as no current validation against site name/postcode etc.
- Each environment will need tearing down and re-seeding as the data model has changed.
- The same ODS Codes are now permitted on multiple sites. Operations don't need to increment the ODSCode for satellite sites that share the same ODS Code.
- The URL in MYA uses the new ID (guid) which is less user-friendly, is this a concern for now or tech debt to improve at a later time?
- Questions about the overall data model for the future. Do we need an organisation level document for a relational data? Future tech debt?
- How does this impact the daily export process?
- Reporting - Editing ODS code information means all existing bookings/availability/users are against that new ODS code and the old one is lost (no Site history in the DB). How is this handled in the bigger picture?

