### PR TITLE
Appt 502/Permission refactor

### DIFF
--- a/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
@@ -11,6 +11,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -23,6 +24,7 @@
         "booking:cancel",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -34,6 +36,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
         "site:get-meta-data"
       ]
@@ -46,6 +49,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "users:manage",
         "users:view",
         "site:get-meta-data"
@@ -62,6 +66,7 @@
         "booking:query",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -74,7 +79,8 @@
         "availability:query",
         "booking:query",
         "users:view",
-        "site:view"
+        "site:view",
+        "site:view:preview"
       ]
     },
     {
@@ -85,7 +91,10 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data",
+        "site:manage",
+        "site:manage:admin",
         "users:view"
       ]
     },
@@ -105,7 +114,9 @@
         "users:view",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
+        "site:manage:admin",
         "system:run-reminders",
         "system:run-provisional-sweep"
       ]

--- a/data/CosmosDbSeeder/items/int/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/int/core_data/global_roles.json
@@ -11,6 +11,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -23,6 +24,7 @@
         "booking:cancel",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -34,6 +36,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
         "site:get-meta-data"
       ]
@@ -46,6 +49,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "users:manage",
         "users:view",
         "site:get-meta-data"
@@ -62,6 +66,7 @@
         "booking:query",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -73,7 +78,10 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data",
+        "site:manage",
+        "site:manage:admin",
         "users:view"
       ]
     },
@@ -93,7 +101,9 @@
         "users:view",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
+        "site:manage:admin",
         "system:run-reminders",
         "system:run-provisional-sweep"
       ]

--- a/data/CosmosDbSeeder/items/local/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/local/core_data/global_roles.json
@@ -11,6 +11,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -23,6 +24,7 @@
         "booking:cancel",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -34,6 +36,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
         "site:get-meta-data"
       ]
@@ -46,6 +49,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "users:manage",
         "users:view",
         "site:get-meta-data"
@@ -56,11 +60,13 @@
       "name": "Admin User",
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
-        "system:admin-user",
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data",
+        "site:manage",
+        "site:manage:admin",
         "users:view"
       ]
     },
@@ -75,6 +81,7 @@
         "booking:query",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -87,7 +94,8 @@
         "availability:query",
         "booking:query",
         "users:view",
-        "site:view"
+        "site:view",
+        "site:view:preview"
       ]
     },
     {
@@ -106,10 +114,11 @@
         "users:view",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
+        "site:manage:admin",
         "system:run-reminders",
-        "system:run-provisional-sweep",
-        "system:admin-user"
+        "system:run-provisional-sweep"
       ]
     },
     {
@@ -127,10 +136,11 @@
         "users:view",
         "sites:query",
         "site:view",
+        "site:view:preview",
+        "site:manage:admin",
         "site:manage",
         "system:run-reminders",
-        "system:run-provisional-sweep",
-        "system:admin-user"
+        "system:run-provisional-sweep"
       ]
     }
   ]

--- a/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
@@ -11,6 +11,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -23,6 +24,7 @@
         "booking:cancel",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -34,6 +36,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
         "site:get-meta-data"
       ]
@@ -46,6 +49,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "users:manage",
         "users:view",
         "site:get-meta-data"
@@ -62,6 +66,7 @@
         "booking:query",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -81,7 +86,9 @@
         "users:view",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
+        "site:manage:admin",
         "system:run-reminders",
         "system:run-provisional-sweep"
       ]

--- a/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
@@ -11,6 +11,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -23,6 +24,7 @@
         "booking:cancel",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -34,6 +36,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
         "site:get-meta-data"
       ]
@@ -46,6 +49,7 @@
         "availability:query",
         "booking:query",
         "site:view",
+        "site:view:preview",
         "users:manage",
         "users:view",
         "site:get-meta-data"
@@ -62,6 +66,7 @@
         "booking:query",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:get-meta-data"
       ]
     },
@@ -81,7 +86,9 @@
         "users:view",
         "sites:query",
         "site:view",
+        "site:view:preview",
         "site:manage",
+        "site:manage:admin",
         "system:run-reminders",
         "system:run-provisional-sweep"
       ]

