### PR TITLE
APPT-588 - Bulk Import Endpoint

### DIFF
--- a/data/CosmosDbSeeder/items/local/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/local/core_data/global_roles.json
@@ -67,7 +67,8 @@
         "site:get-meta-data",
         "site:manage",
         "site:manage:admin",
-        "users:view"
+        "users:view",
+        "system:data-importer"
       ]
     },
     {
@@ -118,7 +119,9 @@
         "site:manage",
         "site:manage:admin",
         "system:run-reminders",
-        "system:run-provisional-sweep"
+        "system:run-provisional-sweep",
+        "system:admin-user",
+        "system:data-importer"
       ]
     },
     {

--- a/postman-collection/Bulk Import.postman_collection.json
+++ b/postman-collection/Bulk Import.postman_collection.json
@@ -1,0 +1,90 @@
+{
+	"info": {
+		"_postman_id": "03133b5f-b5e8-43f8-93ed-0e950486bb46",
+		"name": "Bulk Import",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "39091838"
+	},
+	"item": [
+		{
+			"name": "site/import",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{bearerToken}}",
+						"type": "text"
+					},
+					{
+						"key": "ClientId",
+						"value": "{{clientId}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "file",
+							"type": "file",
+							"src": []
+						}
+					]
+				},
+				"url": {
+					"raw": "{{baseUrl}}/api/site/import",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"api",
+						"site",
+						"import"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "user/import",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{bearerToken}}",
+						"type": "text"
+					},
+					{
+						"key": "ClientId",
+						"value": "{{clientId}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "",
+							"type": "file",
+							"src": []
+						}
+					]
+				},
+				"url": {
+					"raw": "{{baseUrl}}/api/user/import",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"api",
+						"user",
+						"import"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/src/api/Nhs.Appointments.Api/Auth/Permissions.cs
+++ b/src/api/Nhs.Appointments.Api/Auth/Permissions.cs
@@ -7,8 +7,9 @@ public static class Permissions
 {
     public const string SystemRunReminders = "system:run-reminders";
     public const string SystemRunProvisionalSweeper = "system:run-provisional-sweep";
-    
+    public const string SystemDataImporter = "system:data-importer";
     public const string ManageSiteAdmin = "site:manage:admin";
+
     public const string ManageSite = "site:manage";
     public const string ViewSite = "site:view";
     public const string ViewSitePreview = "site:view:preview";

--- a/src/api/Nhs.Appointments.Api/Constants/BulkImportType.cs
+++ b/src/api/Nhs.Appointments.Api/Constants/BulkImportType.cs
@@ -1,0 +1,7 @@
+namespace Nhs.Appointments.Api.Constants;
+internal static class BulkImportType
+{
+    public const string ApiUser = "apiUser";
+    public const string Site = "site";
+    public const string User = "user";
+}

--- a/src/api/Nhs.Appointments.Api/Factories/DataImportHandlerFactory.cs
+++ b/src/api/Nhs.Appointments.Api/Factories/DataImportHandlerFactory.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.DependencyInjection;
+using Nhs.Appointments.Core;
+using Nhs.Appointments.Core.Constants;
+using System;
+
+namespace Nhs.Appointments.Api.Factories;
+public class DataImportHandlerFactory(IServiceProvider serviceProvider) : IDataImportHandlerFactory
+{
+    public IDataImportHandler CreateDataImportHandler(string importType) => importType switch
+    {
+        BulkImportType.ApiUser => serviceProvider.GetService<IApiUserDataImportHandler>(),
+        BulkImportType.Site => serviceProvider.GetService<ISiteDataImportHandler>(),
+        BulkImportType.User => serviceProvider.GetService<IUserDataImportHandler>(),
+        _ => throw new NotSupportedException()
+    };
+}

--- a/src/api/Nhs.Appointments.Api/Factories/IDataImportHandlerFactory.cs
+++ b/src/api/Nhs.Appointments.Api/Factories/IDataImportHandlerFactory.cs
@@ -1,0 +1,7 @@
+using Nhs.Appointments.Core;
+
+namespace Nhs.Appointments.Api.Factories;
+public interface IDataImportHandlerFactory
+{
+    IDataImportHandler CreateDataImportHandler(string importType);
+}

--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Availability;
+using Nhs.Appointments.Api.Factories;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Json;
 using Nhs.Appointments.Api.Models;
@@ -83,6 +84,7 @@ public static class FunctionConfigurationExtensions
             .AddTransient<IUserDataImportHandler, UserDataImportHandler>()
             .AddTransient<ISiteDataImportHandler, SiteDataImporterHandler>()
             .AddTransient<IApiUserDataImportHandler, ApiUserDataImportHandler>()
+            .AddSingleton<IDataImportHandlerFactory, DataImportHandlerFactory>()
             .AddSingleton(TimeProvider.System)
             .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
             .AddUserNotifications()

--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -82,6 +82,7 @@ public static class FunctionConfigurationExtensions
             .AddTransient<IBookingEventFactory, EventFactory>()
             .AddTransient<IUserDataImportHandler, UserDataImportHandler>()
             .AddTransient<ISiteDataImportHandler, SiteDataImporterHandler>()
+            .AddTransient<IApiUserDataImportHandler, ApiUserDataImportHandler>()
             .AddSingleton(TimeProvider.System)
             .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
             .AddUserNotifications()

--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -84,7 +84,7 @@ public static class FunctionConfigurationExtensions
             .AddTransient<IUserDataImportHandler, UserDataImportHandler>()
             .AddTransient<ISiteDataImportHandler, SiteDataImporterHandler>()
             .AddTransient<IApiUserDataImportHandler, ApiUserDataImportHandler>()
-            .AddSingleton<IDataImportHandlerFactory, DataImportHandlerFactory>()
+            .AddTransient<IDataImportHandlerFactory, DataImportHandlerFactory>()
             .AddSingleton(TimeProvider.System)
             .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
             .AddUserNotifications()

--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -80,6 +80,8 @@ public static class FunctionConfigurationExtensions
             .AddTransient<IPermissionChecker, PermissionChecker>()
             .AddTransient<INotificationConfigurationService, NotificationConfigurationService>()
             .AddTransient<IBookingEventFactory, EventFactory>()
+            .AddTransient<IUserDataImportHandler, UserDataImportHandler>()
+            .AddTransient<ISiteDataImportHandler, SiteDataImporterHandler>()
             .AddSingleton(TimeProvider.System)
             .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
             .AddUserNotifications()

--- a/src/api/Nhs.Appointments.Api/Functions/BulkImportFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/BulkImportFunction.cs
@@ -13,8 +13,6 @@ using System.Threading.Tasks;
 using Nhs.Appointments.Core.Inspectors;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Routing;
-using System;
-using Nhs.Appointments.Core.Constants;
 using Nhs.Appointments.Api.Factories;
 
 namespace Nhs.Appointments.Api.Functions;

--- a/src/api/Nhs.Appointments.Api/Functions/BulkImportFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/BulkImportFunction.cs
@@ -20,9 +20,9 @@ namespace Nhs.Appointments.Api.Functions;
 public class BulkImportFunction(IDataImportHandlerFactory dataImportHandlerFactory, IValidator<BulkImportRequest> validator, IUserContextProvider userContextProvider, ILogger<SetAvailabilityFunction> logger, IMetricsRecorder metricsRecorder)
     : BaseApiFunction<BulkImportRequest, IEnumerable<ReportItem>>(validator, userContextProvider, logger, metricsRecorder)
 {
-    [OpenApiOperation(operationId: "Bulk User Import", tags: ["User"], Summary = "Bulk import users")]
+    [OpenApiOperation(operationId: "Bulk Import", tags: ["BulkImport"], Summary = "Bulk import of users and sites")]
     [OpenApiRequestBody("application/json", typeof(SetAvailabilityRequest), Required = true)]
-    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.OK, Description = "Users successfully imported")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.OK, Description = "Data successfully imported")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, "application/json", typeof(ErrorMessageResponseItem), Description = "The body of the request is invalid")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Unauthorized, "application/json", typeof(ErrorMessageResponseItem), Description = "Unauthorized request to a protected API")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Forbidden, "application/json", typeof(ErrorMessageResponseItem), Description = "Request failed due to insufficient permissions")]

