### PR TITLE
APPT-489: Wrap expensive components behind suspense boundaries

### DIFF
--- a/src/client/src/app/eula/accept-eula-form.tsx
+++ b/src/client/src/app/eula/accept-eula-form.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { Button, SmallSpinnerWithText } from '@components/nhsuk-frontend';
+import { acceptEula } from '@services/appointmentsService';
+import { EulaVersion } from '@types';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+
+type AcceptEulaFormProps = {
+  eulaVersion: EulaVersion;
+};
+
+export const AcceptEulaForm = ({ eulaVersion }: AcceptEulaFormProps) => {
+  const { push } = useRouter();
+
+  const {
+    handleSubmit,
+    formState: { isSubmitting, isSubmitSuccessful },
+  } = useForm();
+
+  const submitForm: SubmitHandler<Record<string, undefined>> = async () => {
+    await acceptEula(eulaVersion.versionDate);
+    push('/');
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submitForm)}>
+      {isSubmitting || isSubmitSuccessful ? (
+        <SmallSpinnerWithText text="Working..." />
+      ) : (
+        <Button aria-label="Accept and continue" type="submit">
+          Accept and continue
+        </Button>
+      )}
+    </form>
+  );
+};

--- a/src/client/src/app/eula/eula-page.test.tsx
+++ b/src/client/src/app/eula/eula-page.test.tsx
@@ -3,14 +3,22 @@ import { EulaVersion } from '@types';
 import render from '@testing/render';
 import EulaPage from './page';
 import { fetchEula, acceptEula } from '@services/appointmentsService';
+import { useRouter } from 'next/navigation';
 
 jest.mock('@services/appointmentsService');
 const fetchEulaMock = fetchEula as jest.Mock<Promise<EulaVersion>>;
 const acceptEulaMock = acceptEula as jest.Mock;
 
