### PR TITLE
APPT-577: Return 412 when trying to confirm a booking which is not provisional

### DIFF
--- a/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
@@ -39,7 +39,8 @@ public enum BookingConfirmationResult
     Expired,
     NotFound,
     RescheduleNotFound,
-    RescheduleMismatch
+    RescheduleMismatch,
+    StatusMismatch
 }
 
 public enum BookingCancellationResult

--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -1,7 +1,8 @@
+using System.Collections.Concurrent;
+using System.Net;
 using Microsoft.Azure.Cosmos;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
-using System.Collections.Concurrent;
 
 namespace Nhs.Appointments.Persistance;
 
@@ -44,7 +45,7 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
             var siteId = bookingIndexDocument.Site;
             return await bookingStore.GetDocument<Booking>(bookingReference, siteId);
         }
-        catch(CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
             return default;
         }
@@ -121,6 +122,10 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
         var bookingIndexDocument = await indexStore.GetByIdOrDefaultAsync<BookingIndexDocument>(bookingReference);
         if (bookingIndexDocument == null)
             return BookingConfirmationResult.NotFound;
+        if (bookingIndexDocument.Status is not AppointmentStatus.Provisional)
+        {
+            return BookingConfirmationResult.StatusMismatch;
+        }
 
         var (getRescheduleResult, rescheduleDocument) = await GetBookingForReschedule(bookingToReschedule, bookingIndexDocument.NhsNumber);
 

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBooking.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBooking.feature
@@ -1,60 +1,71 @@
 ﻿Feature: Book an appointment
 
-    Scenario: Confirm a provisional appointment
-        Given the site is configured for MYA
-        And the following sessions
-          | Date     | From  | Until | Services | Slot Length | Capacity |
-          | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
-        And the following provisional bookings have been made
-          | Date     | Time  | Duration | Service |
-          | Tomorrow | 09:00 | 5        | COVID   |
-        When I confirm the booking
-        Then the call should be successful
-        And the booking is no longer marked as provisional
+  Scenario: Confirm a provisional appointment
+    Given the site is configured for MYA
+    And the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following provisional bookings have been made
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:00 | 5        | COVID   |
+    When I confirm the booking
+    Then the call should be successful
+    And the booking is no longer marked as provisional
 
-    Scenario: Confirmation can record contact details
-        Given the site is configured for MYA
-        And the following sessions
-          | Date     | From  | Until | Services | Slot Length | Capacity |
-          | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
-        And the following provisional bookings have been made
-          | Date     | Time  | Duration | Service |
-          | Tomorrow | 09:00 | 5        | COVID   |
-        When I confirm the booking with the following contact information
-          | Email         | Phone         | Landline    |
-          | test@test.com | 07654 3210987 | 00001234567 |
-        Then the call should be successful
-        And the booking should have stored my contact details as follows
-          | Email         | Phone         | Landline    |
-          | test@test.com | 07654 3210987 | 00001234567 |
+  Scenario: Confirmation can record contact details
+    Given the site is configured for MYA
+    And the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following provisional bookings have been made
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:00 | 5        | COVID   |
+    When I confirm the booking with the following contact information
+      | Email         | Phone         | Landline    |
+      | test@test.com | 07654 3210987 | 00001234567 |
+    Then the call should be successful
+    And the booking should have stored my contact details as follows
+      | Email         | Phone         | Landline    |
+      | test@test.com | 07654 3210987 | 00001234567 |
 
-    Scenario: Cannot confirm an appointment that does not exist
-        Given the site is configured for MYA
-        And the following sessions
-          | Date     | From  | Until | Services | Slot Length | Capacity |
-          | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
-        When I confirm the booking
-        Then the call should fail with 404
+  Scenario: Cannot confirm an appointment that does not exist
+    Given the site is configured for MYA
+    And the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    When I confirm the booking
+    Then the call should fail with 404
 
-    Scenario: Cannot confirm a provisional appointment that has expired
-        Given the site is configured for MYA
-        And the following sessions
-          | Date     | From  | Until | Services | Slot Length | Capacity |
-          | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
-        And the following expired provisional bookings have been made
-          | Date     | Time  | Duration | Service |
-          | Tomorrow | 09:00 | 5        | COVID   |
-        When I confirm the booking
-        Then the call should fail with 410
+  Scenario: Cannot confirm a provisional appointment that has expired
+    Given the site is configured for MYA
+    And the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following expired provisional bookings have been made
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:00 | 5        | COVID   |
+    When I confirm the booking
+    Then the call should fail with 410
 
-    Scenario: A provisional booking expires
-        Given the site is configured for MYA
-        And the following sessions
-          | Date     | From  | Until | Services | Slot Length | Capacity |
-          | Yesterday | 09:00 | 10:00 | COVID    | 5           | 1        |
-        And the following expired provisional bookings have been made
-          | Date     | Time  | Duration | Service |
-          | Yesterday | 09:00 | 5        | COVID   |
-        When the provisional bookings are cleaned up
-        Then the call should be successful
-        And the booking should be deleted
+  Scenario: A provisional booking expires
+    Given the site is configured for MYA
+    And the following sessions
+      | Date      | From  | Until | Services | Slot Length | Capacity |
+      | Yesterday | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following expired provisional bookings have been made
+      | Date      | Time  | Duration | Service |
+      | Yesterday | 09:00 | 5        | COVID   |
+    When the provisional bookings are cleaned up
+    Then the call should be successful
+    And the booking should be deleted
+
+  Scenario: Cannot confirm a non-provisional appointment
+    Given the site is configured for MYA
+    And the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following orphaned bookings exist
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:00 | 5        | COVID   |
+    When I confirm the booking
+    Then the call should fail with 412


### PR DESCRIPTION
The `ConfirmProvisionalBookingFunction` does not currently check that a booking is `Provisional` before proceeding to confirm it. 

This PR locks it down so it will return 412 if the booking status is anything other than `Provisional`. 