--- a/src/api/Nhs.Appointments.Api/Functions/BulkImportFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/BulkImportFunction.cs
@@ -14,11 +14,11 @@ using Nhs.Appointments.Core.Inspectors;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Routing;
 using System;
-using Nhs.Appointments.Api.Constants;
+using Nhs.Appointments.Core.Constants;
 
 namespace Nhs.Appointments.Api.Functions;
 
-public class BulkSiteImportFunction(IUserDataImportHandler userDataImportHandler, ISiteDataImportHandler siteDataImportHandler, IApiUserDataImportHandler apiUserDataImportHandler,
+public class BulkImportFunction(IUserDataImportHandler userDataImportHandler, ISiteDataImportHandler siteDataImportHandler, IApiUserDataImportHandler apiUserDataImportHandler,
     IValidator<BulkImportRequest> validator, IUserContextProvider userContextProvider, ILogger<SetAvailabilityFunction> logger, IMetricsRecorder metricsRecorder)
     : BaseApiFunction<BulkImportRequest, IEnumerable<ReportItem>>(validator, userContextProvider, logger, metricsRecorder)
 {
@@ -28,9 +28,8 @@ public class BulkSiteImportFunction(IUserDataImportHandler userDataImportHandler
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, "application/json", typeof(ErrorMessageResponseItem), Description = "The body of the request is invalid")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Unauthorized, "application/json", typeof(ErrorMessageResponseItem), Description = "Unauthorized request to a protected API")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Forbidden, "application/json", typeof(ErrorMessageResponseItem), Description = "Request failed due to insufficient permissions")]
-    // TODO: Add new permission - data importer?
-    //[RequiresPermission(Permissions.SetupAvailability, typeof(NoSiteRequestInspector))]
-    [Function("BulkUserImportFunction")]
+    [RequiresPermission(Permissions.SystemDataImporter, typeof(NoSiteRequestInspector))]
+    [Function("BulkImportFunction")]
     public override Task<IActionResult> RunAsync(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "{type}/import")] HttpRequest req)
     {

--- a/src/api/Nhs.Appointments.Api/Functions/BulkImportFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/BulkImportFunction.cs
@@ -26,7 +26,7 @@ public class BulkImportFunction(IDataImportHandlerFactory dataImportHandlerFacto
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, "application/json", typeof(ErrorMessageResponseItem), Description = "The body of the request is invalid")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Unauthorized, "application/json", typeof(ErrorMessageResponseItem), Description = "Unauthorized request to a protected API")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Forbidden, "application/json", typeof(ErrorMessageResponseItem), Description = "Request failed due to insufficient permissions")]
-    //[RequiresPermission(Permissions.SystemDataImporter, typeof(NoSiteRequestInspector))]
+    [RequiresPermission(Permissions.SystemDataImporter, typeof(NoSiteRequestInspector))]
     [Function("BulkImportFunction")]
     public override Task<IActionResult> RunAsync(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "{type}/import")] HttpRequest req)

--- a/src/api/Nhs.Appointments.Api/Functions/SetAvailabilityFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/SetAvailabilityFunction.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;

--- a/src/api/Nhs.Appointments.Api/Models/BulkImportRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/BulkImportRequest.cs
@@ -1,0 +1,4 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Nhs.Appointments.Api.Models;
+public record BulkImportRequest(IFormFile File, string Type);

--- a/src/api/Nhs.Appointments.Api/Validators/BulkImportRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/BulkImportRequestValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using Nhs.Appointments.Api.Models;
+
+namespace Nhs.Appointments.Api.Validators;
+public class BulkImportRequestValidator : AbstractValidator<BulkImportRequest>
+{
+    public BulkImportRequestValidator()
+    {
+        RuleFor(x => x.File)
+            .NotEmpty()
+            .WithMessage("Provide a csv file.");
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Validators/BulkImportRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/BulkImportRequestValidator.cs
@@ -9,5 +9,9 @@ public class BulkImportRequestValidator : AbstractValidator<BulkImportRequest>
         RuleFor(x => x.File)
             .NotEmpty()
             .WithMessage("Provide a csv file.");
+
+        RuleFor(x => x.Type)
+            .NotEmpty()
+            .WithMessage("Provide an import type");
     }
 }

--- a/src/api/Nhs.Appointments.Core/ApiUserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/ApiUserDataImportHandler.cs
@@ -3,8 +3,6 @@ using Microsoft.AspNetCore.Http;
 
 namespace Nhs.Appointments.Core;
 
-public interface IApiUserDataImportHandler : IDataImportHandler { }
-
 public class ApiUserDataImportHandler(IUserService userService) : IApiUserDataImportHandler
 {
     public async Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile)

--- a/src/api/Nhs.Appointments.Core/ApiUserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/ApiUserDataImportHandler.cs
@@ -1,0 +1,55 @@
+using CsvHelper.Configuration;
+using Microsoft.AspNetCore.Http;
+
+namespace Nhs.Appointments.Core;
+
+public interface IApiUserDataImportHandler : IDataImportHandler { }
+
+public class ApiUserDataImportHandler(IUserService userService) : IApiUserDataImportHandler
+{
+    public async Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile)
+    {
+        var apiUserImportRows = new List<ApiUserImportRow>();
+        var processor = new CsvProcessor<ApiUserImportRow, ApiUserImportRowMap>(aui => Task.Run(() => apiUserImportRows.Add(aui)), aui => aui.ClientId);
+        using TextReader fileReader = new StreamReader(inputFile.OpenReadStream());
+        var report = (await processor.ProcessFile(fileReader)).ToList();
+
+        foreach (var apiUser in apiUserImportRows)
+        {
+            try
+            {
+                var userId = $"api@{apiUser.ClientId}";
+                var roleAssignments = new List<RoleAssignment>
+                {
+                    new() { Role = "system:api-user", Scope = "global" }
+                };
+                await userService.SaveUserAsync(userId, "global", roleAssignments);
+            }
+            catch (Exception ex)
+            {
+                report.Add(new ReportItem(-1, apiUser.ClientId, false, ex.Message));
+            }
+        }
+
+        return report;
+    }
+
+    private class ApiUserImportRow
+    {
+        public string ClientId { get; set; }
+        public string ApiSigningKey { get; set; }
+    }
+
+    private sealed class ApiUserImportRowMap : ClassMap<ApiUserImportRow>
+    {
+        public ApiUserImportRowMap()
+        {
+            Map(m => m.ClientId)
+                .Name("ClientId")
+                .Validate(f => !string.IsNullOrWhiteSpace(f.Field));
+            Map(m => m.ApiSigningKey)
+                .Name("ApiSigningKey")
+                .Validate(f => !string.IsNullOrWhiteSpace(f.Field));
+        }
+    }
+}

