### PR TITLE
APPT-525 - Add site search functionality on the front end. 

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesPreviewFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesPreviewFunction.cs
@@ -47,7 +47,7 @@ public class GetSitesPreviewFunction(ISiteService siteService, IUserService user
 
             foreach (var site in allSites)
             {
-                sitesResult.Add(new SitePreview(site.Id, site.Name));
+                sitesResult.Add(new SitePreview(site.Id, site.Name, site.OdsCode));
             }
         }
         else
@@ -58,7 +58,7 @@ public class GetSitesPreviewFunction(ISiteService siteService, IUserService user
             {
                 var siteInfo = await siteService.GetSiteByIdAsync(site);
                 if (siteInfo != null)
-                    sitesResult.Add(new SitePreview(siteInfo.Id, siteInfo.Name));
+                    sitesResult.Add(new SitePreview(siteInfo.Id, siteInfo.Name, siteInfo.OdsCode));
             }
         }
 

--- a/src/api/Nhs.Appointments.Core/Site.cs
+++ b/src/api/Nhs.Appointments.Core/Site.cs
@@ -46,7 +46,9 @@ public record SitePreview
     [JsonProperty("id")]
     string Id,
     [JsonProperty("name")]
-    string Name
+    string Name,
+    [JsonProperty("odsCode")]
+    string OdsCode
 );
 
 public record DetailsRequest(

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -71,7 +71,7 @@ public class SiteService(ISiteStore siteStore, IMemoryCache memoryCache, TimePro
             memoryCache.Set(CacheKey, sites, time.GetUtcNow().AddMinutes(10));
         }
 
-        return sites.Select(s => new SitePreview(s.Id, s.Name));
+        return sites.Select(s => new SitePreview(s.Id, s.Name, s.OdsCode));
     }
 
     public Task<OperationResult> UpdateSiteAttributesAsync(string siteId, string scope, IEnumerable<AttributeValue> attributeValues)

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@next/env": "^14.2.23",
         "dayjs": "^1.11.13",
-        "lodash.debounce": "^4.0.8",
         "manage-your-appointments": "file:",
         "next": "^14.2.23",
         "nhsuk-frontend": "^8.3.0",
@@ -26,7 +25,6 @@
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.14",
-        "@types/lodash.debounce": "^4.0.9",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1972,23 +1970,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash.debounce": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
-      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -7229,12 +7210,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@next/env": "^14.2.23",
         "dayjs": "^1.11.13",
+        "lodash.debounce": "^4.0.8",
         "manage-your-appointments": "file:",
         "next": "^14.2.23",
         "nhsuk-frontend": "^8.3.0",
@@ -25,6 +26,7 @@
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.14",
+        "@types/lodash.debounce": "^4.0.9",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1654,7 +1656,7 @@
       "version": "1.49.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
       "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.49.1"
@@ -1970,6 +1972,23 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -7211,6 +7230,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -8249,7 +8274,7 @@
       "version": "1.49.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
       "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.49.1"
@@ -8268,7 +8293,7 @@
       "version": "1.49.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
       "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@next/env": "^14.2.23",
     "dayjs": "^1.11.13",
+    "lodash.debounce": "^4.0.8",
     "manage-your-appointments": "file:",
     "next": "^14.2.23",
     "nhsuk-frontend": "^8.3.0",
@@ -40,6 +41,7 @@
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.14",
+    "@types/lodash.debounce": "^4.0.9",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@next/env": "^14.2.23",
     "dayjs": "^1.11.13",
-    "lodash.debounce": "^4.0.8",
     "manage-your-appointments": "file:",
     "next": "^14.2.23",
     "nhsuk-frontend": "^8.3.0",
@@ -41,7 +40,6 @@
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.14",
-    "@types/lodash.debounce": "^4.0.9",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/client/src/app/lib/components/site-list.test.tsx
+++ b/src/client/src/app/lib/components/site-list.test.tsx
@@ -190,6 +190,7 @@ describe('<SiteList>', () => {
     });
     await user.type(searchInput, 'Beta');
 
+    await new Promise(r => setTimeout(r, 400));
     const filteredSites = within(screen.getByRole('list')).getAllByRole(
       'listitem',
     );
@@ -262,6 +263,7 @@ describe('<SiteList>', () => {
     });
     await user.type(searchInput, 'Be');
 
+    await new Promise(r => setTimeout(r, 400));
     const filteredSites = within(screen.getByRole('list')).getAllByRole(
       'listitem',
     );
@@ -333,6 +335,7 @@ describe('<SiteList>', () => {
     });
     await user.type(searchInput, '1004');
 
+    await new Promise(r => setTimeout(r, 400));
     const filteredSites = within(screen.getByRole('list')).getAllByRole(
       'listitem',
     );
