### PR TITLE
APPT-XXX: Bypass server redirect for login

### DIFF
--- a/src/client/src/app/login/log-in-button.tsx
+++ b/src/client/src/app/login/log-in-button.tsx
@@ -1,26 +1,32 @@
-import redirectToIdServer from '../auth/redirectToIdServer';
+'use client';
 import { Button } from '@nhsuk-frontend-components';
+import { useRouter } from 'next/navigation';
 
 type LogInButtonProps = {
-  redirectUrl: string;
+  authHost: string;
   provider: string;
   friendlyName: string;
 };
 
 const LogInButton = ({
-  redirectUrl,
+  authHost,
   provider,
   friendlyName,
 }: LogInButtonProps) => {
+  const router = useRouter();
+
+  const idServerEndpoint = `${authHost}/api/authenticate?provider=${provider}`;
+
   return (
-    <form action={redirectToIdServer.bind(null, redirectUrl, provider)}>
-      <Button
-        aria-label={`Sign in to service with ${friendlyName}`}
-        type="submit"
-      >
-        Sign in to service with {friendlyName}
-      </Button>
-    </form>
+    <Button
+      aria-label={`Sign in to service with ${friendlyName}`}
+      type="submit"
+      onClick={() => {
+        router.push(idServerEndpoint);
+      }}
+    >
+      Sign in to service with {friendlyName}
+    </Button>
   );
 };
 

--- a/src/client/src/app/login/page.tsx
+++ b/src/client/src/app/login/page.tsx
@@ -2,19 +2,16 @@ import { Metadata } from 'next';
 import LogInButton from './log-in-button';
 import NhsAnonymousPage from '@components/nhs-anonymous-page';
 
-export type LoginPageProps = {
-  searchParams?: {
-    redirectUrl?: string;
-  };
-};
-
 export const metadata: Metadata = {
   title: 'Manage your appointments',
   description: 'A National Booking Service site for managing NHS appointments',
 };
 
-const Page = async ({ searchParams }: LoginPageProps) => {
-  const redirectUrl = searchParams?.redirectUrl ?? '/';
+const Page = async () => {
+  if (!process.env.AUTH_HOST) {
+    throw new Error('AUTH_HOST environment variable is not set');
+  }
+
   return (
     <NhsAnonymousPage title="Manage your appointments" originPage="login">
       <p>
@@ -22,12 +19,13 @@ const Page = async ({ searchParams }: LoginPageProps) => {
         service.
       </p>
       <LogInButton
-        redirectUrl={redirectUrl}
+        authHost={process.env.AUTH_HOST}
         provider={'nhs-mail'}
         friendlyName={'NHS Mail'}
       />
+      <br />
       <LogInButton
-        redirectUrl={redirectUrl}
+        authHost={process.env.AUTH_HOST}
         provider={'okta'}
         friendlyName={'Other Email'}
       />

--- a/src/client/src/middleware.ts
+++ b/src/client/src/middleware.ts
@@ -4,26 +4,22 @@ import type { NextRequest } from 'next/server';
 export function middleware(request: NextRequest) {
   const pathAndQuery = `${request.nextUrl.pathname}${request.nextUrl.search}`;
 
-  const shouldHandle = !request.nextUrl.pathname.includes('/api/');
+  const nextArguments = request.nextUrl.pathname.endsWith('login')
+    ? {}
+    : {
+        headers: {
+          'mya-last-requested-path': pathAndQuery,
+        },
+      };
 
-  if (shouldHandle) {
-    const nextArguments = request.nextUrl.pathname.endsWith('login')
-      ? {}
-      : {
-          headers: {
-            'mya-last-requested-path': pathAndQuery,
-          },
-        };
+  const response = NextResponse.next(nextArguments);
 
-    const response = NextResponse.next(nextArguments);
+  response.headers.set(
+    'x-forwarded-host',
+    request.headers.get('origin')?.replace(/(http|https):\/\//, '') || '*',
+  );
 
-    response.headers.set(
-      'x-forwarded-host',
-      request.headers.get('origin')?.replace(/(http|https):\/\//, '') || '*',
-    );
-
-    return response;
-  }
+  return response;
 }
 
 export const config = {

--- a/src/client/testing/tests/create-availability/create-availability.spec.ts
+++ b/src/client/testing/tests/create-availability/create-availability.spec.ts
@@ -6,6 +6,7 @@ import SitePage from '../../page-objects/site';
 import CreateAvailabilityPage from '../../page-objects/create-availability';
 import SummaryPage from '../../page-objects/create-availability/summary-page';
 import { getDateInFuture } from '../../utils/date-utility';
+import { Site } from '@types';
 
 let rootPage: RootPage;
 let oAuthPage: OAuthLoginPage;
@@ -14,8 +15,10 @@ let sitePage: SitePage;
 let createAvailabilityPage: CreateAvailabilityPage;
 let summarypage: SummaryPage;
 
+let site: Site;
+
 test.beforeEach(async ({ page, getTestSite }) => {
-  const site = getTestSite();
+  site = getTestSite();
   rootPage = new RootPage(page);
   oAuthPage = new OAuthLoginPage(page);
   siteSelectionPage = new SiteSelectionPage(page);
@@ -35,9 +38,11 @@ test('A user can navigate to the Create Availability flow from the site page', a
   await expect(createAvailabilityPage.title).toBeVisible();
 });
 
-test('Create single session of RSV availability', async () => {
+test('Create single session of RSV availability', async ({ page }) => {
   const tomorrowDate = getDateInFuture(1);
   await createAvailabilityPage.createAvailabilityButton.click();
+  await page.waitForURL(`**/site/${site.id}/create-availability/wizard`);
+
   await expect(createAvailabilityPage.sessionTitle).toBeVisible();
   await createAvailabilityPage.selectSession('Single date session');
   await createAvailabilityPage.continueButton.click();
@@ -58,10 +63,12 @@ test('Create single session of RSV availability', async () => {
   await expect(createAvailabilityPage.sessionSuccessMsg).toBeVisible();
 });
 
-test('Create weekly session of RSV availability', async () => {
+test('Create weekly session of RSV availability', async ({ page }) => {
   const tomorrowDate = getDateInFuture(1);
   const dayAfterTomorrowDate = getDateInFuture(2);
   await createAvailabilityPage.createAvailabilityButton.click();
+  await page.waitForURL(`**/site/${site.id}/create-availability/wizard`);
+
   await expect(createAvailabilityPage.sessionTitle).toBeVisible();
   await createAvailabilityPage.selectSession('Weekly sessions');
   await createAvailabilityPage.continueButton.click();


### PR DESCRIPTION
The login buttons currently invoke server actions to redirect to the API auth functions. 
This is causing conflicts in Akamai, where NextJS believes these are internal routes (because of the subdomains) and tries to route them against its own router. 

This PR switches the server actions out to use simple client side redirection instead. 