--- a/src/api/Nhs.Appointments.Core/Constants/BulkImportType.cs
+++ b/src/api/Nhs.Appointments.Core/Constants/BulkImportType.cs
@@ -1,5 +1,5 @@
-namespace Nhs.Appointments.Api.Constants;
-internal static class BulkImportType
+namespace Nhs.Appointments.Core.Constants;
+public static class BulkImportType
 {
     public const string ApiUser = "apiUser";
     public const string Site = "site";

--- a/src/api/Nhs.Appointments.Core/Constants/RegularExpressionConstants.cs
+++ b/src/api/Nhs.Appointments.Core/Constants/RegularExpressionConstants.cs
@@ -1,0 +1,17 @@
+using System.Text.RegularExpressions;
+
+namespace Nhs.Appointments.Core.Constants;
+public partial class RegularExpressionConstants
+{
+    private const string GbCulture = "en-GB";
+
+    private const string LandlineNumber =
+         @"^(?:(?:\(?(?:0(?:0|11)\)?[\s-]?\(?|\+)44\)?[\s-]?(?:\(?0\)?[\s-]?)?)|(?:\(?0))(?:(?:\d{5}\)?[\s-]?\d{4,5})|(?:\d{4}\)?[\s-]?(?:\d{5}|\d{3}[\s-]?\d{3}))|(?:\d{3}\)?[\s-]?\d{3}[\s-]?\d{3,4})|(?:\d{2}\)?[\s-]?\d{4}[\s-]?\d{4}))(?:[\s-]?(?:x|ext\.?|\#)\d{3,4})?$";
+    private const string MobileNumber = @"^\s*07(?=\d{9,11}(\s*)$)[\d]+(?:\s[\d]+)*\s*$|^(?(?=(\s*(\+\(44\)|\(\+44\)|\+44)))\s*(\+\(44\)|\(\+44\)|\+44)\s?((07|7)(?=\d{9,11}(\s*)$)[\d]+(?:\s[\d]+)*\s*)|(?(?=(\s*(\+\(\d{2}\)|\(\+\d{2}\)|\+\d{2})))(\s*(\+\(\d{2}\)|\(\+\d{2}\)|\+\d{2}))\s?(?=.{8,19}(\s*)$)[\d]+(?:\s[\d]+)*\s*))$";
+
+    [GeneratedRegex(LandlineNumber, RegexOptions.IgnoreCase, GbCulture)]
+    public static partial Regex LandlineNumberRegex();
+
+    [GeneratedRegex(MobileNumber, RegexOptions.IgnoreCase, GbCulture)]
+    public static partial Regex MobileNumberRegex();
+}

--- a/src/api/Nhs.Appointments.Core/CsvProcessor.cs
+++ b/src/api/Nhs.Appointments.Core/CsvProcessor.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+
+namespace Nhs.Appointments.Core;
+
+public class CsvProcessor<TDocument, TMap>(
+    Func<TDocument, Task> processRow,
+    Func<TDocument, string> getItemName)
+    where TMap : ClassMap
+{
+    public async Task<IEnumerable<ReportItem>> ProcessFile(TextReader csvReader)
+    {
+        var index = -1;
+        var report = new List<ReportItem>();
+
+        var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            HasHeaderRecord = true,
+            ShouldSkipRecord = args =>
+            {
+                index++;
+                return false;
+            },
+            ReadingExceptionOccurred = args =>
+            {
+                report.Add(new ReportItem(index, "", false, args.Exception.ToString()));
+
+                return false;
+            },
+            BadDataFound = args =>
+            {
+                report.Add(new ReportItem(index, "", false, $"Bad data found in field '{args.Field}'"));
+            },
+            Delimiter = ",",
+            Quote = '"'
+        };
+
+        using (var csv = new CsvReader(csvReader, config))
+        {
+            csv.Context.RegisterClassMap<TMap>();
+
+            var imported = csv.GetRecords<TDocument>();
+
+            foreach (var item in imported)
+            {
+                try
+                {
+                    await processRow(item);
+                    report.Add(new ReportItem(index, getItemName(item), true, ""));
+                }
+                catch (Exception ex)
+                {
+                    report.Add(new ReportItem(index, getItemName(item), false, ex.Message));
+                }
+            }
+        }
+
+        return report.ToArray();
+    }
+}

--- a/src/api/Nhs.Appointments.Core/IDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/IDataImportHandler.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Nhs.Appointments.Core;
+
+public interface IDataImportHandler
+{
+    Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile);
+}
+
+public interface IApiUserDataImportHandler : IDataImportHandler { }
+public interface ISiteDataImportHandler : IDataImportHandler { }
+public interface IUserDataImportHandler : IDataImportHandler { }

--- a/src/api/Nhs.Appointments.Core/ISiteStore.cs
+++ b/src/api/Nhs.Appointments.Core/ISiteStore.cs
@@ -14,4 +14,7 @@ public interface ISiteStore
     Task AssignPrefix(string site, int prefix);
     Task<int> GetReferenceNumberGroup(string site);
     Task<IEnumerable<Site>> GetAllSites();
+
+    Task<OperationResult> SaveSiteAsync(string siteId, string odsCode, string name, string address, string phoneNumber,
+        string icb, string region, Location location, IEnumerable<Accessibility> accessibilities);
 }

--- a/src/api/Nhs.Appointments.Core/IUserService.cs
+++ b/src/api/Nhs.Appointments.Core/IUserService.cs
@@ -1,4 +1,4 @@
-﻿namespace Nhs.Appointments.Core;
+namespace Nhs.Appointments.Core;
 
 public interface IUserService
 {
@@ -8,4 +8,5 @@ public interface IUserService
     Task<UpdateUserRoleAssignmentsResult> UpdateUserRoleAssignmentsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
     Task<IEnumerable<User>> GetUsersAsync(string site);
     Task<OperationResult> RemoveUserAsync(string userId, string site);
+    Task SaveUserAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
 }

--- a/src/api/Nhs.Appointments.Core/Nhs.Appointments.Core.csproj
+++ b/src/api/Nhs.Appointments.Core/Nhs.Appointments.Core.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
+		<PackageReference Include="CsvHelper" Version="33.0.1" />
 		<PackageReference Include="MassTransit" Version="8.3.5" />
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
 		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.45.2" />

--- a/src/api/Nhs.Appointments.Core/ReportItem.cs
+++ b/src/api/Nhs.Appointments.Core/ReportItem.cs
@@ -1,0 +1,4 @@
+namespace Nhs.Appointments.Core;
+public record ReportItem(int Index, string Name, bool Success, string Message)
+{
+}

