### PR TITLE
APPT-589: Add validation to the cancel and edit session decision screens

### DIFF
--- a/src/client/src/app/site/[site]/availability/cancel/confirm-cancellation.test.tsx
+++ b/src/client/src/app/site/[site]/availability/cancel/confirm-cancellation.test.tsx
@@ -1,17 +1,21 @@
 import ConfirmCancellation from './confirm-cancellation';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 import { mockWeekAvailability__Summary } from '@testing/availability-and-bookings-mock-data';
 import render from '@testing/render';
+import { cancelSession } from '@services/appointmentsService';
+
+jest.mock('@services/appointmentsService');
+const mockCancelSession = cancelSession as jest.Mock;
 
 jest.mock('next/navigation');
 const mockUseRouter = useRouter as jest.Mock;
-const mockReplace = jest.fn();
+const mockPush = jest.fn();
 
 describe('Confirm Cancellation Page', () => {
   beforeEach(() => {
     mockUseRouter.mockReturnValue({
-      replace: mockReplace,
+      push: mockPush,
     });
   });
 
@@ -81,5 +85,52 @@ describe('Confirm Cancellation Page', () => {
         name: "No, I don't want to cancel this session",
       }),
     ).toBeChecked();
+  });
+
+  it('displays a validation error if no value is selected', async () => {
+    const session = btoa(
+      JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
+    );
+    const { user } = render(
+      <ConfirmCancellation session={session} date="2025-01-15" site="TEST01" />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(screen.getByText('Select an option')).toBeInTheDocument();
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockCancelSession).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('radio', { name: 'Yes, I want to cancel this session' }),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    waitFor(() => {
+      expect(mockCancelSession).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalled();
+    });
+  });
+
+  it('submits the form and cancels the session', async () => {
+    const session = btoa(
+      JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
+    );
+    const { user } = render(
+      <ConfirmCancellation session={session} date="2025-01-15" site="TEST01" />,
+    );
+
+    await user.click(
+      screen.getByRole('radio', { name: 'Yes, I want to cancel this session' }),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    waitFor(() => {
+      expect(mockCancelSession).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalled();
+    });
   });
 });

--- a/src/client/src/app/site/[site]/availability/cancel/confirm-cancellation.tsx
+++ b/src/client/src/app/site/[site]/availability/cancel/confirm-cancellation.tsx
@@ -20,7 +20,7 @@ type PageProps = {
 };
 
 type CancelSessionDecisionFormData = {
-  action: 'cancel-session' | 'dont-cancel-session';
+  action?: 'cancel-session' | 'dont-cancel-session';
 };
 
 const ConfirmCancellation = ({ date, session, site }: PageProps) => {
@@ -48,19 +48,26 @@ const ConfirmCancellation = ({ date, session, site }: PageProps) => {
         <p>You'll need to manually cancel any affected appointments.</p>
       </InsetText>
 
-      <FormGroup legend="Would you like to cancel this session?">
+      <FormGroup
+        legend="Would you like to cancel this session?"
+        error={methods.formState.errors.action?.message}
+      >
         <RadioGroup>
           <Radio
             label="Yes, I want to cancel this session"
             id="cancel-session"
             value="cancel-session"
-            {...methods.register('action')}
+            {...methods.register('action', {
+              required: { value: true, message: 'Select an option' },
+            })}
           />
           <Radio
             label="No, I don't want to cancel this session"
             id="dont-cancel-session"
             value="dont-cancel-session"
-            {...methods.register('action')}
+            {...methods.register('action', {
+              required: { value: true, message: 'Select an option' },
+            })}
           />
         </RadioGroup>
       </FormGroup>

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.test.tsx
@@ -127,7 +127,7 @@ describe('Edit Session Decision Page', () => {
     });
   });
 
-  it('submits the form and cancels the session', async () => {
+  it('submits the form', async () => {
     const session = btoa(
       JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
     );

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.test.tsx
@@ -1,18 +1,18 @@
 import { mockWeekAvailability__Summary } from '@testing/availability-and-bookings-mock-data';
 import render from '@testing/render';
 import { EditSessionDecision } from './edit-session-decision';
-import { screen } from '@testing-library/dom';
+import { screen, waitFor } from '@testing-library/dom';
 import { mockSite } from '@testing/data';
 import { useRouter } from 'next/navigation';
 
 jest.mock('next/navigation');
 const mockUseRouter = useRouter as jest.Mock;
-const mockReplace = jest.fn();
+const mockPush = jest.fn();
 
 describe('Edit Session Decision Page', () => {
   beforeEach(() => {
     mockUseRouter.mockReturnValue({
-      replace: mockReplace,
+      push: mockPush,
     });
   });
 
@@ -94,5 +94,61 @@ describe('Edit Session Decision Page', () => {
     expect(
       screen.getByRole('radio', { name: 'Cancel this session' }),
     ).toBeChecked();
+  });
+
+  it('displays a validation error if no value is selected', async () => {
+    const session = btoa(
+      JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
+    );
+    const { user } = render(
+      <EditSessionDecision
+        sessionSummary={session}
+        date="2025-01-15"
+        site={mockSite}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(screen.getByText('Select an option')).toBeInTheDocument();
+
+    expect(mockPush).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole('radio', {
+        name: 'Cancel this session',
+      }),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    waitFor(() => {
+      expect(mockPush).toHaveBeenCalled();
+    });
+  });
+
+  it('submits the form and cancels the session', async () => {
+    const session = btoa(
+      JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
+    );
+    const { user } = render(
+      <EditSessionDecision
+        sessionSummary={session}
+        date="2025-01-15"
+        site={mockSite}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('radio', {
+        name: 'Change the length or capacity of this session',
+      }),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    waitFor(() => {
+      expect(mockPush).toHaveBeenCalled();
+    });
   });
 });

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.tsx
@@ -19,7 +19,7 @@ type EditSessionDecisionProps = {
 };
 
 type EditSessionDecisionFormData = {
-  action: 'edit-session' | 'cancel-session';
+  action?: 'edit-session' | 'cancel-session';
 };
 
 export const EditSessionDecision = ({
@@ -56,21 +56,28 @@ export const EditSessionDecision = ({
         </p>
       </InsetText>
       <form onSubmit={methods.handleSubmit(submitForm)}>
-        <FormGroup legend="What do you want to do?">
+        <FormGroup
+          legend="What do you want to do?"
+          error={methods.formState.errors.action?.message}
+        >
           <RadioGroup>
             <Radio
               label="Change the length or capacity of this session"
               hint="Shorten the session length or remove capacity"
               id="edit-session"
               value="edit-session"
-              {...methods.register('action')}
+              {...methods.register('action', {
+                required: { value: true, message: 'Select an option' },
+              })}
             />
             <Radio
               label="Cancel this session"
               hint="Cancel all booked appointments, and remove this session"
               id="cancel-session"
               value="cancel-session"
-              {...methods.register('action')}
+              {...methods.register('action', {
+                required: { value: true, message: 'Select an option' },
+              })}
             />
           </RadioGroup>
         </FormGroup>


### PR DESCRIPTION
Ste and I forgot to add validation to this radio buttons for the Edit/Cancel Session routes

<img width="523" alt="image" src="https://github.com/user-attachments/assets/ab66fea7-1123-4616-a258-97271eda98e0" />
