### PR TITLE
APPT-587: Prevent Provisional appointments from being Orphaned

### DIFF
--- a/src/api/Nhs.Appointments.Core/BookingsService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingsService.cs
@@ -182,7 +182,7 @@ public class BookingsService(
                 continue;
             }
 
-            if (booking.Status is AppointmentStatus.Booked or AppointmentStatus.Provisional)
+            if (booking.Status is AppointmentStatus.Booked)
             {
                 await SetBookingStatus(booking.Reference, AppointmentStatus.Orphaned);
             }

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingsServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingsServiceTests.cs
@@ -518,7 +518,7 @@ namespace Nhs.Appointments.Core.UnitTests
                         From = new DateTime(2025, 01, 01, 9, 10, 0),
                         Reference = "2",
                         AttendeeDetails = new AttendeeDetails { FirstName = "Alexander", LastName = "Cooper" },
-                        Status = AppointmentStatus.Provisional,
+                        Status = AppointmentStatus.Booked,
                         Duration = 10
                     }
                 };
@@ -553,6 +553,61 @@ namespace Nhs.Appointments.Core.UnitTests
                         It.Is<string>(s => s == "2"),
                         It.Is<AppointmentStatus>(s => s == AppointmentStatus.Orphaned)),
                     Times.Once);
+            }
+
+            [Fact]
+            public async Task RecalculateAppointmentStatuses_DoesNotOrphanProvisionalAppointments()
+            {
+                IEnumerable<Booking> bookings = new List<Booking>
+                {
+                    new()
+                    {
+                        From = new DateTime(2025, 01, 01, 9, 0, 0),
+                        Reference = "1",
+                        AttendeeDetails = new AttendeeDetails { FirstName = "Daniel", LastName = "Dixon" },
+                        Status = AppointmentStatus.Booked,
+                        Duration = 10
+                    },
+                    new()
+                    {
+                        From = new DateTime(2025, 01, 01, 9, 10, 0),
+                        Reference = "2",
+                        AttendeeDetails = new AttendeeDetails { FirstName = "Alexander", LastName = "Cooper" },
+                        Status = AppointmentStatus.Provisional,
+                        Duration = 10
+                    }
+                };
+
+                _bookingsDocumentStore
+                    .Setup(x => x.GetInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), MockSite))
+                    .ReturnsAsync(bookings);
+
+                var sessions = new List<SessionInstance>
+                {
+                    new(new DateTime(2025, 01, 01, 10, 0, 0), new DateTime(2025, 01, 1, 12, 0, 0))
+                    {
+                        Services = ["Service 1"], SlotLength = 10, Capacity = 1
+                    }
+                };
+
+                _availabilityStore
+                    .Setup(x => x.GetSessions(
+                        It.Is<string>(s => s == MockSite),
+                        It.IsAny<DateOnly>(),
+                        It.IsAny<DateOnly>()))
+                    .ReturnsAsync(sessions);
+
+                await _bookingsService.RecalculateAppointmentStatuses(MockSite, new DateOnly(2025, 1, 1));
+
+                _bookingsDocumentStore.Verify(x => x.UpdateStatus(
+                        It.Is<string>(s => s == "1"),
+                        It.Is<AppointmentStatus>(s => s == AppointmentStatus.Orphaned)),
+                    Times.Once);
+
+                _bookingsDocumentStore.Verify(x => x.UpdateStatus(
+                        It.Is<string>(s => s == "2"),
+                        It.Is<AppointmentStatus>(s => s == AppointmentStatus.Orphaned)),
+                    Times.Never);
             }
 
             [Fact]


### PR DESCRIPTION
The Availability Re-calculator currently orphans Booked or Provisional appointments if there is no longer availability to fulfil them. 

This exposes a risk because the NBS journey for a patient involves creating them a Provisional booking, then confirming it as a Booked booking at the end of the UI flow. If this Provisional booking gets orphaned whilst the user is going through this journey, they'll be told the booking was unsuccessful but clinicians in MYA will see an Orphaned booking and might decide to "honour" it. 