### PR TITLE
APPT-581: View daily appointments when there are bookings but no availability

### DIFF
--- a/src/client/src/app/lib/components/session-summary-table.tsx
+++ b/src/client/src/app/lib/components/session-summary-table.tsx
@@ -69,7 +69,7 @@ export const getSessionSummaryRows = (
               Change
             </Link>,
           ]
-        : []),
+        : ['']),
     ];
   });
 

--- a/src/client/src/app/lib/types/index.tsx
+++ b/src/client/src/app/lib/types/index.tsx
@@ -273,6 +273,8 @@ type DaySummary = {
   sessions: SessionSummary[];
   maximumCapacity: number;
   bookedAppointments: number;
+  cancelledAppointments: number;
+  orphanedAppointments: number;
   remainingCapacity: number;
 };
 

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
@@ -31,92 +31,189 @@ describe('Day Summary Card', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders availability table if there is availability to show', () => {
-    render(
-      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
-    );
+  describe('when there is availability', () => {
+    it('renders availability table', () => {
+      render(
+        <DaySummaryCard
+          daySummary={mockDaySummaries[0]}
+          siteId={'mock-site'}
+        />,
+      );
 
-    expect(
-      screen.getByRole('row', { name: 'Time Services Booked Unbooked Action' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('row', {
-        name: '09:00 - 17:00 RSV (Adult) 5 booked 118 unbooked',
-      }),
-    ).toBeInTheDocument();
+      expect(
+        screen.getByRole('row', {
+          name: 'Time Services Booked Unbooked Action',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('row', {
+          name: '09:00 - 17:00 RSV (Adult) 5 booked 118 unbooked',
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders add session link if the date is in the future', () => {
+      mockIsInTheFuture.mockReturnValue(true);
+
+      render(
+        <DaySummaryCard
+          daySummary={mockDaySummaries[0]}
+          siteId={'mock-site'}
+        />,
+      );
+
+      expect(
+        screen.getByRole('link', { name: 'Add Session' }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render add session link if the date is in the past', () => {
+      mockIsInTheFuture.mockReturnValue(false);
+
+      render(
+        <DaySummaryCard
+          daySummary={mockDaySummaries[0]}
+          siteId={'mock-site'}
+        />,
+      );
+
+      expect(
+        screen.queryByRole('link', { name: 'Add Session' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders total appointments table', () => {
+      render(
+        <DaySummaryCard
+          daySummary={mockDaySummaries[0]}
+          siteId={'mock-site'}
+        />,
+      );
+
+      expect(
+        screen.getByRole('row', {
+          name: 'Total appointments: 123 Booked: 5 Unbooked: 118',
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('renders view appointments link', () => {
+      render(
+        <DaySummaryCard
+          daySummary={mockDaySummaries[0]}
+          siteId={'mock-site'}
+        />,
+      );
+
+      expect(
+        screen.getByRole('link', {
+          name: 'View daily appointments',
+        }),
+      ).toBeInTheDocument();
+    });
   });
 
-  it('renders no availability message if there is no availability to show', () => {
-    render(
-      <DaySummaryCard daySummary={mockEmptyDays[0]} siteId={'mock-site'} />,
-    );
+  describe('when there is no availability', () => {
+    it('renders no availability message', () => {
+      render(
+        <DaySummaryCard daySummary={mockEmptyDays[0]} siteId={'mock-site'} />,
+      );
 
-    expect(screen.getByText('No availability')).toBeInTheDocument();
+      expect(screen.getByText('No availability')).toBeInTheDocument();
 
-    expect(
-      screen.queryByRole('row', {
-        name: 'Time Services Booked Unbooked Action',
-      }),
-    ).toBeNull();
-  });
+      expect(
+        screen.queryByRole('row', {
+          name: 'Time Services Booked Unbooked Action',
+        }),
+      ).toBeNull();
+    });
 
-  it('renders add session link if the date is in the future', () => {
-    mockIsInTheFuture.mockReturnValue(true);
+    it('does not render total appointments table', () => {
+      render(
+        <DaySummaryCard daySummary={mockEmptyDays[0]} siteId={'mock-site'} />,
+      );
 
-    render(
-      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
-    );
+      expect(
+        screen.queryByRole('row', {
+          name: 'Total appointments: 123 Booked: 5 Unbooked: 118',
+        }),
+      ).toBeNull();
+    });
 
-    expect(
-      screen.getByRole('link', { name: 'Add Session' }),
-    ).toBeInTheDocument();
-  });
+    it('renders add session link if the date is in the future', () => {
+      mockIsInTheFuture.mockReturnValue(true);
 
-  it('does not render add session link if the date is in the past', () => {
-    mockIsInTheFuture.mockReturnValue(false);
+      render(
+        <DaySummaryCard daySummary={mockEmptyDays[0]} siteId={'mock-site'} />,
+      );
 
-    render(
-      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
-    );
+      expect(
+        screen.getByRole('link', { name: 'Add availability to this day' }),
+      ).toBeInTheDocument();
+    });
 
-    expect(
-      screen.queryByRole('link', { name: 'Add Session' }),
-    ).not.toBeInTheDocument();
-  });
+    it('does not render add session link if the date is in the past', () => {
+      mockIsInTheFuture.mockReturnValue(false);
 
-  it('renders total appointments table if there is availability to show', () => {
-    render(
-      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
-    );
+      render(
+        <DaySummaryCard daySummary={mockEmptyDays[0]} siteId={'mock-site'} />,
+      );
 
-    expect(
-      screen.getByRole('row', {
-        name: 'Total appointments: 123 Booked: 5 Unbooked: 118',
-      }),
-    ).toBeInTheDocument();
-  });
+      expect(
+        screen.queryByRole('link', { name: 'Add availability to this day' }),
+      ).not.toBeInTheDocument();
+    });
 
-  it('does not render total appointments table if there is no availability to show', () => {
-    render(
-      <DaySummaryCard daySummary={mockEmptyDays[0]} siteId={'mock-site'} />,
-    );
+    it('renders view cancelled appointments if there are any to show', () => {
+      render(
+        <DaySummaryCard
+          daySummary={{ ...mockEmptyDays[0], cancelledAppointments: 1 }}
+          siteId={'mock-site'}
+        />,
+      );
 
-    expect(
-      screen.queryByRole('row', {
-        name: 'Total appointments: 123 Booked: 5 Unbooked: 118',
-      }),
-    ).toBeNull();
-  });
+      expect(
+        screen.getByRole('link', { name: 'View cancelled appointments' }),
+      ).toBeInTheDocument();
+    });
 
-  it('renders view appointments link', () => {
-    render(
-      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
-    );
+    it('does not render view cancelled appointments if there none any to show', () => {
+      render(
+        <DaySummaryCard
+          daySummary={{ ...mockEmptyDays[0], cancelledAppointments: 0 }}
+          siteId={'mock-site'}
+        />,
+      );
 
-    expect(
-      screen.getByRole('link', {
-        name: 'View daily appointments',
-      }),
-    ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: 'View cancelled appointments' }),
+      ).toBeNull();
+    });
+
+    it('renders view orphaned appointments if there are any to show', () => {
+      render(
+        <DaySummaryCard
+          daySummary={{ ...mockEmptyDays[0], orphanedAppointments: 1 }}
+          siteId={'mock-site'}
+        />,
+      );
+
+      expect(
+        screen.getByRole('link', { name: 'View manual cancellations' }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render view orphaned appointments if there none any to show', () => {
+      render(
+        <DaySummaryCard
+          daySummary={{ ...mockEmptyDays[0], orphanedAppointments: 0 }}
+          siteId={'mock-site'}
+        />,
+      );
+
+      expect(
+        screen.queryByRole('link', { name: 'View manual cancellations' }),
+      ).toBeNull();
+    });
   });
 });

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
@@ -1,0 +1,122 @@
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+import { DaySummaryCard } from './day-summary-card';
+import { mockDaySummaries, mockEmptyDays } from '@testing/data';
+import { isInTheFuture } from '@services/timeService';
+
+jest.mock('@services/timeService', () => {
+  const originalModule = jest.requireActual('@services/timeService');
+  return {
+    ...originalModule,
+    isInTheFuture: jest.fn(),
+  };
+});
+
+const mockIsInTheFuture = isInTheFuture as jest.Mock<boolean>;
+
+describe('Day Summary Card', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockIsInTheFuture.mockReturnValue(true);
+  });
+
+  it('renders', () => {
+    render(
+      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Monday 2 December' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders availability table if there is availability to show', () => {
+    render(
+      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
+    );
+
+    expect(
+      screen.getByRole('row', { name: 'Time Services Booked Unbooked Action' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('row', {
+        name: '09:00 - 17:00 RSV (Adult) 5 booked 118 unbooked',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders no availability message if there is no availability to show', () => {
+    render(
+      <DaySummaryCard daySummary={mockEmptyDays[0]} siteId={'mock-site'} />,
+    );
+
+    expect(screen.getByText('No availability')).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('row', {
+        name: 'Time Services Booked Unbooked Action',
+      }),
+    ).toBeNull();
+  });
+
+  it('renders add session link if the date is in the future', () => {
+    mockIsInTheFuture.mockReturnValue(true);
+
+    render(
+      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Add Session' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render add session link if the date is in the past', () => {
+    mockIsInTheFuture.mockReturnValue(false);
+
+    render(
+      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'Add Session' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders total appointments table if there is availability to show', () => {
+    render(
+      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
+    );
+
+    expect(
+      screen.getByRole('row', {
+        name: 'Total appointments: 123 Booked: 5 Unbooked: 118',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render total appointments table if there is no availability to show', () => {
+    render(
+      <DaySummaryCard daySummary={mockEmptyDays[0]} siteId={'mock-site'} />,
+    );
+
+    expect(
+      screen.queryByRole('row', {
+        name: 'Total appointments: 123 Booked: 5 Unbooked: 118',
+      }),
+    ).toBeNull();
+  });
+
+  it('renders view appointments link', () => {
+    render(
+      <DaySummaryCard daySummary={mockDaySummaries[0]} siteId={'mock-site'} />,
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'View daily appointments',
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
@@ -3,6 +3,7 @@ import { SessionSummaryTable } from '@components/session-summary-table';
 import { isInTheFuture } from '@services/timeService';
 import { DaySummary } from '@types';
 import Link from 'next/link';
+import { ReactNode } from 'react';
 
 type DaySummaryCardProps = {
   daySummary: DaySummary;
@@ -15,15 +16,15 @@ export const DaySummaryCard = ({
     sessions,
     maximumCapacity,
     bookedAppointments,
+    cancelledAppointments,
+    orphanedAppointments,
     remainingCapacity,
   },
   siteId,
 }: DaySummaryCardProps) => {
-  const hasAvailability = sessions.length > 0;
-
-  return (
-    <Card title={date.format('dddd D MMMM')}>
-      {hasAvailability ? (
+  if (sessions.length > 0) {
+    return (
+      <Card title={date.format('dddd D MMMM')}>
         <SessionSummaryTable
           sessionSummaries={sessions}
           showChangeSessionLink={{
@@ -31,19 +32,15 @@ export const DaySummaryCard = ({
             date,
           }}
         />
-      ) : (
-        <div>No availability</div>
-      )}
-      <br />
-      {isInTheFuture(date.format('YYYY-MM-DD')) && (
-        <Link
-          className="nhsuk-link"
-          href={`/site/${siteId}/create-availability/wizard?date=${date.format('YYYY-MM-DD')}`}
-        >
-          Add Session
-        </Link>
-      )}
-      {hasAvailability && (
+        <br />
+        {isInTheFuture(date.format('YYYY-MM-DD')) && (
+          <Link
+            className="nhsuk-link"
+            href={`/site/${siteId}/create-availability/wizard?date=${date.format('YYYY-MM-DD')}`}
+          >
+            Add Session
+          </Link>
+        )}
         <Table
           headers={[
             `Total appointments: ${maximumCapacity}`,
@@ -52,14 +49,63 @@ export const DaySummaryCard = ({
           ]}
           rows={[]}
         />
-      )}
-      <br />
+        <br />
+        <Link
+          className="nhsuk-link"
+          href={`daily-appointments?date=${date.format('YYYY-MM-DD')}&page=1`}
+        >
+          View daily appointments
+        </Link>
+      </Card>
+    );
+  }
+
+  const actionLinks: ReactNode[] = [];
+  if (cancelledAppointments > 0) {
+    actionLinks.push(
       <Link
         className="nhsuk-link"
-        href={`daily-appointments?date=${date.format('YYYY-MM-DD')}&page=1`}
+        href={`daily-appointments?date=${date.format('YYYY-MM-DD')}&page=1&tab=1`}
       >
-        View daily appointments
-      </Link>
+        View cancelled appointments
+      </Link>,
+    );
+  }
+  if (orphanedAppointments > 0) {
+    actionLinks.push(
+      <Link
+        className="nhsuk-link"
+        href={`daily-appointments?date=${date.format('YYYY-MM-DD')}&page=1&tab=2`}
+      >
+        View manual cancellations
+      </Link>,
+    );
+  }
+  if (isInTheFuture(date.format('YYYY-MM-DD'))) {
+    actionLinks.push(
+      <Link
+        className="nhsuk-link"
+        href={`/site/${siteId}/create-availability/wizard?date=${date.format('YYYY-MM-DD')}`}
+      >
+        Add availability to this day
+      </Link>,
+    );
+  }
+
+  return (
+    <Card title={date.format('dddd D MMMM')}>
+      <div>No availability</div>
+      <br />
+      {actionLinks.reduce(
+        (prev, curr, index) => (
+          <>
+            {prev}
+            {index > 0 && ' | '}
+            {curr}
+          </>
+        ),
+        null,
+      )}
     </Card>
   );
 };

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
@@ -1,0 +1,65 @@
+import { Card, Table } from '@components/nhsuk-frontend';
+import { SessionSummaryTable } from '@components/session-summary-table';
+import { isInTheFuture } from '@services/timeService';
+import { DaySummary } from '@types';
+import Link from 'next/link';
+
+type DaySummaryCardProps = {
+  daySummary: DaySummary;
+  siteId: string;
+};
+
+export const DaySummaryCard = ({
+  daySummary: {
+    date,
+    sessions,
+    maximumCapacity,
+    bookedAppointments,
+    remainingCapacity,
+  },
+  siteId,
+}: DaySummaryCardProps) => {
+  const hasAvailability = sessions.length > 0;
+
+  return (
+    <Card title={date.format('dddd D MMMM')}>
+      {hasAvailability ? (
+        <SessionSummaryTable
+          sessionSummaries={sessions}
+          showChangeSessionLink={{
+            siteId,
+            date,
+          }}
+        />
+      ) : (
+        <div>No availability</div>
+      )}
+      <br />
+      {isInTheFuture(date.format('YYYY-MM-DD')) && (
+        <Link
+          className="nhsuk-link"
+          href={`/site/${siteId}/create-availability/wizard?date=${date.format('YYYY-MM-DD')}`}
+        >
+          Add Session
+        </Link>
+      )}
+      {hasAvailability && (
+        <Table
+          headers={[
+            `Total appointments: ${maximumCapacity}`,
+            `Booked: ${bookedAppointments}`,
+            `Unbooked: ${remainingCapacity}`,
+          ]}
+          rows={[]}
+        />
+      )}
+      <br />
+      <Link
+        className="nhsuk-link"
+        href={`daily-appointments?date=${date.format('YYYY-MM-DD')}&page=1`}
+      >
+        View daily appointments
+      </Link>
+    </Card>
+  );
+};

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
@@ -1,9 +1,7 @@
-import { Card, Pagination, Table } from '@components/nhsuk-frontend';
+import { Pagination } from '@components/nhsuk-frontend';
 import { DaySummary } from '@types';
 import dayjs from 'dayjs';
-import Link from 'next/link';
-import { isInTheFuture } from '@services/timeService';
-import { SessionSummaryTable } from '@components/session-summary-table';
+import { DaySummaryCard } from './day-summary-card';
 
 type Props = {
   days: DaySummary[];
@@ -56,57 +54,15 @@ export const ViewWeekAvailabilityPage = ({
   return (
     <>
       <Pagination previous={previous} next={next} />
-      {days.map((d, i) => (
-        <Card title={d.date.format('dddd D MMMM')} key={i}>
-          {d.sessions.length > 0 ? (
-            <>
-              <SessionSummaryTable
-                sessionSummaries={d.sessions}
-                showChangeSessionLink={{
-                  siteId: site,
-                  date: d.date,
-                }}
-              />
-              <br />
-              {isInTheFuture(d.date.format('YYYY-MM-DD')) && (
-                <Link
-                  className="nhsuk-link"
-                  href={`/site/${site}/create-availability/wizard?date=${d.date.format('YYYY-MM-DD')}`}
-                >
-                  Add Session
-                </Link>
-              )}
-              <Table
-                headers={[
-                  `Total appointments: ${d.maximumCapacity}`,
-                  `Booked: ${d.bookedAppointments}`,
-                  `Unbooked: ${d.remainingCapacity}`,
-                ]}
-                rows={[]}
-              />
-              <br />
-              <Link
-                className="nhsuk-link"
-                href={`daily-appointments?date=${d.date.format('YYYY-MM-DD')}&page=1`}
-              >
-                View daily appointments
-              </Link>
-            </>
-          ) : (
-            <>
-              <div style={{ marginBottom: '20px' }}>No availability</div>
-              {isInTheFuture(d.date.format('YYYY-MM-DD')) && (
-                <Link
-                  className="nhsuk-link"
-                  href={`/site/${site}/create-availability/wizard?date=${d.date.format('YYYY-MM-DD')}`}
-                >
-                  Add Session
-                </Link>
-              )}
-            </>
-          )}
-        </Card>
-      ))}
+      {days.map((day, dayIndex) => {
+        return (
+          <DaySummaryCard
+            daySummary={day}
+            siteId={site}
+            key={`day-summary-${dayIndex}`}
+          />
+        );
+      })}
     </>
   );
 };

--- a/src/client/src/app/testing/availability-and-bookings-mock-data.ts
+++ b/src/client/src/app/testing/availability-and-bookings-mock-data.ts
@@ -186,12 +186,48 @@ const mockBooking5: Booking = {
   reminderSet: false,
 };
 
+const mockBooking6: Booking = {
+  reference: 'mock-booking-6',
+  from: '2024-06-11T09:10:00',
+  duration: 10,
+  service: 'RSV:Adult',
+  site: 'TEST01',
+  attendeeDetails: {
+    nhsNumber: '9999999994',
+    firstName: 'Zack',
+    lastName: 'Jeremiah',
+    dateOfBirth: new Date(1973, 2, 3),
+  },
+  created: '2024-08-29T03:21:08.0477062',
+  status: 'Cancelled',
+  reminderSet: false,
+};
+
+const mockBooking7: Booking = {
+  reference: 'mock-booking-7',
+  from: '2024-06-11T09:20:00',
+  duration: 10,
+  service: 'RSV:Adult',
+  site: 'TEST01',
+  attendeeDetails: {
+    nhsNumber: '9999999993',
+    firstName: 'Bertha',
+    lastName: 'Mildrew',
+    dateOfBirth: new Date(1973, 2, 3),
+  },
+  created: '2024-08-29T03:21:08.0477062',
+  status: 'Provisional',
+  reminderSet: false,
+};
+
 const mockBookings: Booking[] = [
   mockBooking1,
   mockBooking2,
   mockBooking3,
   mockBooking4,
   mockBooking5,
+  mockBooking6,
+  mockBooking7,
 ];
 
 /**
@@ -223,6 +259,8 @@ const mockWeekAvailability__Summary: DaySummary[] = [
     ],
     maximumCapacity: 126,
     bookedAppointments: 2,
+    cancelledAppointments: 0,
+    orphanedAppointments: 1,
     remainingCapacity: 124,
   },
   {
@@ -232,8 +270,8 @@ const mockWeekAvailability__Summary: DaySummary[] = [
         start: dayjs('2024-06-11 09:00:00'),
         end: dayjs('2024-06-11 12:00:00'),
         maximumCapacity: 36,
-        totalBookings: 2,
-        bookings: { 'RSV:Adult': 1, 'FLU 18-64': 1 },
+        totalBookings: 3,
+        bookings: { 'RSV:Adult': 2, 'FLU 18-64': 1 },
         capacity: 2,
         slotLength: 10,
       },
@@ -248,8 +286,10 @@ const mockWeekAvailability__Summary: DaySummary[] = [
       },
     ],
     maximumCapacity: 72,
-    bookedAppointments: 2,
-    remainingCapacity: 70,
+    bookedAppointments: 3,
+    cancelledAppointments: 1,
+    orphanedAppointments: 0,
+    remainingCapacity: 69,
   },
   {
     date: dayjs('2024-06-12 00:00:00'),
@@ -266,6 +306,8 @@ const mockWeekAvailability__Summary: DaySummary[] = [
     ],
     maximumCapacity: 96,
     bookedAppointments: 0,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 96,
   },
   {
@@ -292,6 +334,8 @@ const mockWeekAvailability__Summary: DaySummary[] = [
     ],
     maximumCapacity: 114,
     bookedAppointments: 0,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 114,
   },
   {
@@ -309,6 +353,8 @@ const mockWeekAvailability__Summary: DaySummary[] = [
     ],
     maximumCapacity: 72,
     bookedAppointments: 0,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 72,
   },
   {
@@ -316,6 +362,8 @@ const mockWeekAvailability__Summary: DaySummary[] = [
     sessions: [],
     maximumCapacity: 0,
     bookedAppointments: 0,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 0,
   },
   {
@@ -323,6 +371,8 @@ const mockWeekAvailability__Summary: DaySummary[] = [
     sessions: [],
     maximumCapacity: 0,
     bookedAppointments: 0,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 0,
   },
 ];

--- a/src/client/src/app/testing/data.ts
+++ b/src/client/src/app/testing/data.ts
@@ -459,6 +459,8 @@ const mockDaySummaries: DaySummary[] = [
     ],
     maximumCapacity: 123,
     bookedAppointments: 5,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 118,
   },
   {
@@ -478,6 +480,8 @@ const mockDaySummaries: DaySummary[] = [
     ],
     maximumCapacity: 200,
     bookedAppointments: 15,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 185,
   },
   {
@@ -497,6 +501,8 @@ const mockDaySummaries: DaySummary[] = [
     ],
     maximumCapacity: 160,
     bookedAppointments: 20,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 140,
   },
 ];
@@ -507,6 +513,8 @@ const mockEmptyDays: DaySummary[] = [
     sessions: [],
     maximumCapacity: 0,
     bookedAppointments: 0,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 0,
   },
   {
@@ -514,6 +522,8 @@ const mockEmptyDays: DaySummary[] = [
     sessions: [],
     maximumCapacity: 0,
     bookedAppointments: 0,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 0,
   },
   {
@@ -521,6 +531,8 @@ const mockEmptyDays: DaySummary[] = [
     sessions: [],
     maximumCapacity: 0,
     bookedAppointments: 0,
+    cancelledAppointments: 0,
+    orphanedAppointments: 0,
     remainingCapacity: 0,
   },
 ];


### PR DESCRIPTION
The cards on the Weekly Availability page currently only render a link to the Daily Availability page if there is availability on that day. However it's possible to have orphaned and cancelled bookings without availability (if availability is cancelled, for example). Therefore this page needs to still present the link. 

After further discussion with the content and design team, this view has been updated to match the below screenshot. This has required tracking orphaned and cancelled appointments throughout the availability calculations (where previously they were filtered out and the calculation was only ran on booked appointments). 

<img width="806" alt="Screenshot 2025-01-21 155811" src="https://github.com/user-attachments/assets/2578e0e8-5ced-401e-85d1-490f0bf7b1f3" />
