### PR TITLE
APPT-634 Daily expired provisional cleanup

### DIFF
--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -216,7 +216,7 @@ public class BookingCosmosDocumentStore(
 
     public async Task<IEnumerable<string>> RemoveUnconfirmedProvisionalBookings()
     {
-        var expiryDateTime = time.GetUtcNow().AddMinutes(-15);        
+        var expiryDateTime = time.GetUtcNow().AddDays(-1);        
 
         var query = new QueryDefinition(
                 query: "SELECT * " +

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -427,7 +427,7 @@ public abstract partial class BaseFeatureSteps : Feature
         BookingType.Recent => DateTime.UtcNow.AddHours(-18),
         BookingType.Confirmed => DateTime.UtcNow.AddHours(-48),
         BookingType.Provisional => DateTime.UtcNow.AddMinutes(-2),
-        BookingType.ExpiredProvisional => DateTime.UtcNow.AddMinutes(-18),
+        BookingType.ExpiredProvisional => DateTime.UtcNow.AddHours(-25),
         BookingType.Orphaned => DateTime.UtcNow.AddHours(-64),
         BookingType.Cancelled => DateTime.UtcNow.AddHours(-82),
         _ => throw new ArgumentOutOfRangeException(nameof(type))


### PR DESCRIPTION
We don't need to be so aggressive with cleanup. NBS bookings can be on the page for an indeterminately long time, so might as well push the cleanup to cleanup daily.

Tech Debt: Ideally would be nice to have a heartbeat functionality where NBS slides our expiry time for a specific booking, if user is still on the NBS page. No time for that though yet!!