@@ -405,6 +408,7 @@ describe('<SiteList>', () => {
     });
     await user.type(searchInput, '1005');
 
+    await new Promise(r => setTimeout(r, 400));
     const filteredSites = within(screen.getByRole('list')).queryAllByRole(
       'listitem',
     );

--- a/src/client/src/app/lib/components/site-list.test.tsx
+++ b/src/client/src/app/lib/components/site-list.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
+import render from '@testing/render';
 import SiteList from '@components/site-list';
 import { Site } from '@types';
 
@@ -122,5 +123,291 @@ describe('<SiteList>', () => {
       'href',
       '/site/95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
     );
+  });
+
+  it('filters sites on search input', async () => {
+    const testSites: Site[] = [
+      {
+        id: '34e990af-5dc9-43a6-8895-b9123216d699',
+        name: 'Site Zulu',
+        address: 'Zulu Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1001',
+        integratedCareBoard: 'ICB1',
+        region: 'R1',
+      },
+      {
+        id: '95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
+        name: 'Site Lima',
+        address: 'Lima Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1002',
+        integratedCareBoard: 'ICB2',
+        region: 'R2',
+      },
+      {
+        id: 'd79bec60-8968-4101-b553-67dec04e1019',
+        name: 'Site November',
+        address: 'November Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1003',
+        integratedCareBoard: 'ICB3',
+        region: 'R3',
+      },
+      {
+        id: '90a9c1f2-83d0-4c40-9c7c-080d91c56e79',
+        name: 'Site Beta',
+        address: 'Beta Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1004',
+        integratedCareBoard: 'ICB4',
+        region: 'R4',
+      },
+    ];
+    const { user } = render(<SiteList sites={testSites} />);
+
+    const siteNames = within(screen.getByRole('list')).getAllByRole('listitem');
+    expect(siteNames).toHaveLength(4);
+
+    const searchInput = screen.getByRole('textbox', {
+      name: 'site-search',
+    });
+    await user.type(searchInput, 'Beta');
+
+    const filteredSites = within(screen.getByRole('list')).getAllByRole(
+      'listitem',
+    );
+    expect(filteredSites).toHaveLength(1);
+    expect(filteredSites[0]?.textContent).toBe('Site Beta');
+  });
+
+  it('does not filter results when search input is less than 3 characters', async () => {
+    const testSites: Site[] = [
+      {
+        id: '34e990af-5dc9-43a6-8895-b9123216d699',
+        name: 'Site Zulu',
+        address: 'Zulu Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1001',
+        integratedCareBoard: 'ICB1',
+        region: 'R1',
+      },
+      {
+        id: '95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
+        name: 'Site Lima',
+        address: 'Lima Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1002',
+        integratedCareBoard: 'ICB2',
+        region: 'R2',
+      },
+      {
+        id: 'd79bec60-8968-4101-b553-67dec04e1019',
+        name: 'Site November',
+        address: 'November Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1003',
+        integratedCareBoard: 'ICB3',
+        region: 'R3',
+      },
+      {
+        id: '90a9c1f2-83d0-4c40-9c7c-080d91c56e79',
+        name: 'Site Beta',
+        address: 'Beta Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1004',
+        integratedCareBoard: 'ICB4',
+        region: 'R4',
+      },
+    ];
+    const { user } = render(<SiteList sites={testSites} />);
+
+    const siteNames = within(screen.getByRole('list')).getAllByRole('listitem');
+    expect(siteNames).toHaveLength(4);
+
+    const searchInput = screen.getByRole('textbox', {
+      name: 'site-search',
+    });
+    await user.type(searchInput, 'Be');
+
+    const filteredSites = within(screen.getByRole('list')).getAllByRole(
+      'listitem',
+    );
+    expect(filteredSites).toHaveLength(4);
+  });
+
+  it('filters sites on exact match of ODS code', async () => {
+    const testSites: Site[] = [
+      {
+        id: '34e990af-5dc9-43a6-8895-b9123216d699',
+        name: 'Site Zulu',
+        address: 'Zulu Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1001',
+        integratedCareBoard: 'ICB1',
+        region: 'R1',
+      },
+      {
+        id: '95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
+        name: 'Site Lima',
+        address: 'Lima Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1002',
+        integratedCareBoard: 'ICB2',
+        region: 'R2',
+      },
+      {
+        id: 'd79bec60-8968-4101-b553-67dec04e1019',
+        name: 'Site November',
+        address: 'November Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1003',
+        integratedCareBoard: 'ICB3',
+        region: 'R3',
+      },
+      {
+        id: '90a9c1f2-83d0-4c40-9c7c-080d91c56e79',
+        name: 'Site Beta',
+        address: 'Beta Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1004',
+        integratedCareBoard: 'ICB4',
+        region: 'R4',
+      },
+    ];
+    const { user } = render(<SiteList sites={testSites} />);
+
+    const siteNames = within(screen.getByRole('list')).getAllByRole('listitem');
+    expect(siteNames).toHaveLength(4);
+
+    const searchInput = screen.getByRole('textbox', {
+      name: 'site-search',
+    });
+    await user.type(searchInput, '1004');
+
+    const filteredSites = within(screen.getByRole('list')).getAllByRole(
+      'listitem',
+    );
+    expect(filteredSites).toHaveLength(1);
+    expect(filteredSites[0]?.textContent).toBe('Site Beta');
+  });
+
+  it('cannot find site on partial ODS code search', async () => {
+    const testSites: Site[] = [
+      {
+        id: '34e990af-5dc9-43a6-8895-b9123216d699',
+        name: 'Site Zulu',
+        address: 'Zulu Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1001',
+        integratedCareBoard: 'ICB1',
+        region: 'R1',
+      },
+      {
+        id: '95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
+        name: 'Site Lima',
+        address: 'Lima Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1002',
+        integratedCareBoard: 'ICB2',
+        region: 'R2',
+      },
+      {
+        id: 'd79bec60-8968-4101-b553-67dec04e1019',
+        name: 'Site November',
+        address: 'November Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1003',
+        integratedCareBoard: 'ICB3',
+        region: 'R3',
+      },
+      {
+        id: '90a9c1f2-83d0-4c40-9c7c-080d91c56e79',
+        name: 'Site Beta',
+        address: 'Beta Street',
+        phoneNumber: '01189998819991197253',
+        location: {
+          coordinates: [],
+          type: 'point',
+        },
+        odsCode: '1004',
+        integratedCareBoard: 'ICB4',
+        region: 'R4',
+      },
+    ];
+    const { user } = render(<SiteList sites={testSites} />);
+
+    const siteNames = within(screen.getByRole('list')).getAllByRole('listitem');
+    expect(siteNames).toHaveLength(4);
+
+    const searchInput = screen.getByRole('textbox', {
+      name: 'site-search',
+    });
+    await user.type(searchInput, '1005');
+
+    const filteredSites = within(screen.getByRole('list')).queryAllByRole(
+      'listitem',
+    );
+    expect(filteredSites).toHaveLength(0);
   });
 });

