### PR TITLE
Updating permissions on change site details link

### DIFF
--- a/src/client/src/app/lib/components/nhs-page.tsx
+++ b/src/client/src/app/lib/components/nhs-page.tsx
@@ -100,7 +100,10 @@ const getLinksForSite = async (
     });
   }
 
-  if (permissions.includes('site:manage')) {
+  if (
+    permissions.includes('site:manage') ||
+    permissions.includes('site:view')
+  ) {
     navigationLinks.push({
       label: 'Change site details',
       href: `/site/${site.id}/details`,


### PR DESCRIPTION
Users should be able to see the _Change site details link_ if they have the `site:view` permission