--- a/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
@@ -31,7 +31,7 @@ public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodes
                 if (!wellKnownOdsCodes.Contains(site.OdsCode))
                 {
                     report.Add(new ReportItem(-1, site.OdsCode, false, $"Provided site ODS code: {site.OdsCode} not found in the well known ODS code list."));
-                    break;
+                    continue;
                 }
 
                 await siteService.SaveSiteAsync(

--- a/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
@@ -17,7 +17,7 @@ public class SiteDataImporterHandler(ISiteService siteService) : ISiteDataImport
         {
             try
             {
-                // TODO: Check the OdsCodes exists in the well known ODS codes list?
+                // TODO: Check the OdsCodes exists in the well known ODS codes list before adding?
                 await siteService.SaveSiteAsync(
                     site.Id,
                     site.OdsCode,

--- a/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
@@ -17,6 +17,7 @@ public class SiteDataImporterHandler(ISiteService siteService) : ISiteDataImport
         {
             try
             {
+                // TODO: Check the OdsCodes exists in the well known ODS codes list?
                 await siteService.SaveSiteAsync(
                     site.Id,
                     site.OdsCode,

--- a/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Nhs.Appointments.Core;
+
+public interface ISiteDataImportHandler : IDataImportHandler { }
+
+public class SiteDataImporterHandler(ISiteService siteService) : ISiteDataImportHandler
+{
+    public async Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile)
+    {
+        var siteRows = new List<SiteImportRow>();
+        var processor = new CsvProcessor<SiteImportRow, SiteMap>(sr => Task.Run(() => siteRows.Add(sr)), sr => sr.Id);
+        using TextReader fileReader = new StreamReader(inputFile.OpenReadStream());
+        var report = (await processor.ProcessFile(fileReader)).ToList();
+
+        foreach (var site in siteRows)
+        {
+            try
+            {
+                await siteService.SaveSiteAsync(
+                    site.Id,
+                    site.OdsCode,
+                    site.Name,
+                    site.Address,
+                    site.PhoneNumber,
+                    site.ICB,
+                    site.Region,
+                    site.Location,
+                    site.Accessibilities);
+            }
+            catch (Exception ex)
+            {
+                report.Add(new ReportItem(-1, site.Id, false, ex.Message));
+            }
+        }
+
+        return report;
+    }
+
+    public class SiteImportRow
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Address { get; set; }
+        public string PhoneNumber { get; set; }
+        public string OdsCode { get; set; }
+        public string Region { get; set; }
+        public string ICB { get; set; }
+        public Location Location { get; set; }
+        public IEnumerable<Accessibility> Accessibilities { get; set; }
+    }
+}

--- a/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
@@ -2,8 +2,6 @@ using Microsoft.AspNetCore.Http;
 
 namespace Nhs.Appointments.Core;
 
-public interface ISiteDataImportHandler : IDataImportHandler { }
-
 public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodesService wellKnowOdsCodesService) : ISiteDataImportHandler
 {
     public async Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile)

--- a/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
@@ -15,19 +15,21 @@ public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodes
             .Where(s => s.Count() > 1)
             .Select(s => s.Key).ToList();
 
+        List<ReportItem> invalidRowReport = [];
         if (duplicateIds.Count > 0)
         {
-            report.Clear();
-            report.AddRange(duplicateIds.Select(dup => new ReportItem(-1, dup, false, $"Duplicate site Id provided: {dup}. SiteIds must be unique.")));
-            return report;
+            invalidRowReport.AddRange(duplicateIds.Select(dup => new ReportItem(-1, dup, false, $"Duplicate site Id provided: {dup}. SiteIds must be unique.")));
         }
 
         var invalidOdsCodes = await GetSitesWithInvalidOdsCodes(siteRows);
         if (invalidOdsCodes.Count > 0)
         {
-            report.Clear();
-            report.AddRange(invalidOdsCodes.Select(ods => new ReportItem(-1, ods, false, $"Provided site ODS code: {ods} not found in the well known ODS code list.")));
-            return report;
+            invalidRowReport.AddRange(invalidOdsCodes.Select(ods => new ReportItem(-1, ods, false, $"Provided site ODS code: {ods} not found in the well known ODS code list.")));
+        }
+
+        if (invalidRowReport.Count > 0)
+        {
+            return invalidRowReport;
         }
 
         foreach (var site in siteRows)

--- a/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
@@ -13,6 +13,13 @@ public class SiteDataImporterHandler(ISiteService siteService) : ISiteDataImport
         using TextReader fileReader = new StreamReader(inputFile.OpenReadStream());
         var report = (await processor.ProcessFile(fileReader)).ToList();
 
+        var distinctIds = siteRows.GroupBy(s => s.Id).Count();
+        if (siteRows.Count != distinctIds)
+        {
+            report.Add(new ReportItem(-1, "Duplicate side IDs", false, "Document contains duplicated siteIds. These IDs must be unique."));
+            return report;
+        }
+
         foreach (var site in siteRows)
         {
             try

--- a/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/SiteDataImporterHandler.cs
@@ -14,6 +14,7 @@ public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodes
         var distinctIds = siteRows.GroupBy(s => s.Id).Count();
         if (siteRows.Count != distinctIds)
         {
+            report.Clear();
             report.Add(new ReportItem(-1, "Duplicate site IDs", false, "Document contains duplicated siteIds. These IDs must be unique."));
             return report;
         }
@@ -26,10 +27,10 @@ public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodes
         {
             try
             {
-                // TODO: Should be break in this case? Or skip over this site and carry on with the rest?
+                // TODO: Should we break in this case? Or skip over this site and carry on with the rest?
                 if (!wellKnownOdsCodes.Contains(site.OdsCode))
                 {
-                    report.Add(new ReportItem(-1, site.OdsCode, false, "Provided site ODS not found in the well known ODS code list."));
+                    report.Add(new ReportItem(-1, site.OdsCode, false, $"Provided site ODS code: {site.OdsCode} not found in the well known ODS code list."));
                     break;
                 }
 

--- a/src/api/Nhs.Appointments.Core/SiteMap.cs
+++ b/src/api/Nhs.Appointments.Core/SiteMap.cs
@@ -1,0 +1,69 @@
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+using static Nhs.Appointments.Core.SiteDataImporterHandler;
+
+namespace Nhs.Appointments.Core;
+
+public class SiteMap : ClassMap<SiteImportRow>
+{
+    public SiteMap()
+    {
+        var accessibilityKeys = new[]
+        {
+            "accessible_toilet",
+            "braille_translation_service",
+            "disabled_car_parking",
+            "car_parking",
+            "induction_loop",
+            "sign_language_service",
+            "step_free_access",
+            "text_relay",
+            "wheelchair_access"
+        };
+
+        //validate ID provided is a GUID
+        Map(m => m.Id).TypeConverter<GuidStringTypeConverter>();
+        Map(m => m.OdsCode).Name("OdsCode");
+        Map(m => m.Name).Name("Name");
+        Map(m => m.Address).Name("Address");
+        Map(m => m.PhoneNumber).Name("PhoneNumber");
+        Map(m => m.Location).Convert(x =>
+            new Location(
+                "Point",
+                [x.Row.GetField<double>("Longitude"), x.Row.GetField<double>("Latitude")]
+            ));
+        Map(m => m.ICB).Name("ICB");
+        Map(m => m.Region).Name("Region");
+        Map(m => m.Accessibilities).Convert(x =>
+        {
+            return accessibilityKeys
+                .Select(key => new Accessibility($"accessibility/{key}",
+                    ParseUserEnteredBoolean(x.Row[key]).ToString()))
+                .ToArray();
+        });
+    }
+
+    private static bool ParseUserEnteredBoolean(string possibleBool)
+    {
+        possibleBool = possibleBool?.ToLower();
+        return possibleBool == "true" || possibleBool == "yes";
+    }
+
+    /// <summary>
+    /// Custom TypeConverter to validate a string GUID
+    /// </summary>
+    private class GuidStringTypeConverter : DefaultTypeConverter
+    {
+        public override object ConvertFromString(string guidString, IReaderRow row, MemberMapData memberMapData)
+        {
+            if (Guid.TryParse(guidString, out var guid))
+            {
+                return guid.ToString();
+            }
+
+            throw new TypeConverterException(this, memberMapData, guidString, row.Context,
+                $"Invalid GUID string format: {guidString}");
+        }
+    }
+}

--- a/src/api/Nhs.Appointments.Core/SiteMap.cs
+++ b/src/api/Nhs.Appointments.Core/SiteMap.cs
@@ -1,6 +1,7 @@
 using CsvHelper;
 using CsvHelper.Configuration;
 using CsvHelper.TypeConversion;
+using Nhs.Appointments.Core.Constants;
 using static Nhs.Appointments.Core.SiteDataImporterHandler;
 
 namespace Nhs.Appointments.Core;
@@ -36,7 +37,7 @@ public class SiteMap : ClassMap<SiteImportRow>
             .Validate(f => StringHasValue(f.Field));
         Map(m => m.PhoneNumber)
             .Name("PhoneNumber")
-            .Validate(f => StringHasValue(f.Field));
+            .Validate(f => StringHasValue(f.Field) && IsValidPhoneNumber(f.Field));
         Map(m => m.Location).Convert(x =>
             new Location(
                 "Point",
@@ -60,8 +61,16 @@ public class SiteMap : ClassMap<SiteImportRow>
 
     private static bool ParseUserEnteredBoolean(string possibleBool)
     {
-        possibleBool = possibleBool?.ToLower();
-        return possibleBool == "true" || possibleBool == "yes";
+        return !bool.TryParse(possibleBool, out var result)
+            ? throw new FormatException($"Invalid bool string format: {possibleBool}")
+            : result;
+    }
+
+    private static bool IsValidPhoneNumber(string phoneNumber)
+    {
+        return !string.IsNullOrWhiteSpace(phoneNumber)
+            && (RegularExpressionConstants.LandlineNumberRegex().IsMatch(phoneNumber)
+            || RegularExpressionConstants.MobileNumberRegex().IsMatch(phoneNumber));
     }
 
     /// <summary>

--- a/src/api/Nhs.Appointments.Core/SiteMap.cs
+++ b/src/api/Nhs.Appointments.Core/SiteMap.cs
@@ -23,18 +23,30 @@ public class SiteMap : ClassMap<SiteImportRow>
         };
 
         //validate ID provided is a GUID
-        Map(m => m.Id).TypeConverter<GuidStringTypeConverter>();
-        Map(m => m.OdsCode).Name("OdsCode");
-        Map(m => m.Name).Name("Name");
-        Map(m => m.Address).Name("Address");
-        Map(m => m.PhoneNumber).Name("PhoneNumber");
+        Map(m => m.Id)
+            .TypeConverter<GuidStringTypeConverter>();
+        Map(m => m.OdsCode)
+            .Name("OdsCode")
+            .Validate(f => StringHasValue(f.Field));
+        Map(m => m.Name)
+            .Name("Name")
+            .Validate(f => StringHasValue(f.Field));
+        Map(m => m.Address)
+            .Name("Address")
+            .Validate(f => StringHasValue(f.Field));
+        Map(m => m.PhoneNumber)
+            .Name("PhoneNumber")
+            .Validate(f => StringHasValue(f.Field));
         Map(m => m.Location).Convert(x =>
             new Location(
                 "Point",
                 [x.Row.GetField<double>("Longitude"), x.Row.GetField<double>("Latitude")]
             ));
-        Map(m => m.ICB).Name("ICB");
-        Map(m => m.Region).Name("Region");
+        Map(m => m.ICB)
+            .Name("ICB")
+            .Validate(f => StringHasValue(f.Field));
+        Map(m => m.Region).Name("Region")
+            .Validate(f => StringHasValue(f.Field));
         Map(m => m.Accessibilities).Convert(x =>
         {
             return accessibilityKeys
@@ -43,6 +55,8 @@ public class SiteMap : ClassMap<SiteImportRow>
                 .ToArray();
         });
     }
+
+    private static bool StringHasValue(string value) => !string.IsNullOrWhiteSpace(value);
 
     private static bool ParseUserEnteredBoolean(string possibleBool)
     {

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -15,6 +15,9 @@ public interface ISiteService
         decimal latitude, decimal longitude);
 
     Task<OperationResult> UpdateSiteReferenceDetailsAsync(string siteId, string odsCode, string icb, string region);
+
+    Task<OperationResult> SaveSiteAsync(string siteId, string odsCode, string name, string address, string phoneNumber,
+        string icb, string region, Location location, IEnumerable<Accessibility> accessibilities);
 }
 
 public class SiteService(ISiteStore siteStore, IMemoryCache memoryCache, TimeProvider time) : ISiteService
@@ -76,6 +79,19 @@ public class SiteService(ISiteStore siteStore, IMemoryCache memoryCache, TimePro
 
         return sites.Select(s => new SitePreview(s.Id, s.Name, s.OdsCode));
     }
+
+    public async Task<OperationResult> SaveSiteAsync(string siteId, string odsCode, string name, string address, string phoneNumber, string icb,
+        string region, Location location, IEnumerable<Accessibility> accessibilities)
+            => await siteStore.SaveSiteAsync(
+                siteId,
+                odsCode,
+                name,
+                address,
+                phoneNumber,
+                icb,
+                region,
+                location,
+                accessibilities);
 
     public Task<OperationResult> UpdateAccessibilities(string siteId, IEnumerable<Accessibility> accessibilities) 
     {

--- a/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
@@ -29,6 +29,7 @@ public class UserDataImportHandler(IUserService userService) : IUserDataImportHa
                 var roleAssignments = userAssignmentGroup
                     .SelectMany(ua => rolesToAssign
                     .Select(r => new RoleAssignment { Role = r, Scope = $"site:{ua.SiteId}" }));
+                // TODO: We can use the UpdateUserRoleAssignmentsAsync method, but this sends out notifications - do we want this initially?
                 await userService.SaveUserAsync(userAssignmentGroup.Key, "site", roleAssignments);
             }
             catch (Exception ex)

--- a/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
@@ -3,13 +3,6 @@ using Microsoft.AspNetCore.Http;
 
 namespace Nhs.Appointments.Core;
 
-public interface IDataImportHandler
-{
-    Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile);
-}
-
-public interface IUserDataImportHandler : IDataImportHandler { }
-
 public class UserDataImportHandler(IUserService userService, ISiteService siteService) : IUserDataImportHandler
 {
     public async Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile)

--- a/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
@@ -25,6 +25,7 @@ public class UserDataImportHandler(IUserService userService) : IUserDataImportHa
         {
             try
             {
+                // TODO: Should we check the site actually exists?
                 var roleAssignments = userAssignmentGroup
                     .SelectMany(ua => rolesToAssign
                     .Select(r => new RoleAssignment { Role = r, Scope = $"site:{ua.SiteId}" }));
@@ -49,8 +50,12 @@ public class UserDataImportHandler(IUserService userService) : IUserDataImportHa
     {
         public UserImportRowMap()
         {
-            Map(m => m.UserId).Name("User");
-            Map(m => m.SiteId).Name("Site");
+            Map(m => m.UserId)
+                .Name("User")
+                .Validate(f => !string.IsNullOrWhiteSpace(f.Field));
+            Map(m => m.SiteId)
+                .Name("Site")
+                .Validate(f => !string.IsNullOrWhiteSpace(f.Field));
         }
     }
 }

--- a/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
@@ -1,0 +1,56 @@
+using CsvHelper.Configuration;
+using Microsoft.AspNetCore.Http;
+
+namespace Nhs.Appointments.Core;
+
+public interface IDataImportHandler
+{
+    Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile);
+}
+
+public interface IUserDataImportHandler : IDataImportHandler { }
+
+public class UserDataImportHandler(IUserService userService) : IUserDataImportHandler
+{
+    public async Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile)
+    {
+        var userImportRows = new List<UserImportRow>();
+        var processor = new CsvProcessor<UserImportRow, UserImportRowMap>(ui => Task.Run(() => userImportRows.Add(ui)), ui => ui.UserId);
+        using TextReader fileReader = new StreamReader(inputFile.OpenReadStream());
+        var report = (await processor.ProcessFile(fileReader)).ToList();
+
+        string[] rolesToAssign = ["canned:site-details-manager", "canned:user-manager", "canned:availability-manager", "canned:appointment-manager"];
+
+        foreach (var userAssignmentGroup in userImportRows.GroupBy(usr => usr.UserId))
+        {
+            try
+            {
+                var roleAssignments = userAssignmentGroup
+                    .SelectMany(ua => rolesToAssign
+                    .Select(r => new RoleAssignment { Role = r, Scope = $"site:{ua.SiteId}" }));
+                await userService.SaveUserAsync(userAssignmentGroup.Key, "site", roleAssignments);
+            }
+            catch (Exception ex)
+            {
+                report.Add(new ReportItem(-1, userAssignmentGroup.Key, false, ex.Message));
+            }
+        }
+
+        return report;
+    }
+
+    private class UserImportRow
+    {
+        public string UserId { get; set; }
+        public string SiteId { get; set; }
+    }
+
+    private class UserImportRowMap : ClassMap<UserImportRow>
+    {
+        public UserImportRowMap()
+        {
+            Map(m => m.UserId).Name("User");
+            Map(m => m.SiteId).Name("Site");
+        }
+    }
+}

--- a/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
@@ -26,6 +26,7 @@ public class UserDataImportHandler(IUserService userService, ISiteService siteSe
 
         if (incorrectSiteIds.Count > 0)
         {
+            report.Clear();
             report.Add(new ReportItem(-1, "Incorrect Site IDs", false, $"The sites with these IDs don't currently exist in the system. {string.Join(',', incorrectSiteIds)}"));
             return report;
         }

--- a/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
@@ -26,7 +26,7 @@ public class UserDataImportHandler(IUserService userService, ISiteService siteSe
 
         if (incorrectSiteIds.Count > 0)
         {
-            report.Add(new ReportItem(-1, "Incorrect Site IDs", false, $"The sites with these IDs don't currently exist in the system. {String.Join(',', incorrectSiteIds)}"));
+            report.Add(new ReportItem(-1, "Incorrect Site IDs", false, $"The sites with these IDs don't currently exist in the system. {string.Join(',', incorrectSiteIds)}"));
             return report;
         }
 

--- a/src/api/Nhs.Appointments.Core/UserService.cs
+++ b/src/api/Nhs.Appointments.Core/UserService.cs
@@ -1,4 +1,4 @@
-﻿using Nhs.Appointments.Core.Messaging;
+using Nhs.Appointments.Core.Messaging;
 using Nhs.Appointments.Core.Messaging.Events;
 
 namespace Nhs.Appointments.Core;
@@ -48,6 +48,9 @@ public class UserService(IUserStore userStore, IRolesStore rolesStore, IMessageB
     {
         return userStore.RemoveUserAsync(userId, site);
     }
+
+    public Task SaveUserAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
+        => userStore.SaveUserAsync(userId, scope, roleAssignments);
 }
 
 public record UpdateUserRoleAssignmentsResult(bool success, string errorUser, IEnumerable<string> errorRoles)

--- a/src/api/Nhs.Appointments.Persistance/CosmosAutoMapperProfile.cs
+++ b/src/api/Nhs.Appointments.Persistance/CosmosAutoMapperProfile.cs
@@ -29,8 +29,7 @@ public class CosmosAutoMapperProfile : Profile
         CreateMap<UserDocument, User>()
             .ForMember(x => x.LatestAcceptedEulaVersion, opt => opt.AllowNull())
             .ForMember(x => x.RoleAssignments, opt => opt.MapFrom(src => src.RoleAssignments));
-        CreateMap<SiteDocument, Site>()
-            .ReverseMap();
+        CreateMap<SiteDocument, Site>();
 
         CreateMap<NotificationConfigurationItem, NotificationConfiguration>();
 

--- a/src/api/Nhs.Appointments.Persistance/CosmosAutoMapperProfile.cs
+++ b/src/api/Nhs.Appointments.Persistance/CosmosAutoMapperProfile.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
 
@@ -29,7 +29,8 @@ public class CosmosAutoMapperProfile : Profile
         CreateMap<UserDocument, User>()
             .ForMember(x => x.LatestAcceptedEulaVersion, opt => opt.AllowNull())
             .ForMember(x => x.RoleAssignments, opt => opt.MapFrom(src => src.RoleAssignments));
-        CreateMap<SiteDocument, Site>();
+        CreateMap<SiteDocument, Site>()
+            .ReverseMap();
 
         CreateMap<NotificationConfigurationItem, NotificationConfiguration>();
 

--- a/src/api/Nhs.Appointments.Persistance/SiteStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/SiteStore.cs
@@ -108,4 +108,35 @@ public class SiteStore(ITypedDocumentCosmosStore<SiteDocument> cosmosStore) : IS
             return default;
         }
     }
+
+    public async Task<OperationResult> SaveSiteAsync(string siteId, string odsCode, string name, string address, string phoneNumber,
+        string icb, string region, Location location, IEnumerable<Accessibility> accessibilities)
+    {
+        var originalDocument = await GetOrDefault(siteId);
+        if (originalDocument is null)
+        {
+            var site = new SiteDocument
+            {
+                Id = siteId,
+                OdsCode = odsCode,
+                Name = name,
+                Address = address,
+                PhoneNumber = phoneNumber,
+                DocumentType = "site",
+                Accessibilities = accessibilities.ToArray(),
+                InformationForCitizens = string.Empty,
+                IntegratedCareBoard = icb,
+                Location = location,
+                Region = region,
+            };
+            var document = cosmosStore.ConvertToDocument(site);
+            await cosmosStore.WriteAsync(document);
+
+            return new OperationResult(true);
+        }
+        else
+        {
+            return new OperationResult(false, "The site already exists.");
+        }
+    }
 }

--- a/src/api/Nhs.Appointments.Persistance/SiteStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/SiteStore.cs
@@ -136,7 +136,12 @@ public class SiteStore(ITypedDocumentCosmosStore<SiteDocument> cosmosStore) : IS
         }
         else
         {
-            return new OperationResult(false, "The site already exists.");
+            var updateSite = UpdateSiteDetails(siteId, name, address, phoneNumber, (decimal)location.Coordinates[0], (decimal)location.Coordinates[1]);
+            var updateAccessiblities = UpdateAccessibilities(siteId, accessibilities);
+
+            await Task.WhenAll(updateSite, updateAccessiblities);
+
+            return new OperationResult(true);
         }
     }
 }

