### PR TITLE
APPT-343 - Expired booking cleanup bugfix

### DIFF
--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -216,7 +216,7 @@ public class BookingCosmosDocumentStore(
 
     public async Task<IEnumerable<string>> RemoveUnconfirmedProvisionalBookings()
     {
-        var expiryDateTime = time.GetUtcNow().AddMinutes(-5);        
+        var expiryDateTime = time.GetUtcNow().AddMinutes(-15);        
 
         var query = new QueryDefinition(
                 query: "SELECT * " +

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -427,7 +427,7 @@ public abstract partial class BaseFeatureSteps : Feature
         BookingType.Recent => DateTime.UtcNow.AddHours(-18),
         BookingType.Confirmed => DateTime.UtcNow.AddHours(-48),
         BookingType.Provisional => DateTime.UtcNow.AddMinutes(-2),
-        BookingType.ExpiredProvisional => DateTime.UtcNow.AddMinutes(-8),
+        BookingType.ExpiredProvisional => DateTime.UtcNow.AddMinutes(-18),
         BookingType.Orphaned => DateTime.UtcNow.AddHours(-64),
         BookingType.Cancelled => DateTime.UtcNow.AddHours(-82),
         _ => throw new ArgumentOutOfRangeException(nameof(type))


### PR DESCRIPTION
Currently the cleanup process runs every 5 mins. This process deletes all provisional bookings that have been expired as of 5 mins ago. This creates an issue where, depending on when the initial booking was made, the 'expired' status of a provisional booking (5 mins old) only exists in the DB between 0-5 mins, before being hard-deleted. 

I have upped the cleanup expired time cleanup, so that now 'Expired' bookings (5 mins old) will exist in the DB for 10-15 more mins before being removed.

Tech Debt Future - We really should have any variables like this controlled via IOptionsMonitor and injected in via config, so we wouldn't have to make further code changes in future.