--- a/src/client/src/app/lib/components/site-list.tsx
+++ b/src/client/src/app/lib/components/site-list.tsx
@@ -4,6 +4,7 @@ import { Site } from '@types';
 import { Card, TextInput } from '@nhsuk-frontend-components';
 import { sortSitesByName } from '@sorting';
 import { ChangeEvent, useState } from 'react';
+import _debounce from 'lodash.debounce';
 
 type Props = {
   sites: Site[];
@@ -28,13 +29,15 @@ const SiteList = ({ sites }: Props) => {
     }
   };
 
+  const debounceSearchHandler = _debounce(handleInputChange, 300);
+
   return (
     <Card title="Choose a site">
       <TextInput
         id="site-search"
         aria-label="site-search"
         placeholder="Search"
-        onChange={handleInputChange}
+        onChange={debounceSearchHandler}
       ></TextInput>
       <ul className="nhsuk-list nhsuk-list--border">
         {filteredSites.map(s => (

--- a/src/client/src/app/lib/components/site-list.tsx
+++ b/src/client/src/app/lib/components/site-list.tsx
@@ -4,11 +4,18 @@ import { Site } from '@types';
 import { Card, TextInput } from '@nhsuk-frontend-components';
 import { sortSitesByName } from '@sorting';
 import { ChangeEvent, useState } from 'react';
-import _debounce from 'lodash.debounce';
 
 type Props = {
   sites: Site[];
 };
+
+function debounce<A extends unknown[]>(fn: (...a: A) => void, time: number) {
+  let timer: ReturnType<typeof setTimeout>;
+  return function (...args: A) {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), time);
+  };
+}
 
 const SiteList = ({ sites }: Props) => {
   const sortedSites = sites.toSorted(sortSitesByName);
@@ -29,7 +36,7 @@ const SiteList = ({ sites }: Props) => {
     }
   };
 
-  const debounceSearchHandler = _debounce(handleInputChange, 300);
+  const debounceSearchHandler = debounce(handleInputChange, 300);
 
   return (
     <Card title="Choose a site">

--- a/src/client/src/app/lib/components/site-list.tsx
+++ b/src/client/src/app/lib/components/site-list.tsx
@@ -1,7 +1,9 @@
+'use client';
 import Link from 'next/link';
 import { Site } from '@types';
-import { Card } from '@nhsuk-frontend-components';
+import { Card, TextInput } from '@nhsuk-frontend-components';
 import { sortSitesByName } from '@sorting';
+import { ChangeEvent, useState } from 'react';
 
 type Props = {
   sites: Site[];
@@ -9,11 +11,33 @@ type Props = {
 
 const SiteList = ({ sites }: Props) => {
   const sortedSites = sites.toSorted(sortSitesByName);
+  const [filteredSites, setFilteredSites] = useState(sortedSites);
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const searchInput = e.target.value.toLowerCase();
+    if (searchInput.length >= 3) {
+      setFilteredSites(
+        sortedSites.filter(
+          s =>
+            s.name.toLowerCase().includes(searchInput) ||
+            s.odsCode.toLowerCase() === searchInput,
+        ),
+      );
+    } else {
+      setFilteredSites(sortedSites);
+    }
+  };
 
   return (
     <Card title="Choose a site">
+      <TextInput
+        id="site-search"
+        aria-label="site-search"
+        placeholder="Search"
+        onChange={handleInputChange}
+      ></TextInput>
       <ul className="nhsuk-list nhsuk-list--border">
-        {sortedSites.map(s => (
+        {filteredSites.map(s => (
           <li key={s.id}>
             <Link
               aria-label={s.name}

--- a/src/client/src/app/lib/components/site-list.tsx
+++ b/src/client/src/app/lib/components/site-list.tsx
@@ -4,18 +4,11 @@ import { Site } from '@types';
 import { Card, TextInput } from '@nhsuk-frontend-components';
 import { sortSitesByName } from '@sorting';
 import { ChangeEvent, useState } from 'react';
+import { debounce } from '../utils/debounce';
 
 type Props = {
   sites: Site[];
 };
-
-function debounce<A extends unknown[]>(fn: (...a: A) => void, time: number) {
-  let timer: ReturnType<typeof setTimeout>;
-  return function (...args: A) {
-    clearTimeout(timer);
-    timer = setTimeout(() => fn(...args), time);
-  };
-}
 
 const SiteList = ({ sites }: Props) => {
   const sortedSites = sites.toSorted(sortSitesByName);

--- a/src/client/src/app/lib/utils/debounce.ts
+++ b/src/client/src/app/lib/utils/debounce.ts
@@ -1,0 +1,10 @@
+export function debounce<A extends unknown[]>(
+  fn: (...a: A) => void,
+  time: number,
+) {
+  let timer: ReturnType<typeof setTimeout>;
+  return function (...args: A) {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), time);
+  };
+}

--- a/src/client/testing/home.spec.ts
+++ b/src/client/testing/home.spec.ts
@@ -37,3 +37,23 @@ test('An admin user loads home page, all sites are loaded', async ({
     page.getByRole('link', { name: 'Robin Lane Medical Centre' }),
   ).toBeVisible();
 });
+
+test('A user loads home page and searches for a site, site list is filtered', async ({
+  page,
+}) => {
+  await oAuthPage.signIn(env.TEST_USERS.testUser6);
+  await expect(
+    page.getByRole('link', { name: 'Church Lane Pharmacy' }),
+  ).not.toBeVisible();
+  await expect(
+    page.getByRole('link', { name: 'Robin Lane Medical Centre' }),
+  ).toBeVisible();
+
+  const searchInput = page.getByRole('textbox', {
+    name: 'site-search',
+  });
+  await searchInput.fill('Church');
+  await expect(
+    page.getByRole('link', { name: 'Robin Lane Medical Centre' }),
+  ).not.toBeVisible();
+});

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesPreviewFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesPreviewFunctionTests.cs
@@ -92,8 +92,8 @@ public class GetSitesPreviewFunctionTests
             new(){ Role = "system:admin-user", Scope = "global" }
         };
         var sitesPreview = new SitePreview[] {
-            new("1", "Site1"),
-            new("2", "Site2")
+            new("1", "Site1", "ODS1"),
+            new("2", "Site2", "ODS2"),
         };
         _userContextProvider.Setup(x => x.UserPrincipal).Returns(testPrincipal);
         _userSiteAssignmentService.Setup(x => x.GetUserAsync("test@test.com")).ReturnsAsync(new User()


### PR DESCRIPTION
 ![image](https://github.com/user-attachments/assets/48493700-82c4-48b7-b032-54d6bf7af4f7)
![image](https://github.com/user-attachments/assets/0ee03040-0757-41ed-9f01-808c2b4851f0)
![image](https://github.com/user-attachments/assets/f220f348-7441-4e28-85a7-d83f4ffa652f)

Search bar for filtering sites:
- Requires at least 3 characters to be input before filtering
- Case insensitive
- Will match on ODS _only_ if it matches **exactly**. 
- Exposing the ODS code on the _sites-preview_ endpoint so we can filter on it
- There were no designs on the ticket itself for the search input so I've gone with this by using the existing TextBox component

Out of scope for APPT-525 but the _sites-preview_ endpoint will return all sites a user has permission to without pagination or without limiting the number of sites returned at a given time. It might be worth considering if we need to add this in at some point in the future, either for MVP or post-MVP