+jest.mock('next/navigation');
+const mockUseRouter = useRouter as jest.Mock;
+const mockPush = jest.fn();
+
 describe('EULA page', () => {
   beforeEach(() => {
     fetchEulaMock.mockResolvedValue({ versionDate: '2021-01-01' });
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+    });
   });
 
   it('renders', async () => {

--- a/src/client/src/app/eula/page.tsx
+++ b/src/client/src/app/eula/page.tsx
@@ -1,7 +1,7 @@
 import NhsAnonymousPage from '@components/nhs-anonymous-page';
-import { Button } from '@components/nhsuk-frontend';
-import { acceptEula, fetchEula } from '@services/appointmentsService';
+import { fetchEula } from '@services/appointmentsService';
 import Link from 'next/link';
+import { AcceptEulaForm } from './accept-eula-form';
 
 const Page = async () => {
   const latestVersion = await fetchEula();
@@ -29,11 +29,7 @@ const Page = async () => {
         of use for this service.
       </p>
 
-      <form action={acceptEula.bind(null, latestVersion.versionDate)}>
-        <Button aria-label="Accept and continue" type="submit">
-          Accept and continue
-        </Button>
-      </form>
+      <AcceptEulaForm eulaVersion={latestVersion} />
     </NhsAnonymousPage>
   );
 };

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -162,7 +162,6 @@ export async function acceptEula(versionDate: string) {
 
   handleEmptyResponse(response);
   revalidatePath(`eula`);
-  redirect(`/`);
 }
 
 export async function assertPermission(site: string, permission: string) {

--- a/src/client/src/app/lib/services/viewAvailabilityService.test.ts
+++ b/src/client/src/app/lib/services/viewAvailabilityService.test.ts
@@ -1,19 +1,24 @@
-import { Booking } from '@types';
-import { fetchBookings } from './appointmentsService';
+import { AvailabilityResponse, Booking } from '@types';
+import { fetchBookings, fetchAvailability } from './appointmentsService';
 import {
   getDetailedMonthView,
   getWeeksInMonth,
 } from './viewAvailabilityService';
-import { mockAvailability, mockBookings } from '@testing/data';
+import { mockAvailability, mockBookings, mockSite } from '@testing/data';
+import dayjs from 'dayjs';
 
 jest.mock('@services/appointmentsService');
 const fetchBookedAppointmentsMock = fetchBookings as jest.Mock<
   Promise<Booking[]>
 >;
+const fetchAvailabilityMock = fetchAvailability as jest.Mock<
+  Promise<AvailabilityResponse[]>
+>;
 
 describe('View Availability Service', () => {
   beforeEach(() => {
     fetchBookedAppointmentsMock.mockResolvedValue(mockBookings);
+    fetchAvailabilityMock.mockResolvedValue(mockAvailability);
   });
 
   it.each([
@@ -41,11 +46,9 @@ describe('View Availability Service', () => {
   );
 
   it('can build a detailed month view for availability', async () => {
-    const weeks = getWeeksInMonth(2024, 10);
     const detailedWeeks = await getDetailedMonthView(
-      mockAvailability,
-      weeks,
-      'TEST01',
+      mockSite,
+      dayjs('2024-11-10T00:00:00'),
     );
 
     expect(detailedWeeks.length).toBe(5);

--- a/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.tsx
+++ b/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.tsx
@@ -4,7 +4,7 @@ import {
   FormGroup,
   Radio,
   RadioGroup,
-  Spinner,
+  SmallSpinnerWithText,
   SummaryList,
   SummaryListItem,
 } from '@components/nhsuk-frontend';
@@ -28,7 +28,6 @@ const CancelAppointmentPage = ({
   const { replace } = useRouter();
   const {
     register,
-    reset,
     handleSubmit,
     formState: { isSubmitting, isSubmitSuccessful },
   } = useForm<CancelFormValue>({
@@ -37,8 +36,6 @@ const CancelAppointmentPage = ({
     },
   });
   const summaryItems = mapSummaryData(booking);
-
-  const cancelOperation = { ...register('cancelAppointment') };
 
   const submitForm: SubmitHandler<CancelFormValue> = async (
     form: CancelFormValue,
@@ -57,42 +54,26 @@ const CancelAppointmentPage = ({
   return (
     <>
       {summaryItems && <SummaryList {...summaryItems} />}
-      <form onSubmit={handleSubmit(submitForm)} noValidate={true}>
+      <form onSubmit={handleSubmit(submitForm)}>
         <FormGroup>
           <RadioGroup>
             <Radio
               label="Yes, I want to cancel this appointment"
-              {...{
-                ...cancelOperation,
-                onChange: e => {
-                  reset({
-                    cancelAppointment: 'yes',
-                  });
-                  cancelOperation.onChange(e);
-                },
-              }}
               id="cancelOperation-yes"
               value="yes"
+              {...register('cancelAppointment')}
             />
             <Radio
               label="No, I do not want to cancel this appointment"
-              {...{
-                ...cancelOperation,
-                onChange: e => {
-                  reset({
-                    cancelAppointment: 'no',
-                  });
-                  cancelOperation.onChange(e);
-                },
-              }}
               id="cancelOperation-no"
               value="no"
+              {...register('cancelAppointment')}
             />
           </RadioGroup>
         </FormGroup>
 
         {isSubmitting || isSubmitSuccessful ? (
-          <Spinner />
+          <SmallSpinnerWithText text="Working..." />
         ) : (
           <Button type="submit">Continue</Button>
         )}

--- a/src/client/src/app/site/[site]/availability/cancel/confirm-cancellation.tsx
+++ b/src/client/src/app/site/[site]/availability/cancel/confirm-cancellation.tsx
@@ -1,11 +1,11 @@
 'use client';
 import {
   Button,
-  ButtonGroup,
   FormGroup,
   InsetText,
   Radio,
   RadioGroup,
+  SmallSpinnerWithText,
 } from '@components/nhsuk-frontend';
 import { SessionSummaryTable } from '@components/session-summary-table';
 import { cancelSession } from '@services/appointmentsService';
@@ -24,7 +24,11 @@ type CancelSessionDecisionFormData = {
 };
 
 const ConfirmCancellation = ({ date, session, site }: PageProps) => {
-  const methods = useForm<CancelSessionDecisionFormData>({});
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting, isSubmitSuccessful, errors },
+  } = useForm<CancelSessionDecisionFormData>({});
   const sessionSummary: SessionSummary = JSON.parse(atob(session));
   const router = useRouter();
   const submitForm: SubmitHandler<CancelSessionDecisionFormData> = async (
@@ -41,7 +45,7 @@ const ConfirmCancellation = ({ date, session, site }: PageProps) => {
   };
 
   return (
-    <form onSubmit={methods.handleSubmit(submitForm)}>
+    <form onSubmit={handleSubmit(submitForm)}>
       <SessionSummaryTable sessionSummaries={[sessionSummary]} />
 
       <InsetText>
@@ -50,14 +54,14 @@ const ConfirmCancellation = ({ date, session, site }: PageProps) => {
 
       <FormGroup
         legend="Would you like to cancel this session?"
-        error={methods.formState.errors.action?.message}
+        error={errors.action?.message}
       >
         <RadioGroup>
           <Radio
             label="Yes, I want to cancel this session"
             id="cancel-session"
             value="cancel-session"
-            {...methods.register('action', {
+            {...register('action', {
               required: { value: true, message: 'Select an option' },
             })}
           />
@@ -65,15 +69,17 @@ const ConfirmCancellation = ({ date, session, site }: PageProps) => {
             label="No, I don't want to cancel this session"
             id="dont-cancel-session"
             value="dont-cancel-session"
-            {...methods.register('action', {
+            {...register('action', {
               required: { value: true, message: 'Select an option' },
             })}
           />
         </RadioGroup>
       </FormGroup>
-      <ButtonGroup>
+      {isSubmitting || isSubmitSuccessful ? (
+        <SmallSpinnerWithText text="Working..." />
+      ) : (
         <Button type="submit">Continue</Button>
-      </ButtonGroup>
+      )}
     </form>
   );
 };

--- a/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import { Site, SessionSummary, Session, AvailabilitySession } from '@types';
 import { useRouter } from 'next/navigation';
 import { editSession } from '@services/appointmentsService';
@@ -7,6 +7,7 @@ import {
   Button,
   FormGroup,
   InsetText,
+  SmallSpinnerWithText,
   TextInput,
 } from '@components/nhsuk-frontend';
 import { Controller } from 'react-hook-form';
@@ -38,7 +39,12 @@ const EditSessionTimeAndCapacityForm = ({
   existingSessionStart,
   existingSessionEnd,
 }: Props) => {
-  const methods = useForm<EditSessionFormValues>({
+  const {
+    handleSubmit,
+    watch,
+    control,
+    formState: { isSubmitting, isSubmitSuccessful, errors },
+  } = useForm<EditSessionFormValues>({
     defaultValues: {
       sessionToEdit: {
         startTime: toTimeComponents(existingSessionStart),
@@ -62,10 +68,8 @@ const EditSessionTimeAndCapacityForm = ({
       },
     },
   });
-  const { control, formState } = methods;
-  const { errors } = formState;
 
-  const sessionToEditWatch = methods.watch('sessionToEdit');
+  const sessionToEditWatch = watch('sessionToEdit');
   const router = useRouter();
 
   const submitForm: SubmitHandler<EditSessionFormValues> = async (
@@ -140,259 +144,254 @@ const EditSessionTimeAndCapacityForm = ({
   };
 
   return (
-    <FormProvider {...methods}>
-      <form onSubmit={methods.handleSubmit(submitForm)}>
-        <InsetText>
-          <p>
-            {existingSession.totalBookings} booked appointments in this session.
-            <br />
-            {existingSession.maximumCapacity -
-              existingSession.totalBookings}{' '}
-            unbooked appointments in this session.
-          </p>
-        </InsetText>
-        <FormGroup
-          legend="Session times"
-          hint="For example, 14:30"
-          error={
-            errors.newSession?.startTime?.message ||
-            errors.newSession?.endTime?.message
-          }
-        >
-          <Controller
-            name={'newSession.startTime'}
-            control={control}
-            rules={{
-              validate: value => {
-                if (formatTimeString(value) === undefined) {
-                  return 'Enter a valid start time';
-                }
+    <form onSubmit={handleSubmit(submitForm)}>
+      <InsetText>
+        <p>
+          {existingSession.totalBookings} booked appointments in this session.
+          <br />
+          {existingSession.maximumCapacity - existingSession.totalBookings}{' '}
+          unbooked appointments in this session.
+        </p>
+      </InsetText>
+      <FormGroup
+        legend="Session times"
+        hint="For example, 14:30"
+        error={
+          errors.newSession?.startTime?.message ||
+          errors.newSession?.endTime?.message
+        }
+      >
+        <Controller
+          name={'newSession.startTime'}
+          control={control}
+          rules={{
+            validate: value => {
+              if (formatTimeString(value) === undefined) {
+                return 'Enter a valid start time';
+              }
 
-                if (
-                  compareTimes(value, sessionToEditWatch.startTime) == 'earlier'
-                ) {
-                  return 'Enter a start or end time that reduces the length of this session.';
-                }
-              },
-            }}
-            render={() => (
-              <>
-                <div className="nhsuk-label">Start time</div>
-                <div className="nhsuk-time-input-custom">
-                  <Controller
-                    control={control}
-                    name="newSession.startTime.hour"
-                    render={({ field }) => (
-                      <div className="nhsuk-time-input-custom__item">
-                        <label
-                          id="start-time-accessibility-label-hour"
-                          htmlFor="start-time-hour"
-                        >
-                          Session start time - hour
-                        </label>
-                        <input
-                          aria-labelledby="start-time-accessibility-label-hour"
-                          id="start-time-hour"
-                          className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
-                          onChange={e =>
-                            field.onChange(
-                              handleTwoDigitPositiveBoundedNumberInput(e, 23),
-                            )
-                          }
-                          value={field.value ?? ''}
-                        ></input>
-                      </div>
-                    )}
-                  />
-
-                  <div className="nhsuk-time-input-custom__item">
-                    <div
-                      style={{ display: 'inline-block', fontSize: 'x-large' }}
-                    >
-                      :
+              if (
+                compareTimes(value, sessionToEditWatch.startTime) == 'earlier'
+              ) {
+                return 'Enter a start or end time that reduces the length of this session.';
+              }
+            },
+          }}
+          render={() => (
+            <>
+              <div className="nhsuk-label">Start time</div>
+              <div className="nhsuk-time-input-custom">
+                <Controller
+                  control={control}
+                  name="newSession.startTime.hour"
+                  render={({ field }) => (
+                    <div className="nhsuk-time-input-custom__item">
+                      <label
+                        id="start-time-accessibility-label-hour"
+                        htmlFor="start-time-hour"
+                      >
+                        Session start time - hour
+                      </label>
+                      <input
+                        aria-labelledby="start-time-accessibility-label-hour"
+                        id="start-time-hour"
+                        className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
+                        onChange={e =>
+                          field.onChange(
+                            handleTwoDigitPositiveBoundedNumberInput(e, 23),
+                          )
+                        }
+                        value={field.value ?? ''}
+                      ></input>
                     </div>
-                  </div>
-
-                  <Controller
-                    control={control}
-                    name="newSession.startTime.minute"
-                    render={({ field }) => (
-                      <div className="nhsuk-time-input-custom__item">
-                        <label
-                          id="start-time-accessibility-label-minute"
-                          htmlFor="start-time-minute"
-                        >
-                          Session start time - minute
-                        </label>
-                        <input
-                          aria-labelledby="start-time-accessibility-label-minute"
-                          className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
-                          id="start-time-minute"
-                          onChange={e =>
-                            field.onChange(
-                              handleTwoDigitPositiveBoundedNumberInput(e, 59),
-                            )
-                          }
-                          value={field.value ?? ''}
-                        ></input>
-                      </div>
-                    )}
-                  />
-                </div>
-              </>
-            )}
-          />
-          <Controller
-            name={'newSession.endTime'}
-            control={control}
-            rules={{
-              validate: (value, form) => {
-                const endTime = formatTimeString(value);
-                const startTime = formatTimeString(form.newSession.startTime);
-                if (endTime === undefined || startTime === undefined) {
-                  return 'Enter a valid end time';
-                }
-
-                const minutesBetweenStartAndEnd = sessionLengthInMinutes(
-                  form.newSession.startTime,
-                  value,
-                );
-
-                if (minutesBetweenStartAndEnd < 0) {
-                  return 'Session end time must be after the start time';
-                }
-
-                if (minutesBetweenStartAndEnd <= 5) {
-                  return 'Session length must be more than 5 minutes';
-                }
-
-                if (
-                  compareTimes(value, sessionToEditWatch.endTime) == 'later'
-                ) {
-                  return 'Enter a start or end time that reduces the length of this session.';
-                }
-              },
-            }}
-            render={() => (
-              <>
-                <div className="nhsuk-label">End time</div>
-                <div className="nhsuk-time-input-custom">
-                  <Controller
-                    control={control}
-                    name="newSession.endTime.hour"
-                    render={({ field }) => (
-                      <div className="nhsuk-time-input-custom__item">
-                        <label
-                          id="end-time-accessibility-label-hour"
-                          htmlFor="end-time-hour"
-                        >
-                          Session end time - hour
-                        </label>
-                        <input
-                          aria-labelledby="end-time-accessibility-label-hour"
-                          className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
-                          id="end-time-hour"
-                          onChange={e =>
-                            field.onChange(
-                              handleTwoDigitPositiveBoundedNumberInput(e, 23),
-                            )
-                          }
-                          value={field.value ?? ''}
-                        ></input>
-                      </div>
-                    )}
-                  />
-
-                  <div className="nhsuk-time-input-custom__item">
-                    <div
-                      style={{ display: 'inline-block', fontSize: 'x-large' }}
-                    >
-                      :
-                    </div>
-                  </div>
-
-                  <Controller
-                    control={control}
-                    name="newSession.endTime.minute"
-                    render={({ field }) => (
-                      <div className="nhsuk-time-input-custom__item">
-                        <label
-                          id="end-time-accessibility-label-minute"
-                          htmlFor="end-time-minute"
-                        >
-                          Session end time - minute
-                        </label>
-                        <input
-                          aria-labelledby="end-time-accessibility-label-minute"
-                          className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
-                          id="end-time-minute"
-                          onChange={e =>
-                            field.onChange(
-                              handleTwoDigitPositiveBoundedNumberInput(e, 59),
-                            )
-                          }
-                          value={field.value ?? ''}
-                        ></input>
-                      </div>
-                    )}
-                  />
-                </div>
-              </>
-            )}
-          />
-        </FormGroup>
-        <br />
-        <FormGroup legend="Capacity">
-          <Controller
-            control={control}
-            name="newSession.capacity"
-            rules={{
-              required: { value: true, message: 'Capacity is required' },
-              min: { value: 1, message: 'Capacity must be at least 1' },
-              validate: value => {
-                const candidate = Number(value);
-                if (!Number.isInteger(candidate)) {
-                  return 'Capacity must be a whole number';
-                }
-                if (candidate > 99) {
-                  return 'Capacity must be less than 100';
-                }
-                if (candidate > existingSession.capacity) {
-                  return 'Enter a number that reduces the vaccinators or vaccinator spaces in this session.';
-                }
-              },
-            }}
-            render={({ field }) => (
-              <FormGroup
-                legend="How many vaccinators or vaccination spaces do you have?"
-                error={errors.newSession?.capacity?.message}
-              >
-                <label
-                  id="capacity"
-                  htmlFor="capacity"
-                  style={{ display: 'none' }}
-                >
-                  How many vaccinators or vaccination spaces do you have?
-                </label>
-                <TextInput
-                  id="capacity"
-                  aria-labelledby="capacity"
-                  inputMode="numeric"
-                  type="number"
-                  width={2}
-                  onChange={e =>
-                    field.onChange(handlePositiveBoundedNumberInput(e, 99))
-                  }
-                  value={field.value ?? ''}
+                  )}
                 />
-              </FormGroup>
-            )}
-          />
-        </FormGroup>
 
+                <div className="nhsuk-time-input-custom__item">
+                  <div style={{ display: 'inline-block', fontSize: 'x-large' }}>
+                    :
+                  </div>
+                </div>
+
+                <Controller
+                  control={control}
+                  name="newSession.startTime.minute"
+                  render={({ field }) => (
+                    <div className="nhsuk-time-input-custom__item">
+                      <label
+                        id="start-time-accessibility-label-minute"
+                        htmlFor="start-time-minute"
+                      >
+                        Session start time - minute
+                      </label>
+                      <input
+                        aria-labelledby="start-time-accessibility-label-minute"
+                        className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
+                        id="start-time-minute"
+                        onChange={e =>
+                          field.onChange(
+                            handleTwoDigitPositiveBoundedNumberInput(e, 59),
+                          )
+                        }
+                        value={field.value ?? ''}
+                      ></input>
+                    </div>
+                  )}
+                />
+              </div>
+            </>
+          )}
+        />
+        <Controller
+          name={'newSession.endTime'}
+          control={control}
+          rules={{
+            validate: (value, form) => {
+              const endTime = formatTimeString(value);
+              const startTime = formatTimeString(form.newSession.startTime);
+              if (endTime === undefined || startTime === undefined) {
+                return 'Enter a valid end time';
+              }
+
+              const minutesBetweenStartAndEnd = sessionLengthInMinutes(
+                form.newSession.startTime,
+                value,
+              );
+
+              if (minutesBetweenStartAndEnd < 0) {
+                return 'Session end time must be after the start time';
+              }
+
+              if (minutesBetweenStartAndEnd <= 5) {
+                return 'Session length must be more than 5 minutes';
+              }
+
+              if (compareTimes(value, sessionToEditWatch.endTime) == 'later') {
+                return 'Enter a start or end time that reduces the length of this session.';
+              }
+            },
+          }}
+          render={() => (
+            <>
+              <div className="nhsuk-label">End time</div>
+              <div className="nhsuk-time-input-custom">
+                <Controller
+                  control={control}
+                  name="newSession.endTime.hour"
+                  render={({ field }) => (
+                    <div className="nhsuk-time-input-custom__item">
+                      <label
+                        id="end-time-accessibility-label-hour"
+                        htmlFor="end-time-hour"
+                      >
+                        Session end time - hour
+                      </label>
+                      <input
+                        aria-labelledby="end-time-accessibility-label-hour"
+                        className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
+                        id="end-time-hour"
+                        onChange={e =>
+                          field.onChange(
+                            handleTwoDigitPositiveBoundedNumberInput(e, 23),
+                          )
+                        }
+                        value={field.value ?? ''}
+                      ></input>
+                    </div>
+                  )}
+                />
+
+                <div className="nhsuk-time-input-custom__item">
+                  <div style={{ display: 'inline-block', fontSize: 'x-large' }}>
+                    :
+                  </div>
+                </div>
+
+                <Controller
+                  control={control}
+                  name="newSession.endTime.minute"
+                  render={({ field }) => (
+                    <div className="nhsuk-time-input-custom__item">
+                      <label
+                        id="end-time-accessibility-label-minute"
+                        htmlFor="end-time-minute"
+                      >
+                        Session end time - minute
+                      </label>
+                      <input
+                        aria-labelledby="end-time-accessibility-label-minute"
+                        className="nhsuk-input nhsuk-time-input-custom__input nhsuk-input--width-2"
+                        id="end-time-minute"
+                        onChange={e =>
+                          field.onChange(
+                            handleTwoDigitPositiveBoundedNumberInput(e, 59),
+                          )
+                        }
+                        value={field.value ?? ''}
+                      ></input>
+                    </div>
+                  )}
+                />
+              </div>
+            </>
+          )}
+        />
+      </FormGroup>
+      <br />
+      <FormGroup legend="Capacity">
+        <Controller
+          control={control}
+          name="newSession.capacity"
+          rules={{
+            required: { value: true, message: 'Capacity is required' },
+            min: { value: 1, message: 'Capacity must be at least 1' },
+            validate: value => {
+              const candidate = Number(value);
+              if (!Number.isInteger(candidate)) {
+                return 'Capacity must be a whole number';
+              }
+              if (candidate > 99) {
+                return 'Capacity must be less than 100';
+              }
+              if (candidate > existingSession.capacity) {
+                return 'Enter a number that reduces the vaccinators or vaccinator spaces in this session.';
+              }
+            },
+          }}
+          render={({ field }) => (
+            <FormGroup
+              legend="How many vaccinators or vaccination spaces do you have?"
+              error={errors.newSession?.capacity?.message}
+            >
+              <label
+                id="capacity"
+                htmlFor="capacity"
+                style={{ display: 'none' }}
+              >
+                How many vaccinators or vaccination spaces do you have?
+              </label>
+              <TextInput
+                id="capacity"
+                aria-labelledby="capacity"
+                inputMode="numeric"
+                type="number"
+                width={2}
+                onChange={e =>
+                  field.onChange(handlePositiveBoundedNumberInput(e, 99))
+                }
+                value={field.value ?? ''}
+              />
+            </FormGroup>
+          )}
+        />
+      </FormGroup>
+
+      {isSubmitting || isSubmitSuccessful ? (
+        <SmallSpinnerWithText text="Working..." />
+      ) : (
         <Button type="submit">Continue</Button>
-      </form>
-    </FormProvider>
+      )}
+    </form>
   );
 };
 

--- a/src/client/src/app/site/[site]/create-availability/availabilityCreatedEventsTable.test.tsx
+++ b/src/client/src/app/site/[site]/create-availability/availabilityCreatedEventsTable.test.tsx
@@ -1,0 +1,74 @@
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+import { mockAvailabilityCreatedEvents, mockSite } from '@testing/data';
+import { fetchAvailabilityCreatedEvents } from '@services/appointmentsService';
+import { AvailabilityCreatedEvent } from '@types';
+import { AvailabilityCreatedEventsTable } from './availabilityCreatedEventsTable';
+
+jest.mock('@services/appointmentsService');
+const fetchAvailabilityCreatedEventsMock =
+  fetchAvailabilityCreatedEvents as jest.Mock<
+    Promise<AvailabilityCreatedEvent[]>
+  >;
+
+describe('Availability Created Events Table', () => {
+  beforeEach(() => {
+    fetchAvailabilityCreatedEventsMock.mockResolvedValue(
+      mockAvailabilityCreatedEvents,
+    );
+  });
+
+  it('renders', async () => {
+    const jsx = await AvailabilityCreatedEventsTable({
+      siteId: mockSite.id,
+    });
+
+    render(jsx);
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('renders a table of availability periods', async () => {
+    const jsx = await AvailabilityCreatedEventsTable({
+      siteId: mockSite.id,
+    });
+
+    render(jsx);
+
+    expect(fetchAvailabilityCreatedEventsMock).toHaveBeenCalledWith(
+      mockSite.id,
+    );
+    expect(screen.getByRole('table')).toBeInTheDocument();
+
+    const columns = ['Dates', 'Days', 'Services', 'Session type'];
+    columns.forEach(column => {
+      screen.getByRole('columnheader', { name: column });
+    });
+
+    expect(screen.getAllByRole('row')).toHaveLength(5);
+
+    expect(
+      screen.getByRole('row', {
+        name: '1 Jan 2024 - 28 Feb 2024 Mon, Tue RSV (Adult) Weekly repeating',
+      }),
+    );
+
+    expect(
+      screen.getByRole('row', {
+        name: '1 Jan 2025 Wed RSV (Adult) Single date',
+      }),
+    );
+
+    expect(
+      screen.getByRole('row', {
+        name: '1 Mar 2024 - 30 Apr 2024 All RSV (Adult) Weekly repeating',
+      }),
+    );
+
+    expect(
+      screen.getByRole('row', {
+        name: '16 Feb 2025 Sun RSV (Adult) Single date',
+      }),
+    );
+  });
+});

--- a/src/client/src/app/site/[site]/create-availability/availabilityCreatedEventsTable.tsx
+++ b/src/client/src/app/site/[site]/create-availability/availabilityCreatedEventsTable.tsx
@@ -1,17 +1,17 @@
 import { Table } from '@components/nhsuk-frontend';
 import { parseDateString } from '@services/timeService';
-import { AvailabilityCreatedEvent, clinicalServices, Site } from '@types';
-import { use } from 'react';
+import { AvailabilityCreatedEvent, clinicalServices } from '@types';
+import { fetchAvailabilityCreatedEvents } from '@services/appointmentsService';
 
 type AvailabilityCreatedEventsTableProps = {
-  site: Site;
-  getAvailabilityCreatedEvents: Promise<AvailabilityCreatedEvent[]>;
+  siteId: string;
 };
 
-export const AvailabilityCreatedEventsTable = ({
-  getAvailabilityCreatedEvents,
+export const AvailabilityCreatedEventsTable = async ({
+  siteId,
 }: AvailabilityCreatedEventsTableProps) => {
-  const availabilityCreatedEvents = use(getAvailabilityCreatedEvents);
+  const availabilityCreatedEvents =
+    await fetchAvailabilityCreatedEvents(siteId);
   if (availabilityCreatedEvents.length === 0) {
     return null;
   }

--- a/src/client/src/app/site/[site]/create-availability/availabilityCreatedEventsTable.tsx
+++ b/src/client/src/app/site/[site]/create-availability/availabilityCreatedEventsTable.tsx
@@ -25,7 +25,7 @@ const mapTableData = (availabilityCreated: AvailabilityCreatedEvent[]) => {
   const rows = availabilityCreated.map(availability => {
     if (availability.template) {
       return [
-        `${parseDateString(availability.from).format('D MMM YYYY')} - ${parseDateString(availability.to ?? '').format('D MMM YYYY')}`, //.format('D MMMM YYYY')
+        `${parseDateString(availability.from).format('D MMM YYYY')} - ${parseDateString(availability.to ?? '').format('D MMM YYYY')}`,
         availability.template.days.length === 7
           ? 'All'
           : availability.template.days.map(d => d.substring(0, 3)).join(', '),

--- a/src/client/src/app/site/[site]/create-availability/availabilityCreatedEventsTable.tsx
+++ b/src/client/src/app/site/[site]/create-availability/availabilityCreatedEventsTable.tsx
@@ -1,0 +1,54 @@
+import { Table } from '@components/nhsuk-frontend';
+import { parseDateString } from '@services/timeService';
+import { AvailabilityCreatedEvent, clinicalServices, Site } from '@types';
+import { use } from 'react';
+
+type AvailabilityCreatedEventsTableProps = {
+  site: Site;
+  getAvailabilityCreatedEvents: Promise<AvailabilityCreatedEvent[]>;
+};
+
+export const AvailabilityCreatedEventsTable = ({
+  getAvailabilityCreatedEvents,
+}: AvailabilityCreatedEventsTableProps) => {
+  const availabilityCreatedEvents = use(getAvailabilityCreatedEvents);
+  if (availabilityCreatedEvents.length === 0) {
+    return null;
+  }
+
+  return <Table {...mapTableData(availabilityCreatedEvents)} />;
+};
+
+const mapTableData = (availabilityCreated: AvailabilityCreatedEvent[]) => {
+  const headers = ['Dates', 'Days', 'Services', 'Session type'];
+
+  const rows = availabilityCreated.map(availability => {
+    if (availability.template) {
+      return [
+        `${parseDateString(availability.from).format('D MMM YYYY')} - ${parseDateString(availability.to ?? '').format('D MMM YYYY')}`, //.format('D MMMM YYYY')
+        availability.template.days.length === 7
+          ? 'All'
+          : availability.template.days.map(d => d.substring(0, 3)).join(', '),
+        availability.template.sessions[0].services
+          .map(serviceValueToLabel)
+          .join(', '),
+        'Weekly repeating',
+      ];
+    }
+    return [
+      parseDateString(availability.from).format('D MMM YYYY'),
+      parseDateString(availability.from).format('ddd'),
+      availability.sessions
+        ? availability.sessions[0].services.map(serviceValueToLabel)
+        : 'Error',
+      'Single date',
+    ];
+  });
+
+  return { headers, rows };
+};
+
+const serviceValueToLabel = (serviceValue: string) => {
+  const service = clinicalServices.find(s => s.value === serviceValue);
+  return service?.label;
+};

--- a/src/client/src/app/site/[site]/create-availability/create-availability-page.test.tsx
+++ b/src/client/src/app/site/[site]/create-availability/create-availability-page.test.tsx
@@ -1,28 +1,20 @@
 import render from '@testing/render';
 import { screen } from '@testing-library/react';
 import { CreateAvailabilityPage } from './create-availability-page';
-import { mockAvailabilityCreatedEvents, mockSite } from '@testing/data';
-import { fetchAvailabilityCreatedEvents } from '@services/appointmentsService';
-import { AvailabilityCreatedEvent } from '@types';
+import { mockSite } from '@testing/data';
 
-jest.mock('@services/appointmentsService');
-const fetchAvailabilityCreatedEventsMock =
-  fetchAvailabilityCreatedEvents as jest.Mock<
-    Promise<AvailabilityCreatedEvent[]>
-  >;
+jest.mock('./availabilityCreatedEventsTable', () => {
+  const MockAvailabilityCreatedEventsTable = () => {
+    return <div>This is a mock table</div>;
+  };
+  return {
+    AvailabilityCreatedEventsTable: MockAvailabilityCreatedEventsTable,
+  };
+});
 
 describe('Create Availability Page', () => {
-  beforeEach(() => {
-    fetchAvailabilityCreatedEventsMock.mockResolvedValue(
-      mockAvailabilityCreatedEvents,
-    );
-  });
-  it('renders', async () => {
-    const jsx = await CreateAvailabilityPage({
-      site: mockSite,
-    });
-
-    render(jsx);
+  it('renders', () => {
+    render(<CreateAvailabilityPage site={mockSite} />);
 
     expect(
       screen.getByText(
@@ -31,56 +23,8 @@ describe('Create Availability Page', () => {
     ).toBeInTheDocument;
   });
 
-  it('renders a table of availability periods', async () => {
-    const jsx = await CreateAvailabilityPage({
-      site: mockSite,
-    });
-
-    render(jsx);
-
-    expect(fetchAvailabilityCreatedEventsMock).toHaveBeenCalledWith(
-      mockSite.id,
-    );
-    expect(screen.getByRole('table')).toBeInTheDocument();
-
-    const columns = ['Dates', 'Days', 'Services', 'Session type'];
-    columns.forEach(column => {
-      screen.getByRole('columnheader', { name: column });
-    });
-
-    expect(screen.getAllByRole('row')).toHaveLength(5);
-
-    expect(
-      screen.getByRole('row', {
-        name: '1 Jan 2024 - 28 Feb 2024 Mon, Tue RSV (Adult) Weekly repeating',
-      }),
-    );
-
-    expect(
-      screen.getByRole('row', {
-        name: '1 Jan 2025 Wed RSV (Adult) Single date',
-      }),
-    );
-
-    expect(
-      screen.getByRole('row', {
-        name: '1 Mar 2024 - 30 Apr 2024 All RSV (Adult) Weekly repeating',
-      }),
-    );
-
-    expect(
-      screen.getByRole('row', {
-        name: '16 Feb 2025 Sun RSV (Adult) Single date',
-      }),
-    );
-  });
-
-  it('renders a button to create more availability periods', async () => {
-    const jsx = await CreateAvailabilityPage({
-      site: mockSite,
-    });
-
-    render(jsx);
+  it('renders a button to create more availability periods', () => {
+    render(<CreateAvailabilityPage site={mockSite} />);
 
     expect(
       screen.getByRole('button', { name: 'Create availability' }),

--- a/src/client/src/app/site/[site]/create-availability/create-availability-page.tsx
+++ b/src/client/src/app/site/[site]/create-availability/create-availability-page.tsx
@@ -1,18 +1,15 @@
-import { Button, Table } from '@nhsuk-frontend-components';
+import { Button, Spinner } from '@nhsuk-frontend-components';
 import Link from 'next/link';
-import { AvailabilityCreatedEvent, Site, clinicalServices } from '@types';
+import { Site } from '@types';
+import { Suspense } from 'react';
+import { AvailabilityCreatedEventsTable } from './availabilityCreatedEventsTable';
 import { fetchAvailabilityCreatedEvents } from '@services/appointmentsService';
-import { parseDateString } from '@services/timeService';
 
 type Props = {
   site: Site;
 };
 
 export const CreateAvailabilityPage = async ({ site }: Props) => {
-  const response = await fetchAvailabilityCreatedEvents(site.id);
-
-  const tableData = mapTableData(response);
-
   return (
     <>
       <p>
@@ -20,49 +17,17 @@ export const CreateAvailabilityPage = async ({ site }: Props) => {
         to accurately reflect your site's capacity.
       </p>
       <br />
-      {tableData && <Table {...tableData}></Table>}
+      <Suspense fallback={<Spinner />}>
+        <AvailabilityCreatedEventsTable
+          site={site}
+          getAvailabilityCreatedEvents={fetchAvailabilityCreatedEvents(site.id)}
+        />
+      </Suspense>
+
       <br />
       <Link href={`/site/${site.id}/create-availability/wizard`}>
         <Button type="button">Create availability</Button>
       </Link>
     </>
   );
-};
-
-const mapTableData = (availabilityCreated: AvailabilityCreatedEvent[]) => {
-  if (!availabilityCreated.length) {
-    return undefined;
-  }
-
-  const headers = ['Dates', 'Days', 'Services', 'Session type'];
-
-  const rows = availabilityCreated.map(availability => {
-    if (availability.template) {
-      return [
-        `${parseDateString(availability.from).format('D MMM YYYY')} - ${parseDateString(availability.to ?? '').format('D MMM YYYY')}`, //.format('D MMMM YYYY')
-        availability.template.days.length === 7
-          ? 'All'
-          : availability.template.days.map(d => d.substring(0, 3)).join(', '),
-        availability.template.sessions[0].services
-          .map(serviceValueToLabel)
-          .join(', '),
-        'Weekly repeating',
-      ];
-    }
-    return [
-      parseDateString(availability.from).format('D MMM YYYY'),
-      parseDateString(availability.from).format('ddd'),
-      availability.sessions
-        ? availability.sessions[0].services.map(serviceValueToLabel)
-        : 'Error',
-      'Single date',
-    ];
-  });
-
-  return { headers, rows };
-};
-
-const serviceValueToLabel = (serviceValue: string) => {
-  const service = clinicalServices.find(s => s.value === serviceValue);
-  return service?.label;
 };

--- a/src/client/src/app/site/[site]/create-availability/create-availability-page.tsx
+++ b/src/client/src/app/site/[site]/create-availability/create-availability-page.tsx
@@ -1,15 +1,14 @@
 import { Button, Spinner } from '@nhsuk-frontend-components';
 import Link from 'next/link';
-import { Site } from '@types';
 import { Suspense } from 'react';
 import { AvailabilityCreatedEventsTable } from './availabilityCreatedEventsTable';
-import { fetchAvailabilityCreatedEvents } from '@services/appointmentsService';
+import { Site } from '@types';
 
 type Props = {
   site: Site;
 };
 
-export const CreateAvailabilityPage = async ({ site }: Props) => {
+export const CreateAvailabilityPage = ({ site }: Props) => {
   return (
     <>
       <p>
@@ -18,10 +17,7 @@ export const CreateAvailabilityPage = async ({ site }: Props) => {
       </p>
       <br />
       <Suspense fallback={<Spinner />}>
-        <AvailabilityCreatedEventsTable
-          site={site}
-          getAvailabilityCreatedEvents={fetchAvailabilityCreatedEvents(site.id)}
-        />
+        <AvailabilityCreatedEventsTable siteId={site.id} />
       </Suspense>
 
       <br />

--- a/src/client/src/app/site/[site]/users/remove/remove-user-page.tsx
+++ b/src/client/src/app/site/[site]/users/remove/remove-user-page.tsx
@@ -4,13 +4,19 @@ import React from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import { removeUserFromSite } from '@services/appointmentsService';
-import { Button, ButtonGroup } from '@nhsuk-frontend-components';
+import {
+  Button,
+  ButtonGroup,
+  SmallSpinnerWithText,
+} from '@nhsuk-frontend-components';
 import { Site } from '@types';
 
 const RemoveUserPage = ({ site, user }: { site: Site; user: string }) => {
   const { replace } = useRouter();
-  const { handleSubmit } = useForm();
-
+  const {
+    handleSubmit,
+    formState: { isSubmitting, isSubmitSuccessful },
+  } = useForm();
   const cancel = () => {
     replace(`/site/${site.id}/users`);
   };
@@ -34,14 +40,18 @@ const RemoveUserPage = ({ site, user }: { site: Site; user: string }) => {
         <li>This will not remove their access from any other sites</li>
       </ul>
 
-      <ButtonGroup>
-        <Button type="submit" styleType="warning">
-          Remove this account
-        </Button>
-        <Button styleType="secondary" onClick={cancel}>
-          Cancel
-        </Button>
-      </ButtonGroup>
+      {isSubmitting || isSubmitSuccessful ? (
+        <SmallSpinnerWithText text="Working..." />
+      ) : (
+        <ButtonGroup>
+          <Button type="submit" styleType="warning">
+            Remove this account
+          </Button>
+          <Button styleType="secondary" onClick={cancel}>
+            Cancel
+          </Button>
+        </ButtonGroup>
+      )}
     </form>
   );
 };

--- a/src/client/src/app/site/[site]/view-availability/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/page.tsx
@@ -2,8 +2,6 @@ import NhsPage from '@components/nhs-page';
 import { assertPermission, fetchSite } from '@services/appointmentsService';
 import dayjs from 'dayjs';
 import { ViewAvailabilityPage } from './view-availability-page';
-import { Suspense } from 'react';
-import { Spinner } from '@components/nhsuk-frontend';
 
 type PageProps = {
   params: {
@@ -28,9 +26,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
       site={site}
       originPage="view-availability"
     >
-      <Suspense fallback={<Spinner />}>
-        <ViewAvailabilityPage site={site} searchMonth={searchMonth} />
-      </Suspense>
+      <ViewAvailabilityPage site={site} searchMonth={searchMonth} />
     </NhsPage>
   );
 };

--- a/src/client/src/app/site/[site]/view-availability/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/page.tsx
@@ -1,16 +1,10 @@
 import NhsPage from '@components/nhs-page';
-import {
-  assertPermission,
-  fetchAvailability,
-  fetchSite,
-} from '@services/appointmentsService';
+import { assertPermission, fetchSite } from '@services/appointmentsService';
 import dayjs from 'dayjs';
 import { ViewAvailabilityPage } from './view-availability-page';
-import { FetchAvailabilityRequest } from '@types';
-import {
-  getDetailedMonthView,
-  getWeeksInMonth,
-} from '@services/viewAvailabilityService';
+import { getDetailedMonthView } from '@services/viewAvailabilityService';
+import { Suspense } from 'react';
+import { Spinner } from '@components/nhsuk-frontend';
 
 type PageProps = {
   params: {
@@ -28,37 +22,19 @@ const Page = async ({ params, searchParams }: PageProps) => {
     ? dayjs(searchParams?.date, 'YYYY-MM-DD')
     : dayjs();
 
-  const title = `View availability for ${searchMonth.format('MMMM YYYY')}`;
-
-  const weeks = getWeeksInMonth(searchMonth.year(), searchMonth.month());
-
-  const startDate = weeks[0].startDate.format('YYYY-MM-DD');
-  const endDate = weeks[weeks.length - 1].endDate.format('YYYY-MM-DD');
-  const payload: FetchAvailabilityRequest = {
-    sites: [site.id],
-    service: '*',
-    from: startDate,
-    until: endDate,
-    queryType: 'Days',
-  };
-  const availability = await fetchAvailability(payload);
-  const detailedMonthView = await getDetailedMonthView(
-    availability,
-    weeks,
-    site.id,
-  );
-
   return (
     <NhsPage
-      title={title}
+      title={`View availability for ${searchMonth.format('MMMM YYYY')}`}
       caption={site.name}
       site={site}
       originPage="view-availability"
     >
-      <ViewAvailabilityPage
-        weeks={detailedMonthView}
-        searchMonth={searchMonth}
-      />
+      <Suspense fallback={<Spinner />}>
+        <ViewAvailabilityPage
+          getWeeks={getDetailedMonthView(site, searchMonth)}
+          searchMonth={searchMonth}
+        />
+      </Suspense>
     </NhsPage>
   );
 };

--- a/src/client/src/app/site/[site]/view-availability/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/page.tsx
@@ -2,7 +2,6 @@ import NhsPage from '@components/nhs-page';
 import { assertPermission, fetchSite } from '@services/appointmentsService';
 import dayjs from 'dayjs';
 import { ViewAvailabilityPage } from './view-availability-page';
-import { getDetailedMonthView } from '@services/viewAvailabilityService';
 import { Suspense } from 'react';
 import { Spinner } from '@components/nhsuk-frontend';
 
@@ -30,10 +29,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
       originPage="view-availability"
     >
       <Suspense fallback={<Spinner />}>
-        <ViewAvailabilityPage
-          getWeeks={getDetailedMonthView(site, searchMonth)}
-          searchMonth={searchMonth}
-        />
+        <ViewAvailabilityPage site={site} searchMonth={searchMonth} />
       </Suspense>
     </NhsPage>
   );

--- a/src/client/src/app/site/[site]/view-availability/view-availability-page.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/view-availability-page.test.tsx
@@ -1,16 +1,31 @@
 import { render, screen } from '@testing-library/react';
 import { ViewAvailabilityPage } from './view-availability-page';
-import { mockDetailedWeeks } from '@testing/data';
+import { mockDetailedWeeks, mockSite } from '@testing/data';
 import dayjs from 'dayjs';
+import { getDetailedMonthView } from '@services/viewAvailabilityService';
+import { Week } from '@types';
+
+jest.mock('@services/viewAvailabilityService', () => ({
+  getDetailedMonthView: jest.fn(),
+}));
+
+const mockGetDetailedMonthView = getDetailedMonthView as jest.Mock<
+  Promise<Week[]>
+>;
 
 describe('View Availability Page', () => {
-  it('renders', async () => {
-    render(
-      <ViewAvailabilityPage
-        getWeeks={Promise.resolve(mockDetailedWeeks)}
-        searchMonth={dayjs().year(2024).month(11)}
-      />,
+  beforeEach(() => {
+    mockGetDetailedMonthView.mockReturnValue(
+      Promise.resolve(mockDetailedWeeks),
     );
+  });
+
+  it('renders', async () => {
+    const jsx = await ViewAvailabilityPage({
+      site: mockSite,
+      searchMonth: dayjs().year(2024).month(11),
+    });
+    render(jsx);
 
     expect(
       screen.getByRole('heading', { name: '1 December to 7 December' }),
@@ -18,13 +33,12 @@ describe('View Availability Page', () => {
     expect(screen.getAllByRole('table')).toHaveLength(6);
   });
 
-  it('renders the correct information for a week', () => {
-    render(
-      <ViewAvailabilityPage
-        getWeeks={Promise.resolve(mockDetailedWeeks)}
-        searchMonth={dayjs().year(2024).month(11)}
-      />,
-    );
+  it('renders the correct information for a week', async () => {
+    const jsx = await ViewAvailabilityPage({
+      site: mockSite,
+      searchMonth: dayjs().year(2024).month(11),
+    });
+    render(jsx);
 
     expect(
       screen.getByRole('row', {
@@ -45,24 +59,22 @@ describe('View Availability Page', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders a link for each week', () => {
-    render(
-      <ViewAvailabilityPage
-        getWeeks={Promise.resolve(mockDetailedWeeks)}
-        searchMonth={dayjs().year(2024).month(11)}
-      />,
-    );
+  it('renders a link for each week', async () => {
+    const jsx = await ViewAvailabilityPage({
+      site: mockSite,
+      searchMonth: dayjs().year(2024).month(11),
+    });
+    render(jsx);
 
     expect(screen.getAllByText('View week')).toHaveLength(3);
   });
 
-  it('renders pagination options with the correct values', () => {
-    render(
-      <ViewAvailabilityPage
-        getWeeks={Promise.resolve(mockDetailedWeeks)}
-        searchMonth={dayjs().year(2024).month(11)}
-      />,
-    );
+  it('renders pagination options with the correct values', async () => {
+    const jsx = await ViewAvailabilityPage({
+      site: mockSite,
+      searchMonth: dayjs().year(2024).month(11),
+    });
+    render(jsx);
 
     expect(
       screen.getByRole('link', { name: 'Previous : November 2024' }),

--- a/src/client/src/app/site/[site]/view-availability/view-availability-page.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/view-availability-page.test.tsx
@@ -1,80 +1,34 @@
 import { render, screen } from '@testing-library/react';
 import { ViewAvailabilityPage } from './view-availability-page';
-import { mockDetailedWeeks, mockSite } from '@testing/data';
+import { mockSite } from '@testing/data';
 import dayjs from 'dayjs';
-import { getDetailedMonthView } from '@services/viewAvailabilityService';
-import { Week } from '@types';
 
-jest.mock('@services/viewAvailabilityService', () => ({
-  getDetailedMonthView: jest.fn(),
-}));
-
-const mockGetDetailedMonthView = getDetailedMonthView as jest.Mock<
-  Promise<Week[]>
->;
+jest.mock('./week-card-list', () => {
+  const MockWeekCardList = () => {
+    return <div>This is a list of week cards</div>;
+  };
+  return {
+    WeekCardList: MockWeekCardList,
+  };
+});
 
 describe('View Availability Page', () => {
-  beforeEach(() => {
-    mockGetDetailedMonthView.mockReturnValue(
-      Promise.resolve(mockDetailedWeeks),
+  it('renders', async () => {
+    render(
+      <ViewAvailabilityPage
+        site={mockSite}
+        searchMonth={dayjs().year(2024).month(11)}
+      />,
     );
   });
 
-  it('renders', async () => {
-    const jsx = await ViewAvailabilityPage({
-      site: mockSite,
-      searchMonth: dayjs().year(2024).month(11),
-    });
-    render(jsx);
-
-    expect(
-      screen.getByRole('heading', { name: '1 December to 7 December' }),
-    ).toBeInTheDocument();
-    expect(screen.getAllByRole('table')).toHaveLength(6);
-  });
-
-  it('renders the correct information for a week', async () => {
-    const jsx = await ViewAvailabilityPage({
-      site: mockSite,
-      searchMonth: dayjs().year(2024).month(11),
-    });
-    render(jsx);
-
-    expect(
-      screen.getByRole('row', {
-        name: 'Total appointments: 30 Booked: 17 Unbooked: 13',
-      }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('row', { name: 'FLU 18-64 5' }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('row', { name: 'COVID 75+ 10' }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('row', { name: 'RSV (Adult) 2' }),
-    ).toBeInTheDocument();
-  });
-
-  it('renders a link for each week', async () => {
-    const jsx = await ViewAvailabilityPage({
-      site: mockSite,
-      searchMonth: dayjs().year(2024).month(11),
-    });
-    render(jsx);
-
-    expect(screen.getAllByText('View week')).toHaveLength(3);
-  });
-
   it('renders pagination options with the correct values', async () => {
-    const jsx = await ViewAvailabilityPage({
-      site: mockSite,
-      searchMonth: dayjs().year(2024).month(11),
-    });
-    render(jsx);
+    render(
+      <ViewAvailabilityPage
+        site={mockSite}
+        searchMonth={dayjs().year(2024).month(11)}
+      />,
+    );
 
     expect(
       screen.getByRole('link', { name: 'Previous : November 2024' }),

--- a/src/client/src/app/site/[site]/view-availability/view-availability-page.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/view-availability-page.test.tsx
@@ -7,7 +7,7 @@ describe('View Availability Page', () => {
   it('renders', async () => {
     render(
       <ViewAvailabilityPage
-        weeks={mockDetailedWeeks}
+        getWeeks={Promise.resolve(mockDetailedWeeks)}
         searchMonth={dayjs().year(2024).month(11)}
       />,
     );
@@ -21,7 +21,7 @@ describe('View Availability Page', () => {
   it('renders the correct information for a week', () => {
     render(
       <ViewAvailabilityPage
-        weeks={mockDetailedWeeks}
+        getWeeks={Promise.resolve(mockDetailedWeeks)}
         searchMonth={dayjs().year(2024).month(11)}
       />,
     );
@@ -48,7 +48,7 @@ describe('View Availability Page', () => {
   it('renders a link for each week', () => {
     render(
       <ViewAvailabilityPage
-        weeks={mockDetailedWeeks}
+        getWeeks={Promise.resolve(mockDetailedWeeks)}
         searchMonth={dayjs().year(2024).month(11)}
       />,
     );
@@ -59,7 +59,7 @@ describe('View Availability Page', () => {
   it('renders pagination options with the correct values', () => {
     render(
       <ViewAvailabilityPage
-        weeks={mockDetailedWeeks}
+        getWeeks={Promise.resolve(mockDetailedWeeks)}
         searchMonth={dayjs().year(2024).month(11)}
       />,
     );

--- a/src/client/src/app/site/[site]/view-availability/view-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/view-availability-page.tsx
@@ -2,13 +2,15 @@ import { Card, Pagination, Table } from '@components/nhsuk-frontend';
 import { Week } from '@types';
 import dayjs from 'dayjs';
 import Link from 'next/link';
+import { use } from 'react';
 
 type Props = {
-  weeks: Week[];
+  getWeeks: Promise<Week[]>;
   searchMonth: dayjs.Dayjs;
 };
 
-export const ViewAvailabilityPage = ({ weeks, searchMonth }: Props) => {
+export const ViewAvailabilityPage = ({ getWeeks, searchMonth }: Props) => {
+  const weeks = use(getWeeks);
   const nextMonth = searchMonth.startOf('month').add(1, 'month');
   const previousMonth = searchMonth.startOf('month').subtract(1, 'month');
 

--- a/src/client/src/app/site/[site]/view-availability/view-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/view-availability-page.tsx
@@ -1,16 +1,16 @@
 import { Card, Pagination, Table } from '@components/nhsuk-frontend';
-import { Week } from '@types';
+import { getDetailedMonthView } from '@services/viewAvailabilityService';
+import { Site } from '@types';
 import dayjs from 'dayjs';
 import Link from 'next/link';
-import { use } from 'react';
 
 type Props = {
-  getWeeks: Promise<Week[]>;
+  site: Site;
   searchMonth: dayjs.Dayjs;
 };
 
-export const ViewAvailabilityPage = ({ getWeeks, searchMonth }: Props) => {
-  const weeks = use(getWeeks);
+export const ViewAvailabilityPage = async ({ site, searchMonth }: Props) => {
+  const weeks = await getDetailedMonthView(site, searchMonth);
   const nextMonth = searchMonth.startOf('month').add(1, 'month');
   const previousMonth = searchMonth.startOf('month').subtract(1, 'month');
 

--- a/src/client/src/app/site/[site]/view-availability/view-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/view-availability-page.tsx
@@ -1,16 +1,15 @@
-import { Card, Pagination, Table } from '@components/nhsuk-frontend';
-import { getDetailedMonthView } from '@services/viewAvailabilityService';
+import { Pagination, Spinner } from '@components/nhsuk-frontend';
 import { Site } from '@types';
 import dayjs from 'dayjs';
-import Link from 'next/link';
+import { WeekCardList } from './week-card-list';
+import { Suspense } from 'react';
 
 type Props = {
   site: Site;
   searchMonth: dayjs.Dayjs;
 };
 
-export const ViewAvailabilityPage = async ({ site, searchMonth }: Props) => {
-  const weeks = await getDetailedMonthView(site, searchMonth);
+export const ViewAvailabilityPage = ({ site, searchMonth }: Props) => {
   const nextMonth = searchMonth.startOf('month').add(1, 'month');
   const previousMonth = searchMonth.startOf('month').subtract(1, 'month');
 
@@ -25,35 +24,13 @@ export const ViewAvailabilityPage = async ({ site, searchMonth }: Props) => {
 
   return (
     <>
-      <Pagination previous={previous} next={next} />
-      {weeks.map((week, i) => (
-        <Card
-          title={`${week.startDate.format('D MMMM')} to ${week.endDate.format('D MMMM')}`}
-          key={i}
-        >
-          <Table
-            headers={['Services', 'Booked appointments']}
-            rows={week.bookedAppointments.map(appts => {
-              return [appts.service, appts.count];
-            })}
-          ></Table>
-          <Table
-            headers={[
-              `Total appointments: ${week.totalAppointments}`,
-              `Booked: ${week.booked}`,
-              `Unbooked: ${week.unbooked}`,
-            ]}
-            rows={[]}
-          ></Table>
-          <br />
-          <Link
-            className="nhsuk-link"
-            href={`view-availability/week?date=${week.startDate.format('YYYY-MM-DD')}`}
-          >
-            View week
-          </Link>
-        </Card>
-      ))}
+      <Pagination previous={previous} next={next} />{' '}
+      <Suspense
+        key={searchMonth.format('YYYY-MM-DDTHH:mm:ssZZ')}
+        fallback={<Spinner />}
+      >
+        <WeekCardList site={site} searchMonth={searchMonth} />
+      </Suspense>
     </>
   );
 };

--- a/src/client/src/app/site/[site]/view-availability/week-card-list.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week-card-list.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { mockDetailedWeeks, mockSite } from '@testing/data';
+import dayjs from 'dayjs';
+import { getDetailedMonthView } from '@services/viewAvailabilityService';
+import { Week } from '@types';
+import { WeekCardList } from './week-card-list';
+
+jest.mock('@services/viewAvailabilityService', () => ({
+  getDetailedMonthView: jest.fn(),
+}));
+
+const mockGetDetailedMonthView = getDetailedMonthView as jest.Mock<
+  Promise<Week[]>
+>;
+
+describe('Week Card List', () => {
+  beforeEach(() => {
+    mockGetDetailedMonthView.mockReturnValue(
+      Promise.resolve(mockDetailedWeeks),
+    );
+  });
+
+  it('renders', async () => {
+    const jsx = await WeekCardList({
+      site: mockSite,
+      searchMonth: dayjs().year(2024).month(11),
+    });
+    render(jsx);
+
+    expect(
+      screen.getByRole('heading', { name: '1 December to 7 December' }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('table')).toHaveLength(6);
+  });
+
+  it('renders the correct information for a week', async () => {
+    const jsx = await WeekCardList({
+      site: mockSite,
+      searchMonth: dayjs().year(2024).month(11),
+    });
+    render(jsx);
+
+    expect(
+      screen.getByRole('row', {
+        name: 'Total appointments: 30 Booked: 17 Unbooked: 13',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('row', { name: 'FLU 18-64 5' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('row', { name: 'COVID 75+ 10' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('row', { name: 'RSV (Adult) 2' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a link for each week', async () => {
+    const jsx = await WeekCardList({
+      site: mockSite,
+      searchMonth: dayjs().year(2024).month(11),
+    });
+    render(jsx);
+
+    expect(screen.getAllByText('View week')).toHaveLength(3);
+  });
+});

--- a/src/client/src/app/site/[site]/view-availability/week-card-list.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week-card-list.tsx
@@ -1,0 +1,47 @@
+import { Card, Table } from '@components/nhsuk-frontend';
+import { getDetailedMonthView } from '@services/viewAvailabilityService';
+import { Site } from '@types';
+import dayjs from 'dayjs';
+import Link from 'next/link';
+
+type Props = {
+  site: Site;
+  searchMonth: dayjs.Dayjs;
+};
+
+export const WeekCardList = async ({ site, searchMonth }: Props) => {
+  const weeks = await getDetailedMonthView(site, searchMonth);
+
+  return (
+    <>
+      {weeks.map((week, i) => (
+        <Card
+          title={`${week.startDate.format('D MMMM')} to ${week.endDate.format('D MMMM')}`}
+          key={i}
+        >
+          <Table
+            headers={['Services', 'Booked appointments']}
+            rows={week.bookedAppointments.map(appts => {
+              return [appts.service, appts.count];
+            })}
+          ></Table>
+          <Table
+            headers={[
+              `Total appointments: ${week.totalAppointments}`,
+              `Booked: ${week.booked}`,
+              `Unbooked: ${week.unbooked}`,
+            ]}
+            rows={[]}
+          ></Table>
+          <br />
+          <Link
+            className="nhsuk-link"
+            href={`view-availability/week?date=${week.startDate.format('YYYY-MM-DD')}`}
+          >
+            View week
+          </Link>
+        </Card>
+      ))}
+    </>
+  );
+};

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.tsx
@@ -6,6 +6,7 @@ import {
   InsetText,
   Radio,
   RadioGroup,
+  SmallSpinnerWithText,
 } from '@components/nhsuk-frontend';
 import { SessionSummaryTable } from '@components/session-summary-table';
 import { SessionSummary, Site } from '@types';
@@ -28,7 +29,11 @@ export const EditSessionDecision = ({
   date,
 }: EditSessionDecisionProps) => {
   const router = useRouter();
-  const methods = useForm<EditSessionDecisionFormData>({});
+  const {
+    handleSubmit,
+    register,
+    formState: { isSubmitting, isSubmitSuccessful, errors },
+  } = useForm<EditSessionDecisionFormData>({});
 
   const submitForm: SubmitHandler<EditSessionDecisionFormData> = async (
     form: EditSessionDecisionFormData,
@@ -55,10 +60,10 @@ export const EditSessionDecision = ({
           to increase availability for this day, you must create a new session.
         </p>
       </InsetText>
-      <form onSubmit={methods.handleSubmit(submitForm)}>
+      <form onSubmit={handleSubmit(submitForm)}>
         <FormGroup
           legend="What do you want to do?"
-          error={methods.formState.errors.action?.message}
+          error={errors.action?.message}
         >
           <RadioGroup>
             <Radio
@@ -66,7 +71,7 @@ export const EditSessionDecision = ({
               hint="Shorten the session length or remove capacity"
               id="edit-session"
               value="edit-session"
-              {...methods.register('action', {
+              {...register('action', {
                 required: { value: true, message: 'Select an option' },
               })}
             />
@@ -75,15 +80,19 @@ export const EditSessionDecision = ({
               hint="Cancel all booked appointments, and remove this session"
               id="cancel-session"
               value="cancel-session"
-              {...methods.register('action', {
+              {...register('action', {
                 required: { value: true, message: 'Select an option' },
               })}
             />
           </RadioGroup>
         </FormGroup>
-        <ButtonGroup>
-          <Button type="submit">Continue</Button>
-        </ButtonGroup>
+        {isSubmitting || isSubmitSuccessful ? (
+          <SmallSpinnerWithText text="Working..." />
+        ) : (
+          <ButtonGroup>
+            <Button type="submit">Continue</Button>
+          </ButtonGroup>
+        )}
       </form>
     </>
   );

--- a/src/client/src/app/site/[site]/view-availability/week/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/page.tsx
@@ -4,6 +4,8 @@ import { ViewWeekAvailabilityPage } from './view-week-availability-page';
 import { endOfWeek, startOfWeek } from '@services/timeService';
 import { NavigationByHrefProps } from '@components/nhsuk-frontend/back-link';
 import { summariseWeek } from '@services/availabilityCalculatorService';
+import { Suspense } from 'react';
+import { Spinner } from '@components/nhsuk-frontend';
 
 type PageProps = {
   searchParams: {
@@ -21,8 +23,6 @@ const Page = async ({ searchParams, params }: PageProps) => {
   const weekStart = startOfWeek(searchParams.date);
   const weekEnd = endOfWeek(searchParams.date);
 
-  const days = await summariseWeek(weekStart, weekEnd, site.id);
-
   const backLink: NavigationByHrefProps = {
     renderingStrategy: 'server',
     href: `/site/${params.site}/view-availability?date=${searchParams.date}`,
@@ -36,12 +36,14 @@ const Page = async ({ searchParams, params }: PageProps) => {
       backLink={backLink}
       originPage="view-availability-week"
     >
-      <ViewWeekAvailabilityPage
-        days={days}
-        weekStart={weekStart}
-        weekEnd={weekEnd}
-        site={params.site}
-      />
+      <Suspense fallback={<Spinner />}>
+        <ViewWeekAvailabilityPage
+          days={summariseWeek(weekStart, weekEnd, site.id)}
+          weekStart={weekStart}
+          weekEnd={weekEnd}
+          site={params.site}
+        />
+      </Suspense>
     </NhsPage>
   );
 };

--- a/src/client/src/app/site/[site]/view-availability/week/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/page.tsx
@@ -3,7 +3,6 @@ import { assertPermission, fetchSite } from '@services/appointmentsService';
 import { ViewWeekAvailabilityPage } from './view-week-availability-page';
 import { endOfWeek, startOfWeek } from '@services/timeService';
 import { NavigationByHrefProps } from '@components/nhsuk-frontend/back-link';
-import { summariseWeek } from '@services/availabilityCalculatorService';
 import { Suspense } from 'react';
 import { Spinner } from '@components/nhsuk-frontend';
 
@@ -38,10 +37,9 @@ const Page = async ({ searchParams, params }: PageProps) => {
     >
       <Suspense fallback={<Spinner />}>
         <ViewWeekAvailabilityPage
-          days={summariseWeek(weekStart, weekEnd, site.id)}
           weekStart={weekStart}
           weekEnd={weekEnd}
-          site={params.site}
+          site={site}
         />
       </Suspense>
     </NhsPage>

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.test.tsx
@@ -35,7 +35,7 @@ describe('View Week Availability Page', () => {
   it('renders', () => {
     render(
       <ViewWeekAvailabilityPage
-        days={mockDaySummaries}
+        days={Promise.resolve(mockDaySummaries)}
         weekStart={mockWeekAvailabilityStart}
         weekEnd={mockWeekAvailabilityEnd}
         site={'mock-site'}
@@ -51,7 +51,7 @@ describe('View Week Availability Page', () => {
   it('renders no availability', () => {
     render(
       <ViewWeekAvailabilityPage
-        days={mockEmptyDays}
+        days={Promise.resolve(mockEmptyDays)}
         weekStart={mockWeekAvailabilityStart}
         weekEnd={mockWeekAvailabilityEnd}
         site={'mock-site'}
@@ -67,7 +67,7 @@ describe('View Week Availability Page', () => {
   it('renders correct information for a day', () => {
     render(
       <ViewWeekAvailabilityPage
-        days={mockDaySummaries}
+        days={Promise.resolve(mockDaySummaries)}
         weekStart={mockWeekAvailabilityStart}
         weekEnd={mockWeekAvailabilityEnd}
         site={'mock-site'}
@@ -104,7 +104,7 @@ describe('View Week Availability Page', () => {
   it('renders pagination options with the correct values', () => {
     render(
       <ViewWeekAvailabilityPage
-        days={mockDaySummaries}
+        days={Promise.resolve(mockDaySummaries)}
         weekStart={mockWeekAvailabilityStart}
         weekEnd={mockWeekAvailabilityEnd}
         site={'mock-site'}
@@ -130,7 +130,7 @@ describe('View Week Availability Page', () => {
 
     render(
       <ViewWeekAvailabilityPage
-        days={daySummaries}
+        days={Promise.resolve(daySummaries)}
         weekStart={mockWeekAvailabilityStart}
         weekEnd={mockWeekAvailabilityEnd}
         site={'mock-site'}
@@ -151,7 +151,7 @@ describe('View Week Availability Page', () => {
 
     render(
       <ViewWeekAvailabilityPage
-        days={mockDaySummaries}
+        days={Promise.resolve(daySummaries)}
         weekStart={mockWeekAvailabilityStart}
         weekEnd={mockWeekAvailabilityEnd}
         site={'mock-site'}

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.test.tsx
@@ -3,18 +3,26 @@ import { ViewWeekAvailabilityPage } from './view-week-availability-page';
 import {
   mockDaySummaries,
   mockEmptyDays,
+  mockSite,
   mockWeekAvailabilityEnd,
   mockWeekAvailabilityStart,
 } from '@testing/data';
 import dayjs from 'dayjs';
 import { now } from '@services/timeService';
+import { summariseWeek } from '@services/availabilityCalculatorService';
+import { DaySummary } from '@types';
 
 jest.mock('@services/timeService', () => ({
   ...jest.requireActual('@services/timeService'),
   now: jest.fn(),
 }));
 
+jest.mock('@services/availabilityCalculatorService', () => ({
+  summariseWeek: jest.fn(),
+}));
+
 const mockNow = now as jest.Mock<dayjs.Dayjs>;
+const mockSummariseWeek = summariseWeek as jest.Mock<Promise<DaySummary[]>>;
 
 jest.mock('@types', () => ({
   ...jest.requireActual('@types'),
@@ -30,17 +38,16 @@ describe('View Week Availability Page', () => {
     jest.resetAllMocks();
 
     mockNow.mockReturnValue(dayjs('2023-06-10 08:34:00'));
+    mockSummariseWeek.mockReturnValue(Promise.resolve(mockDaySummaries));
   });
 
-  it('renders', () => {
-    render(
-      <ViewWeekAvailabilityPage
-        days={Promise.resolve(mockDaySummaries)}
-        weekStart={mockWeekAvailabilityStart}
-        weekEnd={mockWeekAvailabilityEnd}
-        site={'mock-site'}
-      />,
-    );
+  it('renders', async () => {
+    const jsx = await ViewWeekAvailabilityPage({
+      weekStart: mockWeekAvailabilityStart,
+      weekEnd: mockWeekAvailabilityEnd,
+      site: mockSite,
+    });
+    render(jsx);
 
     expect(
       screen.getByRole('heading', { name: 'Monday 2 December' }),
@@ -48,15 +55,15 @@ describe('View Week Availability Page', () => {
     expect(screen.getAllByRole('table')).toHaveLength(6);
   });
 
-  it('renders no availability', () => {
-    render(
-      <ViewWeekAvailabilityPage
-        days={Promise.resolve(mockEmptyDays)}
-        weekStart={mockWeekAvailabilityStart}
-        weekEnd={mockWeekAvailabilityEnd}
-        site={'mock-site'}
-      />,
-    );
+  it('renders no availability', async () => {
+    mockSummariseWeek.mockReturnValue(Promise.resolve(mockEmptyDays));
+
+    const jsx = await ViewWeekAvailabilityPage({
+      weekStart: mockWeekAvailabilityStart,
+      weekEnd: mockWeekAvailabilityEnd,
+      site: mockSite,
+    });
+    render(jsx);
 
     expect(
       screen.getByRole('heading', { name: 'Monday 2 December' }),
@@ -64,15 +71,13 @@ describe('View Week Availability Page', () => {
     expect(screen.queryAllByRole('table')).toHaveLength(0);
   });
 
-  it('renders correct information for a day', () => {
-    render(
-      <ViewWeekAvailabilityPage
-        days={Promise.resolve(mockDaySummaries)}
-        weekStart={mockWeekAvailabilityStart}
-        weekEnd={mockWeekAvailabilityEnd}
-        site={'mock-site'}
-      />,
-    );
+  it('renders correct information for a day', async () => {
+    const jsx = await ViewWeekAvailabilityPage({
+      weekStart: mockWeekAvailabilityStart,
+      weekEnd: mockWeekAvailabilityEnd,
+      site: mockSite,
+    });
+    render(jsx);
 
     expect(
       screen.getByRole('row', {
@@ -101,15 +106,13 @@ describe('View Week Availability Page', () => {
     );
   });
 
-  it('renders pagination options with the correct values', () => {
-    render(
-      <ViewWeekAvailabilityPage
-        days={Promise.resolve(mockDaySummaries)}
-        weekStart={mockWeekAvailabilityStart}
-        weekEnd={mockWeekAvailabilityEnd}
-        site={'mock-site'}
-      />,
-    );
+  it('renders pagination options with the correct values', async () => {
+    const jsx = await ViewWeekAvailabilityPage({
+      weekStart: mockWeekAvailabilityStart,
+      weekEnd: mockWeekAvailabilityEnd,
+      site: mockSite,
+    });
+    render(jsx);
 
     expect(
       screen.getByRole('link', { name: 'Next : 9-15 December 2024' }),
@@ -122,20 +125,20 @@ describe('View Week Availability Page', () => {
     ).toBeInTheDocument();
   });
 
-  it('Add Session only available for future date', () => {
+  it('Add Session only available for future date', async () => {
     const daySummaries = mockDaySummaries;
     daySummaries[0].date = dayjs();
     daySummaries[1].date = dayjs().add(1, 'day');
     daySummaries[2].date = dayjs().add(2, 'day');
 
-    render(
-      <ViewWeekAvailabilityPage
-        days={Promise.resolve(daySummaries)}
-        weekStart={mockWeekAvailabilityStart}
-        weekEnd={mockWeekAvailabilityEnd}
-        site={'mock-site'}
-      />,
-    );
+    mockSummariseWeek.mockReturnValue(Promise.resolve(daySummaries));
+
+    const jsx = await ViewWeekAvailabilityPage({
+      weekStart: mockWeekAvailabilityStart,
+      weekEnd: mockWeekAvailabilityEnd,
+      site: mockSite,
+    });
+    render(jsx);
 
     const links = screen.getAllByRole('link', {
       name: /Add Session/i,
@@ -143,21 +146,19 @@ describe('View Week Availability Page', () => {
     expect(links.length).toBe(2);
   });
 
-  it('Allows future sessions to be changed', () => {
+  it('Allows future sessions to be changed', async () => {
     const daySummaries = mockDaySummaries;
     daySummaries[0].date = dayjs();
     daySummaries[1].date = dayjs().add(1, 'day');
     daySummaries[2].date = dayjs().add(2, 'day');
 
-    render(
-      <ViewWeekAvailabilityPage
-        days={Promise.resolve(daySummaries)}
-        weekStart={mockWeekAvailabilityStart}
-        weekEnd={mockWeekAvailabilityEnd}
-        site={'mock-site'}
-      />,
-    );
-  });
+    mockSummariseWeek.mockReturnValue(Promise.resolve(daySummaries));
 
-  it('Does not allow past sessions to be changed', () => {});
+    const jsx = await ViewWeekAvailabilityPage({
+      weekStart: mockWeekAvailabilityStart,
+      weekEnd: mockWeekAvailabilityEnd,
+      site: mockSite,
+    });
+    render(jsx);
+  });
 });

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
@@ -1,18 +1,16 @@
 import { Pagination } from '@components/nhsuk-frontend';
-import { DaySummary } from '@types';
 import dayjs from 'dayjs';
 import { DaySummaryCard } from './day-summary-card';
-import { use } from 'react';
+import { summariseWeek } from '@services/availabilityCalculatorService';
+import { Site } from '@types';
 
 type Props = {
-  days: Promise<DaySummary[]>;
   weekStart: dayjs.Dayjs;
   weekEnd: dayjs.Dayjs;
-  site: string;
+  site: Site;
 };
 
-export const ViewWeekAvailabilityPage = ({
-  days,
+export const ViewWeekAvailabilityPage = async ({
   weekStart,
   weekEnd,
   site,
@@ -52,7 +50,7 @@ export const ViewWeekAvailabilityPage = ({
     href: `week?date=${previousWeek.format('YYYY-MM-DD')}`,
   };
 
-  const daySummaries = use(days);
+  const daySummaries = await summariseWeek(weekStart, weekEnd, site.id);
 
   return (
     <>
@@ -61,7 +59,7 @@ export const ViewWeekAvailabilityPage = ({
         return (
           <DaySummaryCard
             daySummary={day}
-            siteId={site}
+            siteId={site.id}
             key={`day-summary-${dayIndex}`}
           />
         );

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
@@ -2,9 +2,10 @@ import { Pagination } from '@components/nhsuk-frontend';
 import { DaySummary } from '@types';
 import dayjs from 'dayjs';
 import { DaySummaryCard } from './day-summary-card';
+import { use } from 'react';
 
 type Props = {
-  days: DaySummary[];
+  days: Promise<DaySummary[]>;
   weekStart: dayjs.Dayjs;
   weekEnd: dayjs.Dayjs;
   site: string;
@@ -51,10 +52,12 @@ export const ViewWeekAvailabilityPage = ({
     href: `week?date=${previousWeek.format('YYYY-MM-DD')}`,
   };
 
+  const daySummaries = use(days);
+
   return (
     <>
       <Pagination previous={previous} next={next} />
-      {days.map((day, dayIndex) => {
+      {daySummaries.map((day, dayIndex) => {
         return (
           <DaySummaryCard
             daySummary={day}


### PR DESCRIPTION
Components which take a long time to load currently block the entire rendering process. This isn't a problem yet, but once the monthly/weekly view availability pages start fetching thousands of appointments they could seem unresponsive to users with slower connections. 

This PR moves expensive API calls lower down the component tree and wraps them in [Suspense ](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming) boundaries so the basic page load can happen, and only the components which depend on the slow data are blocking. A loading spinner is shown whilst these components load. 

I have tested these components locally by throttling my browser and adding manual delays to the backend API. I am trusting our e2e tests for a regression against existing functionality. 

![chrome-capture-2025-0-23](https://github.com/user-attachments/assets/cb28a466-347e-462f-9190-f5d6aea08da9)