--- a/tests/CsvDataTool.UnitTests/CsvProcessorTests.cs
+++ b/tests/CsvDataTool.UnitTests/CsvProcessorTests.cs
@@ -446,7 +446,7 @@ public class CsvProcessorTests
         actualSiteDocuments.Should().HaveCount(1);
 
         report.Count().Should().Be(2);
-        report.First().Message.Should().StartWith($"CsvHelper.TypeConversion.TypeConverterException: The conversion cannot be performed.\n    Text: 'foo'");
+        report.First().Message.Should().StartWith($"CsvHelper.TypeConversion.TypeConverterException: The conversion cannot be performed.\r\n    Text: 'foo'");
         report.Count(r => r.Success).Should().Be(1);
         report.Count(r => !r.Success).Should().Be(1);
     }

--- a/tests/CsvDataTool.UnitTests/CsvProcessorTests.cs
+++ b/tests/CsvDataTool.UnitTests/CsvProcessorTests.cs
@@ -446,7 +446,9 @@ public class CsvProcessorTests
         actualSiteDocuments.Should().HaveCount(1);
 
         report.Count().Should().Be(2);
-        report.First().Message.Should().StartWith($"CsvHelper.TypeConversion.TypeConverterException: The conversion cannot be performed.\r\n    Text: 'foo'");
+        report.First().Message
+            .Should().Contain($"CsvHelper.TypeConversion.TypeConverterException: The conversion cannot be performed.")
+            .And.Contain("Text: 'foo'");
         report.Count(r => r.Success).Should().Be(1);
         report.Count(r => !r.Success).Should().Be(1);
     }

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/BulkImportFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/BulkImportFunctionTests.cs
@@ -1,0 +1,152 @@
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Nhs.Appointments.Api.Factories;
+using Nhs.Appointments.Api.Functions;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Core;
+using Nhs.Appointments.Core.UnitTests;
+using System.Text;
+
+namespace Nhs.Appointments.Api.Tests.Functions;
+public class BulkImportFunctionTests
+{
+    private readonly Mock<IDataImportHandlerFactory> _mockDataImportFactory = new();
+    private readonly Mock<IValidator<BulkImportRequest>> _mockValidator = new();
+    private readonly Mock<IUserContextProvider> _mockUserContextProvider = new();
+    private readonly Mock<ILogger<BulkImportFunction>> _mockLogger = new();
+    private readonly Mock<IMetricsRecorder> _mockMetricsRecorder = new();
+    private readonly Mock<ISiteDataImportHandler> _mockSiteDataImporter = new();
+    private readonly Mock<IUserDataImportHandler> _mockUserDataImporter = new();
+
+    private readonly BulkImportFunction _sut;
+
+    public BulkImportFunctionTests()
+    {
+        _sut = new BulkImportFunction(
+            _mockDataImportFactory.Object,
+            _mockValidator.Object,
+            _mockUserContextProvider.Object,
+            _mockLogger.Object,
+            _mockMetricsRecorder.Object);
+
+        _mockValidator.Setup(x => x.ValidateAsync(It.IsAny<BulkImportRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ValidationResult());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsBadRequest_WhenNoFilesSent()
+    {
+        var request = CreateBadRequest_NoFiles();
+
+        var response = await _sut.RunAsync(request) as ContentResult;
+
+        response.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsBadRequest_WhenMultipleFilesSent()
+    {
+        var request = CreateBadRequest_MultipleFiles();
+
+        var response = await _sut.RunAsync(request) as ContentResult;
+
+        response.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task RunAsync_UploadsSiteInformation()
+    {
+        string[] inputRows =
+        [
+            "ferfgsd,site1,\"test site 1\",\"123 test street\",\"01234 567890\",1.0,60.0,\"test icb1\",\"Yorkshire\",,true,True,False,false,\"true\",false,true,true,false",
+            "sadfsdafsdf,site2,\"test site 2\",\"123 test street\",\"01234 567890\",1.0,60.0,\"test icb2\",\"Yorkshire\",,true,True,False,false,\"true\",false,true,true,false"
+        ];
+
+        var input = CsvFileBuilder.BuildInputCsv("SiteHeaders", inputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var request = CreateDefaultRequest();
+        request.Form = new FormCollection([], new FormFileCollection { file });
+
+        _mockDataImportFactory.Setup(x => x.CreateDataImportHandler(It.IsAny<string>()))
+            .Returns(_mockSiteDataImporter.Object);
+        _mockSiteDataImporter.Setup(x => x.ProcessFile(It.IsAny<IFormFile>()))
+            .ReturnsAsync(new List<ReportItem>
+            {
+                new(0, "Test 1", true, "")
+            });
+
+        var response = await _sut.RunAsync(request) as ContentResult;
+
+        response.StatusCode.Should().Be(200);
+
+        _mockSiteDataImporter.Verify(x => x.ProcessFile(It.IsAny<IFormFile>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_UploadsUserInformation()
+    {
+        string[] inputRows =
+        [
+            "test1@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test1@nhs.net,308d515c-2002-450e-b248-4ba36f6667bb",
+            "test2@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test2@nhs.net,9a06bacd-e916-4c10-8263-21451ca751b8",
+        ];
+
+        var input = CsvFileBuilder.BuildInputCsv("SiteHeaders", inputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var request = CreateDefaultRequest();
+        request.Form = new FormCollection([], new FormFileCollection { file });
+
+        _mockDataImportFactory.Setup(x => x.CreateDataImportHandler(It.IsAny<string>()))
+            .Returns(_mockUserDataImporter.Object);
+        _mockUserDataImporter.Setup(x => x.ProcessFile(It.IsAny<IFormFile>()))
+            .ReturnsAsync(new List<ReportItem>
+            {
+                new(0, "Test 1", true, "")
+            });
+
+        var response = await _sut.RunAsync(request) as ContentResult;
+
+        response.StatusCode.Should().Be(200);
+
+        _mockUserDataImporter.Verify(x => x.ProcessFile(It.IsAny<IFormFile>()), Times.Once);
+    }
+
+    private static HttpRequest CreateBadRequest_MultipleFiles()
+    {
+        var request = CreateDefaultRequest();
+        var file = new FormFile(new MemoryStream(Encoding.UTF8.GetBytes("This is a dummy file")), 0, 0, "Data", "dummy.csv");
+        var file2 = new FormFile(new MemoryStream(Encoding.UTF8.GetBytes("This is another dummy file")), 0, 0, "Data", "dummy2.csv");
+        request.Form = new FormCollection([], new FormFileCollection { file, file2 });
+        return request;
+    }
+
+    private static HttpRequest CreateBadRequest_NoFiles()
+    {
+        var request = CreateDefaultRequest();
+        request.Form = new FormCollection([], new FormFileCollection());
+        return request;
+    }
+
+    private static HttpRequest CreateDefaultRequest()
+    {
+        var context = new DefaultHttpContext();
+        var request = context.Request;
+        request.Headers.Append("Content-Type", "multipart/form-data;");
+        request.Headers.Append("Authorization", "Test 123");
+        return request;
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/BulkImportRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/BulkImportRequestValidatorTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Api.Validators;
+using Nhs.Appointments.Core.UnitTests;
+using System.Text;
+
+namespace Nhs.Appointments.Api.Tests.Validators;
+
+public class BulkImportRequestValidatorTests
+{
+    private readonly BulkImportRequestValidator _sut = new();
+
+    [Fact]
+    public void ShouldFailValidation_WhenFileNotProvided()
+    {
+        var request = new BulkImportRequest(null, "test");
+
+        var result = _sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Count.Should().Be(1);
+    }
+    
+    [Fact]
+    public void ShouldFailValidation_WhenTypeNotProvided()
+    {
+        var request = new BulkImportRequest(GetFile(), string.Empty);
+
+        var result = _sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void ShouldPassValidation()
+    {
+        var request = new BulkImportRequest(GetFile(), "test");
+
+        var result = _sut.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    private static FormFile GetFile()
+    {
+        string[] inputRows =
+        [
+            "test1@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test1@nhs.net,308d515c-2002-450e-b248-4ba36f6667bb",
+            "test2@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test2@nhs.net,9a06bacd-e916-4c10-8263-21451ca751b8",
+        ];
+
+        var input = CsvFileBuilder.BuildInputCsv("User,Site", inputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        return new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/ApiUserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/ApiUserDataImportHandlerTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http.Internal;
+using System.Text;
+
+namespace Nhs.Appointments.Core.UnitTests;
+public class ApiUserDataImportHandlerTests
+{
+    private readonly Mock<IUserService> _userServiceMock = new();
+
+    private readonly ApiUserDataImportHandler _sut;
+    private const string ApiUserHeader = "ClientId,ApiSigningKey";
+
+    public ApiUserDataImportHandlerTests()
+    {
+        _sut = new ApiUserDataImportHandler(_userServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task CanReadApiUserData()
+    {
+        string[] inputRows =
+        [
+            "test1,ABC123",
+            "test2,DEF345"
+        ];
+
+        var input = CsvFileBuilder.BuildInputCsv(ApiUserHeader, inputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var report = await _sut.ProcessFile(file);
+
+        report.Count().Should().Be(2);
+        report.All(r => r.Success).Should().BeTrue();
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/CsvFileBuilder.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/CsvFileBuilder.cs
@@ -1,7 +1,7 @@
 using System.Text;
 
 namespace Nhs.Appointments.Core.UnitTests;
-internal static class CsvFileBuilder
+public static class CsvFileBuilder
 {
     public static string BuildInputCsv(string header, IEnumerable<string> dataLines)
     {

--- a/tests/Nhs.Appointments.Core.UnitTests/CsvFileBuilder.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/CsvFileBuilder.cs
@@ -1,0 +1,17 @@
+using System.Text;
+
+namespace Nhs.Appointments.Core.UnitTests;
+internal static class CsvFileBuilder
+{
+    public static string BuildInputCsv(string header, IEnumerable<string> dataLines)
+    {
+        var result = new StringBuilder(header);
+        result.Append("\r\n");
+        foreach (var line in dataLines)
+        {
+            result.Append($"{line}\r\n");
+        }
+
+        return result.ToString();
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/SiteDataImporterHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/SiteDataImporterHandlerTests.cs
@@ -93,7 +93,9 @@ public class SiteDataImporterHandlerTests
 
         report.Count().Should().Be(2);
         report.All(r => r.Success ).Should().BeFalse();
-        report.First().Message.Should().StartWith($"CsvHelper.TypeConversion.TypeConverterException: The conversion cannot be performed.\r\n    Text: 'foo'");
+        report.First().Message
+            .Should().Contain($"CsvHelper.TypeConversion.TypeConverterException: The conversion cannot be performed.")
+            .And.Contain("Text: 'foo'");
     }
 
     [Fact]

--- a/tests/Nhs.Appointments.Core.UnitTests/SiteDataImporterHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/SiteDataImporterHandlerTests.cs
@@ -114,6 +114,13 @@ public class SiteDataImporterHandlerTests
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
         var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
 
+        _wellKnownOdsCodesServiceMock.Setup(x => x.GetWellKnownOdsCodeEntries())
+            .ReturnsAsync(new List<WellKnownOdsEntry>
+            {
+                new("site1", "Site 1", "Test1"),
+                new("site2", "Site 2", "Test2"),
+            });
+
         var report = await _sut.ProcessFile(file);
 
         report.Count().Should().Be(1);

--- a/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
@@ -52,9 +52,9 @@ public class UserDataImportHandlerTests
 
         var report = await _sut.ProcessFile(file);
 
-        report.Count().Should().Be(5);
+        report.Count().Should().Be(1);
         report.All(r => r.Success).Should().BeFalse();
-        report.Last().Message.Should().Be("The sites with these IDs don't currently exist in the system. d3793464-b421-41f3-9bfa-53b06e7b3d19,308d515c-2002-450e-b248-4ba36f6667bb,9a06bacd-e916-4c10-8263-21451ca751b8");
+        report.First().Message.Should().Be("The sites with these IDs don't currently exist in the system. d3793464-b421-41f3-9bfa-53b06e7b3d19,308d515c-2002-450e-b248-4ba36f6667bb,9a06bacd-e916-4c10-8263-21451ca751b8");
     }
 
     private List<Site> GetSites()

--- a/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
@@ -18,25 +18,12 @@ public class UserDataImportHandlerTests
     [Fact]
     public async Task CanReadUserData()
     {
-        string[] inputRows =
-        [
-            "test1@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
-            "test1@nhs.net,308d515c-2002-450e-b248-4ba36f6667bb",
-            "test2@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
-            "test2@nhs.net,9a06bacd-e916-4c10-8263-21451ca751b8",
-        ];
-
-        var input = CsvFileBuilder.BuildInputCsv(UsersHeader, inputRows);
+        var input = CsvFileBuilder.BuildInputCsv(UsersHeader, InputRows);
 
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
         var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
 
-        var sites = new List<Site>();
-
-        foreach (var row in inputRows)
-        {
-            sites.Add(new Site(row.Split(',')[1], "Test", "Test Address", "07777777777", "ABC123", "Test Region", "ICB", "", [], new Location("Test", [1.0, 60.0])));
-        }
+        var sites = GetSites();
 
         _siteServiceMock.SetupSequence(s => s.GetSiteByIdAsync(It.IsAny<string>(), "*"))
             .ReturnsAsync(sites[0])
@@ -50,5 +37,43 @@ public class UserDataImportHandlerTests
         report.All(r => r.Success).Should().BeTrue();
     }
 
-    // TODO: Add test around incorrect siteIds
+    [Fact]
+    public async Task ReportsIncorrectSiteId_WhenNotFound()
+    {
+        var input = CsvFileBuilder.BuildInputCsv(UsersHeader, InputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var sites = GetSites();
+
+        _siteServiceMock.Setup(s => s.GetSiteByIdAsync(It.IsAny<string>(), "*"))
+            .ReturnsAsync(null as Site);
+
+        var report = await _sut.ProcessFile(file);
+
+        report.Count().Should().Be(5);
+        report.All(r => r.Success).Should().BeFalse();
+        report.Last().Message.Should().Be("The sites with these IDs don't currently exist in the system. d3793464-b421-41f3-9bfa-53b06e7b3d19,308d515c-2002-450e-b248-4ba36f6667bb,9a06bacd-e916-4c10-8263-21451ca751b8");
+    }
+
+    private List<Site> GetSites()
+    {
+        var sites = new List<Site>();
+
+        foreach (var row in InputRows)
+        {
+            sites.Add(new Site(row.Split(',')[1], "Test", "Test Address", "07777777777", "ABC123", "Test Region", "ICB", "", [], new Location("Test", [1.0, 60.0])));
+        }
+
+        return sites;
+    }
+
+    private readonly string[] InputRows =
+        [
+            "test1@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test1@nhs.net,308d515c-2002-450e-b248-4ba36f6667bb",
+            "test2@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test2@nhs.net,9a06bacd-e916-4c10-8263-21451ca751b8",
+        ];
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Http.Internal;
+using System.Text;
+
+namespace Nhs.Appointments.Core.UnitTests;
+public class UserDataImportHandlerTests
+{
+    private readonly Mock<IUserService> _userServiceMock = new();
+    private readonly Mock<ISiteService> _siteServiceMock = new();
+
+    private readonly UserDataImportHandler _sut;
+    private const string UsersHeader = "User,Site";
+
+    public UserDataImportHandlerTests()
+    {
+        _sut = new UserDataImportHandler(_userServiceMock.Object, _siteServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task CanReadUserData()
+    {
+        string[] inputRows =
+        [
+            "test1@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test1@nhs.net,308d515c-2002-450e-b248-4ba36f6667bb",
+            "test2@nhs.net,d3793464-b421-41f3-9bfa-53b06e7b3d19",
+            "test2@nhs.net,9a06bacd-e916-4c10-8263-21451ca751b8",
+        ];
+
+        var input = CsvFileBuilder.BuildInputCsv(UsersHeader, inputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var sites = new List<Site>();
+
+        foreach (var row in inputRows)
+        {
+            sites.Add(new Site(row.Split(',')[1], "Test", "Test Address", "07777777777", "ABC123", "Test Region", "ICB", "", [], new Location("Test", [1.0, 60.0])));
+        }
+
+        _siteServiceMock.SetupSequence(s => s.GetSiteByIdAsync(It.IsAny<string>(), "*"))
+            .ReturnsAsync(sites[0])
+            .ReturnsAsync(sites[1])
+            .ReturnsAsync(sites[2])
+            .ReturnsAsync(sites[3]);
+
+        var report = await _sut.ProcessFile(file);
+
+        report.Count().Should().Be(4);
+        report.All(r => r.Success).Should().BeTrue();
+    }
+
+    // TODO: Add test around incorrect siteIds
+}


### PR DESCRIPTION
- A new bulk import endpoint that supports importing users / sites / API users
- The new endpoint requires us to use Bearer authentication instead of HMAC, so there is a new postman collection specifically for this new endpoint as there is a pre-release script for the _Appointments Service_ postman collection which can't read the contents of the .csv files for the new endpoint resulting in a signature mismatch and a 401 response
- There is some basic validation for both user and site csv files themselves e.g. does the field have a value / is the value a valid boolean
- There are further checks once we've mapped the contents of the csv file. 
- Sites - for siteIds we check to make sure they are distinct and that the ODS Code is present in the well known ODS codes document store
- Users - I've added a check to make sure the siteId provided exists in the site document store before we add the user
- A new permission required to access the endpoint - `system:data-importer`

There are a couple of TODOs we need to iron out that are still in the code and a couple of other things:
- Removal of the CsvDataTool from the solution in a separate PR. There is some code duplication from there - the CsvProcessor was lifted from it. Remove that later once we've made sure this solution has been tested first.
- We need a test bearer token for this endpoint in postman against local and dev environments - also applies for integration testing which isn't included in this PR. 
- Integration tests to be added once the above is sorted
