### PR TITLE
APPT-592: Return Orphaned bookings from QueryBookingByNhsNumber

### DIFF
--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -56,7 +56,10 @@ public class BookingCosmosDocumentStore(ITypedDocumentCosmosStore<BookingDocumen
         var bookingIndexDocuments = (await indexStore.RunQueryAsync<BookingIndexDocument>(bi => bi.DocumentType == "booking_index" && bi.NhsNumber == nhsNumber)).ToList();
         var results = new List<Booking>();
 
-        var grouped = bookingIndexDocuments.Where(bi => bi.Status == AppointmentStatus.Booked).GroupBy(bi => bi.Site);
+        var grouped = bookingIndexDocuments
+            .Where(bi => bi.Status is AppointmentStatus.Booked or AppointmentStatus.Orphaned)
+            .GroupBy(bi => bi.Site);
+
         foreach (var siteBookings in grouped)
         {
             if (siteBookings.Count() > PointReadLimit)

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Xunit.Gherkin.Quick;
 using FluentAssertions;
+using Gherkin.Ast;
 using Nhs.Appointments.Api.Json;
 using Nhs.Appointments.Core;
+using Xunit.Gherkin.Quick;
 
 namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
 {
@@ -28,7 +29,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
         
         // TODO: Need to add this to the base class along with new tests for QueryByReference
         [Then(@"the following bookings are returned")]
-        public void Assert(Gherkin.Ast.DataTable expectedBookingDetailsTable)
+        public void Assert(DataTable expectedBookingDetailsTable)
         {
             var expectedBookings = expectedBookingDetailsTable.Rows.Skip(1).Select(
                 (row, index) =>
@@ -39,8 +40,10 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
                     Duration = int.Parse(row.Cells.ElementAt(2).Value),
                     Service = row.Cells.ElementAt(3).Value,
                     Site = GetSiteId(),
-                    Created = GetCreationDateTime(BookingType.Confirmed),
-                    Status = AppointmentStatus.Booked,
+                    Created = row.Cells.ElementAtOrDefault(6)?.Value is not null
+                        ? DateTimeOffset.Parse(row.Cells.ElementAtOrDefault(6)?.Value)
+                        : GetCreationDateTime(BookingType.Confirmed),
+                    Status = Enum.Parse<AppointmentStatus>(row.Cells.ElementAt(5).Value ?? "Booked"),
                     AttendeeDetails = new AttendeeDetails
                     {
                         NhsNumber = NhsNumber,

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/QueryBookingByNhsNumber.feature
@@ -6,14 +6,18 @@
       | Tomorrow          | 09:00 | 10:00 | COVID, FLU | 5           | 1        |
       | 2 days from today | 09:00 | 10:00 | COVID, FLU | 10          | 1        |
     And the following bookings have been made
-      | Date              | Time  | Duration | Service |
-      | Tomorrow          | 09:00 | 5        | COVID   |
-      | 2 days from today | 09:20 | 10       | FLU     |
+      | Date              | Time  | Duration | Service | Reference   | Created                  |
+      | Tomorrow          | 09:00 | 5        | COVID   | 49581-39578 | 2024-12-01T09:00:00.000Z |
+      | 2 days from today | 09:20 | 10       | FLU     | 58371-39584 | 2024-11-02T09:00:00.000Z |
+    And the following orphaned bookings exist
+      | Date              | Time  | Duration | Service | Reference   | Created                  |
+      | 3 days from today | 09:20 | 5        | COVID   | 59283-59481 | 2024-12-03T09:00:00.000Z |
     When I query for bookings for a person using their NHS number
     Then the following bookings are returned
-      | Date              | Time  | Duration | Service |
-      | Tomorrow          | 09:00 | 5        | COVID   |
-      | 2 days from today | 09:20 | 10       | FLU     |
+      | Date              | Time  | Duration | Service | Reference   | Status   | Created                  |
+      | Tomorrow          | 09:00 | 5        | COVID   | 49581-39578 | Booked   | 2024-12-01T09:00:00.000Z |
+      | 2 days from today | 09:20 | 10       | FLU     | 58371-39584 | Booked   | 2024-11-02T09:00:00.000Z |
+      | 3 days from today | 09:20 | 5        | COVID   | 59283-59481 | Orphaned | 2024-12-03T09:00:00.000Z |
 
   Scenario: Provisional bookings are not returned
     Given the following sessions
@@ -26,22 +30,41 @@
     When I query for bookings for a person using their NHS number
     Then the request is successful and no bookings are returned
 
-  Scenario: Provisional bookings are not returned but confirmed bookings are
+  Scenario: Cancelled bookings are not returned
+    Given the following sessions
+      | Date              | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow          | 09:00 | 10:00 | COVID, FLU | 5           | 1        |
+      | 2 days from today | 09:00 | 10:00 | COVID, FLU | 10          | 1        |
+    Given the following cancelled bookings have been made
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:00 | 5        | COVID   |
+    When I query for bookings for a person using their NHS number
+    Then the request is successful and no bookings are returned
+
+  Scenario: Provisional and Cancelled bookings are not returned but confirmed and Orphaned bookings are
     Given the following sessions
       | Date              | From  | Until | Services   | Slot Length | Capacity |
       | Tomorrow          | 09:00 | 10:00 | COVID, FLU | 5           | 1        |
       | 2 days from today | 09:00 | 10:00 | COVID, FLU | 10          | 1        |
     Given the following provisional bookings have been made
-      | Date     | Time  | Duration | Service |
-      | Tomorrow | 09:00 | 5        | COVID   |
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:00 | 5        | COVID   | 10394-12039 |
     And the following bookings have been made
-      | Date     | Time  | Duration | Service |
-      | Tomorrow | 09:10 | 5        | COVID   |
+      | Date     | Time  | Duration | Service | Reference   | Created                  |
+      | Tomorrow | 09:10 | 5        | COVID   | 39031-93231 | 2024-12-01T09:00:00.000Z |
+    And the following orphaned bookings exist
+      | Date              | Time  | Duration | Service | Reference   | Created                  |
+      | 2 days from today | 09:20 | 5        | COVID   | 01923-76941 | 2024-12-03T09:00:00.000Z |
+    And the following cancelled bookings have been made
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:00 | 5        | COVID   | 50192-39381 |
     When I query for bookings for a person using their NHS number
     Then the following bookings are returned
-      | Date     | Time  | Duration | Service |
-      | Tomorrow | 09:10 | 5        | COVID   |
+      | Date              | Time  | Duration | Service | Reference   | Status   | Created                  |
+      | Tomorrow          | 09:10 | 5        | COVID   | 39031-93231 | Booked   | 2024-12-01T09:00:00.000Z |
+      | 2 days from today | 09:20 | 5        | COVID   | 01923-76941 | Orphaned | 2024-12-03T09:00:00.000Z |
 
   Scenario: Returns success if no bookings are found for a person
     When I query for bookings for a person using their NHS number
     Then the request is successful and no bookings are returned
+


### PR DESCRIPTION
`GET api/booking?nhsNUmber=123` derives a list of sites a person has bookings at but filters it by status = `Booked`. It then queries all their bookings at that site and returns them regardless of status. 

This means if a citizen only has Orphaned bookings at a given site, these will not be included in the response. They need to be so NBS can detect when a user has a live booking.