--- a/src/api/Nhs.Appointments.Api/Auth/IPermissionChecker.cs
+++ b/src/api/Nhs.Appointments.Api/Auth/IPermissionChecker.cs
@@ -1,10 +1,28 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Nhs.Appointments.Core;
 
 namespace Nhs.Appointments.Api.Auth;
 
 public interface IPermissionChecker
 {
     Task<bool> HasPermissionAsync(string userId, IEnumerable<string> siteIds, string requiredPermission);
+    
+    /// <summary>
+    /// Checks if the user has the required permission globally (i.e for all sites)
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="requiredPermission"></param>
+    /// <returns></returns>
+    Task<bool> HasGlobalPermissionAsync(string userId, string requiredPermission);
+    
+    /// <summary>
+    /// Returns all site Ids that the user has the permission for.
+    /// </summary>
+    /// <param name="userId"></param>
+    /// <param name="requiredPermission"></param>
+    /// <returns>SiteId list</returns>
+    Task<IEnumerable<string>> GetSitesWithPermissionAsync(string userId, string requiredPermission);
+    
     Task<IEnumerable<string>> GetPermissionsAsync(string userId, string siteId);
 }

--- a/src/api/Nhs.Appointments.Api/Auth/PermissionChecker.cs
+++ b/src/api/Nhs.Appointments.Api/Auth/PermissionChecker.cs
@@ -7,48 +7,90 @@ using Nhs.Appointments.Core;
 
 namespace Nhs.Appointments.Api.Auth;
 
