### PR TITLE
APPT-XXX: Parallelise data fetches

### DIFF
--- a/src/client/src/app/lib/services/availabilityCalculatorService.ts
+++ b/src/client/src/app/lib/services/availabilityCalculatorService.ts
@@ -23,17 +23,18 @@ export const summariseWeek = async (
   weekEnd: dayjs.Dayjs,
   siteId: string,
 ): Promise<DaySummary[]> => {
-  const dailyAvailability = await fetchDailyAvailability(
-    siteId,
-    weekStart.format('YYYY-MM-DD'),
-    weekEnd.format('YYYY-MM-DD'),
-  );
-
-  const dailyBookings = await fetchBookings({
-    from: weekStart.format('YYYY-MM-DD HH:mm:ss'),
-    to: weekEnd.format('YYYY-MM-DD HH:mm:ss'),
-    site: siteId,
-  });
+  const [dailyAvailability, dailyBookings] = await Promise.all([
+    fetchDailyAvailability(
+      siteId,
+      weekStart.format('YYYY-MM-DD'),
+      weekEnd.format('YYYY-MM-DD'),
+    ),
+    fetchBookings({
+      from: weekStart.format('YYYY-MM-DD HH:mm:ss'),
+      to: weekEnd.format('YYYY-MM-DD HH:mm:ss'),
+      site: siteId,
+    }),
+  ]);
 
   const week = getWeek(weekStart);
 

--- a/src/client/src/app/site/[site]/appointment/[reference]/cancel/page.tsx
+++ b/src/client/src/app/site/[site]/appointment/[reference]/cancel/page.tsx
@@ -16,10 +16,12 @@ type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  await assertPermission(site.id, 'booking:cancel');
+  const [site, booking] = await Promise.all([
+    fetchSite(params.site),
+    fetchBooking(params.reference, params.site),
+    assertPermission(params.site, 'booking:cancel'),
+  ]);
 
-  const booking = await fetchBooking(params.reference, site.id);
   if (!booking || booking.status === 'Cancelled') {
     notFound();
   }

--- a/src/client/src/app/site/[site]/availability/cancel/confirmed/page.tsx
+++ b/src/client/src/app/site/[site]/availability/cancel/confirmed/page.tsx
@@ -16,8 +16,10 @@ type PageProps = {
 };
 
 const Page = async ({ searchParams, params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  await assertPermission(site.id, 'availability:setup');
+  const [site] = await Promise.all([
+    fetchSite(params.site),
+    assertPermission(params.site, 'availability:setup'),
+  ]);
 
   if (searchParams.session === undefined || searchParams.date === undefined) {
     notFound();

--- a/src/client/src/app/site/[site]/availability/cancel/page.tsx
+++ b/src/client/src/app/site/[site]/availability/cancel/page.tsx
@@ -15,8 +15,10 @@ type PageProps = {
 };
 
 const Page = async ({ searchParams, params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  await assertPermission(site.id, 'availability:setup');
+  const [site] = await Promise.all([
+    fetchSite(params.site),
+    assertPermission(params.site, 'availability:setup'),
+  ]);
 
   if (searchParams.session === undefined || searchParams.date === undefined) {
     notFound();

--- a/src/client/src/app/site/[site]/availability/edit/confirmed/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/confirmed/page.tsx
@@ -15,8 +15,10 @@ type PageProps = {
 };
 
 const Page = async ({ searchParams, params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  await assertPermission(site.id, 'availability:setup');
+  const [site] = await Promise.all([
+    fetchSite(params.site),
+    assertPermission(params.site, 'availability:setup'),
+  ]);
   const date = dayjs(searchParams.date, 'YYYY-MM-DD');
 
   const updatedSession: AvailabilitySession = JSON.parse(

--- a/src/client/src/app/site/[site]/availability/edit/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/page.tsx
@@ -15,8 +15,10 @@ type PageProps = {
 };
 
 const Page = async ({ searchParams, params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  await assertPermission(site.id, 'availability:setup');
+  const [site] = await Promise.all([
+    fetchSite(params.site),
+    assertPermission(params.site, 'availability:setup'),
+  ]);
   const date = dayjs(searchParams.date, 'YYYY-MM-DD');
 
   const sessionSummary: SessionSummary = JSON.parse(atob(searchParams.session));

--- a/src/client/src/app/site/[site]/create-availability/page.tsx
+++ b/src/client/src/app/site/[site]/create-availability/page.tsx
@@ -9,9 +9,10 @@ type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
-  const site = await fetchSite(params.site);
-
-  await assertPermission(site.id, 'availability:setup');
+  const [site] = await Promise.all([
+    fetchSite(params.site),
+    assertPermission(params.site, 'availability:setup'),
+  ]);
 
   return (
     <NhsPage

--- a/src/client/src/app/site/[site]/create-availability/wizard/page.tsx
+++ b/src/client/src/app/site/[site]/create-availability/wizard/page.tsx
@@ -1,4 +1,4 @@
-import { fetchSite } from '@services/appointmentsService';
+import { assertPermission, fetchSite } from '@services/appointmentsService';
 import NhsTransactionalPage from '@components/nhs-transactional-page';
 import AvailabilityTemplateWizard from './availability-template-wizard';
 
@@ -12,7 +12,10 @@ type PageProps = {
 };
 
 const Page = async ({ params, searchParams }: PageProps) => {
-  const site = await fetchSite(params.site);
+  const [site] = await Promise.all([
+    fetchSite(params.site),
+    assertPermission(params.site, 'availability:setup'),
+  ]);
 
   return (
     <NhsTransactionalPage originPage="create-availability-wizard">

--- a/src/client/src/app/site/[site]/details/edit-attributes/edit-attributes-page.tsx
+++ b/src/client/src/app/site/[site]/details/edit-attributes/edit-attributes-page.tsx
@@ -10,11 +10,13 @@ type Props = {
 };
 
 export const EditAttributesPage = async ({ site }: Props) => {
-  const attributeDefinitions = await fetchAttributeDefinitions();
+  const [attributeDefinitions, siteDetails] = await Promise.all([
+    fetchAttributeDefinitions(),
+    fetchSite(site),
+  ]);
   const accessibilityAttributeDefinitions = attributeDefinitions.filter(ad =>
     ad.id.startsWith('accessibility'),
   );
-  const siteDetails = await fetchSite(site);
 
   return (
     <>

--- a/src/client/src/app/site/[site]/details/edit-attributes/page.tsx
+++ b/src/client/src/app/site/[site]/details/edit-attributes/page.tsx
@@ -13,10 +13,11 @@ export type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  const sitePermissions = await fetchPermissions(params.site);
-
-  await assertPermission(site.id, 'site:manage');
+  const [site, sitePermissions] = await Promise.all([
+    fetchSite(params.site),
+    fetchPermissions(params.site),
+    assertPermission(params.site, 'site:manage'),
+  ]);
 
   return (
     <NhsPage

--- a/src/client/src/app/site/[site]/details/edit-information-for-citizens/page.tsx
+++ b/src/client/src/app/site/[site]/details/edit-information-for-citizens/page.tsx
@@ -13,10 +13,11 @@ export type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  const sitePermissions = await fetchPermissions(params.site);
-
-  await assertPermission(site.id, 'site:manage');
+  const [site, sitePermissions] = await Promise.all([
+    fetchSite(params.site),
+    fetchPermissions(params.site),
+    assertPermission(params.site, 'site:manage'),
+  ]);
 
   return (
     <NhsPage

--- a/src/client/src/app/site/[site]/details/page.tsx
+++ b/src/client/src/app/site/[site]/details/page.tsx
@@ -14,12 +14,12 @@ export type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  const wellKnownOdsCodeEntries = await fetchWellKnownOdsCodeEntries();
-
-  const sitePermissions = await fetchPermissions(params.site);
-
-  await assertAllPermissions(site.id, ['site:view', 'site:get-meta-data']);
+  const [site, wellKnownOdsCodeEntries, sitePermissions] = await Promise.all([
+    fetchSite(params.site),
+    fetchWellKnownOdsCodeEntries(),
+    fetchPermissions(params.site),
+    assertAllPermissions(params.site, ['site:view', 'site:get-meta-data']),
+  ]);
 
   return (
     <NhsPage

--- a/src/client/src/app/site/[site]/details/site-details-page.tsx
+++ b/src/client/src/app/site/[site]/details/site-details-page.tsx
@@ -18,11 +18,14 @@ const SiteDetailsPage = async ({
   permissions,
   wellKnownOdsEntries,
 }: Props) => {
-  const attributeDefinitions = await fetchAttributeDefinitions();
+  const [attributeDefinitions, siteDetails] = await Promise.all([
+    fetchAttributeDefinitions(),
+    fetchSite(site.id),
+  ]);
+
   const accessibilityAttributeDefinitions = attributeDefinitions.filter(ad =>
     ad.id.startsWith('accessibility'),
   );
-  const siteDetails = await fetchSite(site.id);
   const informationForCitizenAttribute = siteDetails.attributeValues.find(
     sa => sa.id === 'site_details/info_for_citizen',
   );

--- a/src/client/src/app/site/[site]/page.tsx
+++ b/src/client/src/app/site/[site]/page.tsx
@@ -22,11 +22,12 @@ type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  const wellKnownOdsCodeEntries = await fetchWellKnownOdsCodeEntries();
-  const sitePermissions = await fetchPermissions(params.site);
-
-  await assertPermission(site.id, 'site:view');
+  const [site, wellKnownOdsCodeEntries, sitePermissions] = await Promise.all([
+    fetchSite(params.site),
+    fetchWellKnownOdsCodeEntries(),
+    fetchPermissions(params.site),
+    assertPermission(params.site, 'site:view'),
+  ]);
 
   return (
     <NhsPage title={site.name} site={site} originPage="site">

--- a/src/client/src/app/site/[site]/users/manage/assign-roles.tsx
+++ b/src/client/src/app/site/[site]/users/manage/assign-roles.tsx
@@ -10,8 +10,10 @@ const AssignRoles = async ({ params, searchParams }: UserPageProps) => {
   if (user === undefined || !user.endsWith('@nhs.net'))
     throw Error('You must specify a valid NHS email address');
 
-  const roles = await fetchRoles();
-  const users = await fetchUsers(params.site);
+  const [roles, users] = await Promise.all([
+    fetchRoles(),
+    fetchUsers(params.site),
+  ]);
 
   const currentUserAssignments =
     users.find(usr => usr.id === user)?.roleAssignments ??

--- a/src/client/src/app/site/[site]/users/manage/page.tsx
+++ b/src/client/src/app/site/[site]/users/manage/page.tsx
@@ -20,11 +20,12 @@ const AssignRolesPage = async ({ params, searchParams }: UserPageProps) => {
   const userIsSpecified = () =>
     (searchParams && 'user' in searchParams) ?? false;
 
-  const site = await fetchSite(params.site);
+  const [site, userProfile] = await Promise.all([
+    fetchSite(params.site),
+    fetchUserProfile(),
+    assertPermission(params.site, 'users:manage'),
+  ]);
 
-  await assertPermission(site.id, 'users:manage');
-
-  const userProfile = await fetchUserProfile();
   if (userProfile.emailAddress === searchParams?.user) {
     notAuthorized();
   }

--- a/src/client/src/app/site/[site]/users/page.tsx
+++ b/src/client/src/app/site/[site]/users/page.tsx
@@ -16,13 +16,15 @@ type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
-  const userProfile = await fetchUserProfile();
-  const users = await fetchUsers(params.site);
-  const rolesResponse = await fetchRoles();
-  const site = await fetchSite(params.site);
-  const permissions = await fetchPermissions(params.site);
-
-  await assertAnyPermissions(site.id, ['users:view', 'users:view']);
+  const [userProfile, users, rolesResponse, site, permissions] =
+    await Promise.all([
+      fetchUserProfile(),
+      fetchUsers(params.site),
+      fetchRoles(),
+      fetchSite(params.site),
+      fetchPermissions(params.site),
+      assertAnyPermissions(params.site, ['users:view', 'users:view']),
+    ]);
 
   return (
     <NhsPage title="Manage Staff Roles" site={site} originPage="users">

--- a/src/client/src/app/site/[site]/users/remove/page.tsx
+++ b/src/client/src/app/site/[site]/users/remove/page.tsx
@@ -23,16 +23,17 @@ const Page = async ({ params, searchParams }: UserPageProps) => {
     redirect(`/site/${params.site}/users`);
   }
 
-  const site = await fetchSite(params.site);
+  const [site, users, userProfile] = await Promise.all([
+    fetchSite(params.site),
+    fetchUsers(params.site),
+    fetchUserProfile(),
+    assertPermission(params.site, 'users:manage'),
+  ]);
 
-  const users = await fetchUsers(params.site);
   if (users === undefined || !users.some(u => u.id === searchParams?.user)) {
     notFound();
   }
 
-  await assertPermission(site.id, 'users:manage');
-
-  const userProfile = await fetchUserProfile();
   if (userProfile.emailAddress === searchParams?.user) {
     notAuthorized();
   }

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
@@ -23,17 +23,19 @@ type PageProps = {
 };
 
 const Page = async ({ params, searchParams }: PageProps) => {
-  const site = await fetchSite(params.site);
-  await assertPermission(site.id, 'availability:query');
   const date = dayjs(searchParams.date);
-
   const fetchBookingsRequest: FetchBookingsRequest = {
     from: date.hour(0).minute(0).second(0).format('YYYY-MM-DDTHH:mm:ssZ'),
     to: date.hour(23).minute(59).second(59).format('YYYY-MM-DDTHH:mm:ssZ'),
-    site: site.id,
+    site: params.site,
   };
 
-  const bookings = await fetchBookings(fetchBookingsRequest);
+  const [site, bookings] = await Promise.all([
+    fetchSite(params.site),
+    fetchBookings(fetchBookingsRequest),
+    assertPermission(params.site, 'availability:query'),
+  ]);
+
   const scheduledBookings = bookings.filter(b => b.status === 'Booked');
   const cancelledBookings = bookings.filter(b => b.status === 'Cancelled');
   const orphanedAppointments = bookings.filter(b => b.status === 'Orphaned');

--- a/src/client/src/app/site/[site]/view-availability/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/page.tsx
@@ -13,8 +13,11 @@ type PageProps = {
 };
 
 const Page = async ({ params, searchParams }: PageProps) => {
-  const site = await fetchSite(params.site);
-  await assertPermission(site.id, 'availability:query');
+  const [site] = await Promise.all([
+    fetchSite(params.site),
+    assertPermission(params.site, 'availability:query'),
+  ]);
+
   const searchMonth = searchParams?.date
     ? dayjs(searchParams?.date, 'YYYY-MM-DD')
     : dayjs();

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/page.tsx
@@ -15,8 +15,11 @@ type PageProps = {
 };
 
 const Page = async ({ searchParams, params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  await assertPermission(site.id, 'availability:setup');
+  const [site] = await Promise.all([
+    fetchSite(params.site),
+    assertPermission(params.site, 'availability:setup'),
+  ]);
+
   const date = dayjs(searchParams.date, 'YYYY-MM-DD');
 
   if (searchParams.session === undefined || searchParams.date === undefined) {

--- a/src/client/src/app/site/[site]/view-availability/week/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/page.tsx
@@ -16,8 +16,10 @@ type PageProps = {
 };
 
 const Page = async ({ searchParams, params }: PageProps) => {
-  const site = await fetchSite(params.site);
-  await assertPermission(site.id, 'availability:query');
+  const [site] = await Promise.all([
+    fetchSite(params.site),
+    assertPermission(params.site, 'availability:query'),
+  ]);
 
   const weekStart = startOfWeek(searchParams.date);
   const weekEnd = endOfWeek(searchParams.date);


### PR DESCRIPTION
Cheeky off-ticket PR to improve data fetching performance on the frontend. 

We're currently doing multiple server actions sequentially which hasn't stung us yet because they're all quite quick, but there's no reason we can't fire off these requests in parallel. 