-public class PermissionChecker(IUserService userService, IRolesService rolesService, IMemoryCache cache) : IPermissionChecker
+public class PermissionChecker(IUserService userService, IRolesService rolesService, IMemoryCache cache)
+    : IPermissionChecker
 {
     public async Task<bool> HasPermissionAsync(string userId, IEnumerable<string> siteIds, string requiredPermission)
-    {                
+    {
         var globalPermissions = await GetFilteredPermissionsAsync(userId, ra => ra.Scope == "global");
         if (globalPermissions.Contains(requiredPermission))
+        {
             return true;
+        }
 
         foreach (var siteId in siteIds)
         {
             var usersPermissions = await GetFilteredPermissionsAsync(userId, ra => ra.Scope == $"site:{siteId}");
             if (usersPermissions.Contains(requiredPermission) == false)
+            {
                 return false;
+            }
         }
+
+        return siteIds.Any();
+    }
+
+    public async Task<bool> HasGlobalPermissionAsync(string userId, string requiredPermission)
+    {
+        var globalPermissions = await GetFilteredPermissionsAsync(userId, ra => ra.Scope == "global");
+        return globalPermissions.Contains(requiredPermission);
+    }
+
+    public async Task<IEnumerable<string>> GetSitesWithPermissionAsync(string userId, string requiredPermission)
+    {
+        var siteIds = new List<string>();
         
-        return siteIds.Any();        
+        var userRoleAssignments = await GetUserRoleAssignmentsAsync(userId);
+
+        var distinctSiteRoles = userRoleAssignments.Where(ra => ra.Scope.StartsWith("site:")).Distinct();
+
+        foreach (var siteRole in distinctSiteRoles)
+        {
+            var usersPermissions = await GetFilteredPermissionsAsync(userId, ra => ra.Scope == siteRole.Scope && ra.Role == siteRole.Role);
+
+            if (usersPermissions.Contains(requiredPermission))
+            {
+                siteIds.Add(siteRole.Scope.Replace("site:", ""));
+            }
+        }
+
+        return siteIds.Distinct();
     }
 
     public Task<IEnumerable<string>> GetPermissionsAsync(string userId, string siteId)
     {
-        Func<RoleAssignment, bool> filter = string.IsNullOrEmpty(siteId) ? ra => ra.Scope == "global" : ra => ra.Scope == "global" || ra.Scope == $"site:{siteId}";
+        Func<RoleAssignment, bool> filter = string.IsNullOrEmpty(siteId)
+            ? ra => ra.Scope == "global"
+            : ra => ra.Scope == "global" || ra.Scope == $"site:{siteId}";
         return GetFilteredPermissionsAsync(userId, filter);
     }
 
-    private async Task<IEnumerable<string>> GetFilteredPermissionsAsync(string userId, Func<RoleAssignment, bool> filter)
+    private async Task<IEnumerable<string>> GetFilteredPermissionsAsync(string userId,
+        Func<RoleAssignment, bool> filter)
     {
-        var roles = await GetRolesAsync();
-        var userRoleAssignments = await GetUserRoleAssignmentsAsync(userId);
-        
-        var userRoles = userRoleAssignments.Where(filter).Select(ra => ra.Role);
-        return roles.Where(r => userRoles.Contains(r.Id)).SelectMany(r => r.Permissions).Distinct();
+        var rolesTask = GetRolesAsync();
+        var userRoleAssignmentsTask = GetUserRoleAssignmentsAsync(userId);
+
+        await Task.WhenAll(rolesTask, userRoleAssignmentsTask);
+
+        var userRoles = userRoleAssignmentsTask.Result.Where(filter).Select(ra => ra.Role);
+        return rolesTask.Result.Where(r => userRoles.Contains(r.Id)).SelectMany(r => r.Permissions).Distinct();
     }
 
     private async Task<IEnumerable<RoleAssignment>> GetUserRoleAssignmentsAsync(string userId)
     {
         var cacheKey = $"user_roles_{userId}";
         if (cache.TryGetValue(cacheKey, out List<RoleAssignment> cachedRoleAssignments))
+        {
             return cachedRoleAssignments;
+        }
 
         var userRoleAssignmentsOp = await TryPattern.TryAsync(() => userService.GetUserRoleAssignments(userId));
         if (userRoleAssignmentsOp.Completed == false)
-            return Enumerable.Empty<RoleAssignment>();
+        {
+            return [];
+        }
+
         var userRoleAssignments = userRoleAssignmentsOp.Result.ToList();
         cache.Set(cacheKey, userRoleAssignments, TimeSpan.FromSeconds(20));
         return userRoleAssignments;
@@ -56,12 +98,17 @@ public class PermissionChecker(IUserService userService, IRolesService rolesServ
 
     private async Task<IEnumerable<Role>> GetRolesAsync()
     {
-        if(cache.TryGetValue("roles", out List<Role> cachedRoles))
+        if (cache.TryGetValue("roles", out List<Role> cachedRoles))
+        {
             return cachedRoles;
+        }
+
         var rolesOp = await TryPattern.TryAsync(rolesService.GetRoles);
         if (rolesOp.Completed == false)
-            return Enumerable.Empty<Role>();
-        
+        {
+            return [];
+        }
+
         var roles = rolesOp.Result.ToList();
         cache.Set("roles", roles, TimeSpan.FromMinutes(5));
         return roles;

--- a/src/api/Nhs.Appointments.Api/Auth/Permissions.cs
+++ b/src/api/Nhs.Appointments.Api/Auth/Permissions.cs
@@ -5,12 +5,13 @@ namespace Nhs.Appointments.Api.Auth;
 /// </summary>
 public static class Permissions
 {
-    public const string SystemAdmin = "system:admin-user";
     public const string SystemRunReminders = "system:run-reminders";
     public const string SystemRunProvisionalSweeper = "system:run-provisional-sweep";
     
+    public const string ManageSiteAdmin = "site:manage:admin";
     public const string ManageSite = "site:manage";
     public const string ViewSite = "site:view";
+    public const string ViewSitePreview = "site:view:preview";
     public const string ViewSiteMetadata = "site:get-meta-data";
     public const string QuerySites = "sites:query";
     

--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesPreviewFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesPreviewFunction.cs
@@ -1,48 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
+using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-using Nhs.Appointments.Api.Auth;
 
 namespace Nhs.Appointments.Api.Functions;
-public class GetSitesPreviewFunction(ISiteService siteService, IUserService userService, IValidator<EmptyRequest> validator, IUserContextProvider userContextProvider, ILogger<GetSitesPreviewFunction> logger, IMetricsRecorder metricsRecorder)
+
+public class GetSitesPreviewFunction(
+    ISiteService siteService,
+    IUserService userService,
+    IValidator<EmptyRequest> validator,
+    IUserContextProvider userContextProvider,
+    ILogger<GetSitesPreviewFunction> logger,
+    IMetricsRecorder metricsRecorder,
+    IPermissionChecker permissionChecker)
     : BaseApiFunction<EmptyRequest, IEnumerable<SitePreview>>(validator, userContextProvider, logger, metricsRecorder)
 {
-
-
-
-    [OpenApiOperation(operationId: "GetSitesPreview", tags: ["Site"], Summary = "Gets preview of sites available to user")] 
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, "application/json", typeof(IEnumerable<SitePreview>), Description = "Users preview sites")]
+    [OpenApiOperation(operationId: "GetSitesPreview", tags: ["Site"],
+        Summary = "Gets preview of sites available to user")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, "application/json", typeof(IEnumerable<SitePreview>),
+        Description = "Users preview sites")]
     [Function("GetSitesPreviewFunction")]
     public override Task<IActionResult> RunAsync(
-      [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "sites-preview")] HttpRequest req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "sites-preview")]
+        HttpRequest req)
     {
         return base.RunAsync(req);
     }
 
-    protected override async Task<ApiResult<IEnumerable<SitePreview>>> HandleRequest(EmptyRequest request, ILogger logger)
+    protected override async Task<ApiResult<IEnumerable<SitePreview>>> HandleRequest(EmptyRequest request,
+        ILogger logger)
     {
         var userEmail = Principal.Claims.GetUserEmail();
 
         var user = await userService.GetUserAsync(userEmail);
         if (user is null)
         {
-            return Success(Enumerable.Empty<SitePreview>());
+            return Success([]);
         }
 
         var sitesResult = new List<SitePreview>();
 
-        if (IsAdminUser(user))
+        if (await permissionChecker.HasGlobalPermissionAsync(user.Id, Permissions.ViewSitePreview))
         {
             var allSites = await siteService.GetSitesPreview();
 
@@ -53,13 +60,15 @@ public class GetSitesPreviewFunction(ISiteService siteService, IUserService user
         }
         else
         {
-            var siteIdsForUser = user.RoleAssignments.Where(ra => ra.Scope.StartsWith("site:")).Select(ra => ra.Scope.Replace("site:", ""));
+            var siteIds = await permissionChecker.GetSitesWithPermissionAsync(user.Id, Permissions.ViewSitePreview);
 
-            foreach (var site in siteIdsForUser.Distinct())
+            foreach (var siteId in siteIds)
             {
-                var siteInfo = await siteService.GetSiteByIdAsync(site);
+                var siteInfo = await siteService.GetSiteByIdAsync(siteId);
                 if (siteInfo != null)
+                {
                     sitesResult.Add(new SitePreview(siteInfo.Id, siteInfo.Name, siteInfo.OdsCode));
+                }
             }
         }
 
@@ -69,10 +78,5 @@ public class GetSitesPreviewFunction(ISiteService siteService, IUserService user
     protected override Task<IEnumerable<ErrorMessageResponseItem>> ValidateRequest(EmptyRequest request)
     {
         return Task.FromResult(Enumerable.Empty<ErrorMessageResponseItem>());
-    }
-
-    private bool IsAdminUser(User user)
-    {
-        return user.RoleAssignments.Any(ra => ra.Role == Permissions.SystemAdmin);
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/SetSiteReferenceDetailsFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/SetSiteReferenceDetailsFunction.cs
@@ -36,7 +36,7 @@ public class SetSiteReferenceDetailsFunction(
         typeof(ErrorMessageResponseItem), Description = "Unauthorized request to a protected API")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Forbidden, "application/json", typeof(ErrorMessageResponseItem),
         Description = "Request failed due to insufficient permissions")]
-    [RequiresPermission(Permissions.SystemAdmin, typeof(SiteFromPathInspector))]
+    [RequiresPermission(Permissions.ManageSiteAdmin, typeof(SiteFromPathInspector))]
     [RequiresAudit(typeof(SiteFromPathInspector))]
     [Function("SetSiteReferenceDetailsFunction")]
     public override Task<IActionResult> RunAsync(

--- a/src/client/src/app/site/[site]/details/edit-reference-details/page.tsx
+++ b/src/client/src/app/site/[site]/details/edit-reference-details/page.tsx
@@ -10,7 +10,7 @@ export type PageProps = {
 };
 
 const Page = async ({ params }: PageProps) => {
-  await assertPermission(params.site, 'system:admin-user');
+  await assertPermission(params.site, 'site:manage:admin');
 
   const backLink: NavigationByHrefProps = {
     renderingStrategy: 'server',

--- a/src/client/src/app/site/[site]/details/site-details-page.tsx
+++ b/src/client/src/app/site/[site]/details/site-details-page.tsx
@@ -38,7 +38,7 @@ const SiteDetailsPage = async ({
         {siteReferenceSummaryData && (
           <SummaryList {...siteReferenceSummaryData}></SummaryList>
         )}
-        {permissions.includes('system:admin-user') ? (
+        {permissions.includes('site:manage:admin') ? (
           <Link
             href={`/site/${site.id}/details/edit-reference-details`}
             className="nhsuk-link"

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -509,12 +509,12 @@ public abstract partial class BaseFeatureSteps : Feature
                         Permissions.QuerySites,
                         Permissions.ViewSiteMetadata,
                         Permissions.ViewSite,
+                        Permissions.ViewSitePreview,
                         Permissions.ManageSite,
                         Permissions.QueryAvailability,
                         Permissions.SetupAvailability,
                         Permissions.SystemRunProvisionalSweeper,
-                        Permissions.SystemRunReminders,
-                        Permissions.SystemAdmin,
+                        Permissions.SystemRunReminders
                     ]
                 },
                 new Role
@@ -524,7 +524,7 @@ public abstract partial class BaseFeatureSteps : Feature
                     Description = "A user can create, view, and manage site availability.",
                     Permissions =
                     [
-                        Permissions.SetupAvailability, Permissions.QueryAvailability, Permissions.QueryBooking, Permissions.ViewSite, Permissions.ViewSiteMetadata
+                        Permissions.SetupAvailability, Permissions.QueryAvailability, Permissions.QueryBooking, Permissions.ViewSite, Permissions.ViewSitePreview, Permissions.ViewSiteMetadata
                     ]
                 },
                 new Role
@@ -533,7 +533,7 @@ public abstract partial class BaseFeatureSteps : Feature
                     Name = "Appointment manager",
                     Description = "A user can view and cancel appointments.",
                     Permissions =
-                        [Permissions.QueryAvailability, Permissions.CancelBooking, Permissions.QueryBooking, Permissions.ViewSite, Permissions.ViewSiteMetadata]
+                        [Permissions.QueryAvailability, Permissions.CancelBooking, Permissions.QueryBooking, Permissions.ViewSite, Permissions.ViewSitePreview, Permissions.ViewSiteMetadata]
                 },
                 new Role
                 {
@@ -541,7 +541,7 @@ public abstract partial class BaseFeatureSteps : Feature
                     Name = "Site details manager",
                     Description = "A user can edit site details and accessibility information.",
                     Permissions =
-                        [Permissions.QueryAvailability, Permissions.QueryBooking, Permissions.ViewSite, Permissions.ManageSite, Permissions.ViewSiteMetadata]
+                        [Permissions.QueryAvailability, Permissions.QueryBooking, Permissions.ViewSite, Permissions.ViewSitePreview, Permissions.ManageSite, Permissions.ViewSiteMetadata]
                 },
             ]
         };

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesPreviewFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesPreviewFunctionTests.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
+using Nhs.Appointments.Api.Auth;
 
 namespace Nhs.Appointments.Api.Tests.Functions;
 public class GetSitesPreviewFunctionTests
@@ -23,12 +24,13 @@ public class GetSitesPreviewFunctionTests
     private readonly Mock<IValidator<EmptyRequest>> _validator = new();
     private readonly Mock<IUserContextProvider> _userContextProvider = new();
     private readonly Mock<ILogger<GetSitesPreviewFunction>> _logger = new();
+    private readonly Mock<IPermissionChecker> _permissionChecker = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
     private GetSitesPreviewFunction _sut;
 
     public GetSitesPreviewFunctionTests()
     {
-        _sut = new GetSitesPreviewFunction(_siteService.Object, _userSiteAssignmentService.Object, _validator.Object, _userContextProvider.Object, _logger.Object, _metricsRecorder.Object);
+        _sut = new GetSitesPreviewFunction(_siteService.Object, _userSiteAssignmentService.Object, _validator.Object, _userContextProvider.Object, _logger.Object, _metricsRecorder.Object, _permissionChecker.Object);
     }
 
     [Fact]
@@ -102,6 +104,7 @@ public class GetSitesPreviewFunctionTests
             RoleAssignments = roleAssignments
         });
         _siteService.Setup(x => x.GetSitesPreview()).ReturnsAsync(sitesPreview);
+        _permissionChecker.Setup(x => x.HasGlobalPermissionAsync("test@test.com", Permissions.ViewSitePreview)).ReturnsAsync(true);
 
         var response = await _sut.RunAsync(request) as ContentResult;
         var actualResponse = await ReadResponseAsync<IEnumerable<SitePreview>>(response.Content);
@@ -120,7 +123,7 @@ public class GetSitesPreviewFunctionTests
         var roleAssignments = new RoleAssignment[] {
             new(){ Role = "Role1", Scope = "site:1" }
         };
-        var site = new Site(
+        var site1 = new Site(
             Id: "1",
             Name: "Alpha",
             Address: "somewhere",
@@ -132,24 +135,57 @@ public class GetSitesPreviewFunctionTests
             Accessibilities: new[] { new Accessibility(Id: "accessibility/attr_1", Value: "true") },
             Location: new Location("point", [0.1, 10])
         );
-
-
+        
+        var site2 = new Site(
+            Id: "2",
+            Name: "Beta",
+            Address: "somewhere",
+            PhoneNumber: "0113 22222222",
+            OdsCode: "odsCode2",
+            Region: "R1",
+            IntegratedCareBoard: "ICB1",
+            InformationForCitizens: "Information For Citizens 123456",
+            Accessibilities: new[] { new Accessibility(Id: "accessibility/attr_1", Value: "true") },
+            Location: new Location("point", [0.1, 10])
+        );
+        
+        var site3 = new Site(
+            Id: "3",
+            Name: "Gamma",
+            Address: "somewhere",
+            PhoneNumber: "0113 333333",
+            OdsCode: "odsCode3",
+            Region: "R1",
+            IntegratedCareBoard: "ICB1",
+            InformationForCitizens: "Information For Citizens 123456",
+            Accessibilities: new[] { new Accessibility(Id: "accessibility/attr_1", Value: "true") },
+            Location: new Location("point", [0.1, 10])
+        );
+        
         _userContextProvider.Setup(x => x.UserPrincipal).Returns(testPrincipal);
         _userSiteAssignmentService.Setup(x => x.GetUserAsync("test@test.com")).ReturnsAsync(new User()
         {
             Id = "test@test.com",
             RoleAssignments = roleAssignments
         });
-        _siteService.Setup(x => x.GetSiteByIdAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(site);
+        
+        _siteService.Setup(x => x.GetSiteByIdAsync(site1.Id, It.IsAny<string>())).ReturnsAsync(site1);
+        _siteService.Setup(x => x.GetSiteByIdAsync(site2.Id, It.IsAny<string>())).ReturnsAsync(site2);
+        _siteService.Setup(x => x.GetSiteByIdAsync(site3.Id, It.IsAny<string>())).ReturnsAsync(site3);
+        
+        _permissionChecker.Setup(x=> x.GetSitesWithPermissionAsync("test@test.com", Permissions.ViewSitePreview))
+            .ReturnsAsync(new List<string>() {site1.Id, site3.Id});
 
         var response = await _sut.RunAsync(request) as ContentResult;
         var actualResponse = await ReadResponseAsync<IEnumerable<SitePreview>>(response.Content);
 
-        actualResponse.Count().Should().Be(1);
+        actualResponse.Count().Should().Be(2);
         actualResponse.First().Id.Should().Be("1");
         actualResponse.First().Name.Should().Be("Alpha");
+        actualResponse.Last().Id.Should().Be("3");
+        actualResponse.Last().Name.Should().Be("Gamma");
         _siteService.Verify(x => x.GetSitesPreview(), Times.Never);
-        _siteService.Verify(x => x.GetSiteByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _siteService.Verify(x => x.GetSiteByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(2));
     }
 
     private static async Task<TRequest> ReadResponseAsync<TRequest>(string response)


### PR DESCRIPTION
Refactor permissions for SitePreview and SiteReferenceDetails. Created new permission for viewing site previews and managing admin details of a site. Two new permission checker methods to check for global permission, and a list of sites the user has a specific permission for.