### PR TITLE
APPT-XXX: Remove the fixme on the eula tests

### DIFF
--- a/src/client/testing/eula.spec.ts
+++ b/src/client/testing/eula.spec.ts
@@ -16,28 +16,28 @@ test.beforeEach(async ({ page }) => {
   eulaConsentPage = new EulaConsentPage(page);
 });
 
-test.fixme(
-  'A user with an out of date EULA consent version is prompted with the EULA consent page',
-  async ({ page, getTestUser }) => {
-    const user5 = getTestUser(5);
-    await rootPage.goto();
-    await rootPage.pageContentLogInButton.click();
+test('A user with an out of date EULA consent version is prompted with the EULA consent page', async ({
+  page,
+  getTestUser,
+}) => {
+  const user5 = getTestUser(5);
+  await rootPage.goto();
+  await rootPage.pageContentLogInButton.click();
 
-    await oAuthPage.page.getByLabel('Username').fill(user5.username);
-    await oAuthPage.page.getByLabel('Password').fill(user5.password);
-    await oAuthPage.page.getByLabel('Password').press('Enter');
+  await oAuthPage.page.getByLabel('Username').fill(user5.username);
+  await oAuthPage.page.getByLabel('Password').fill(user5.password);
+  await oAuthPage.page.getByLabel('Password').press('Enter');
 
-    await page.waitForURL('**/eula');
-    await expect(eulaConsentPage.title).toBeVisible();
+  await page.waitForURL('**/eula');
+  await expect(eulaConsentPage.title).toBeVisible();
 
-    // Try to bypass EULA consent
-    await page.goto('/');
+  // Try to bypass EULA consent
+  await page.goto('/');
 
-    await page.waitForURL('**/eula');
-    await expect(eulaConsentPage.title).toBeVisible();
-    await expect(siteSelectionPage.title).not.toBeVisible();
-  },
-);
+  await page.waitForURL('**/eula');
+  await expect(eulaConsentPage.title).toBeVisible();
+  await expect(siteSelectionPage.title).not.toBeVisible();
+});
 
 test('A user with an out of date EULA version is prompted with the EULA consent page on login, but not again after they have consented', async ({
   page,

--- a/src/client/testing/eula.spec.ts
+++ b/src/client/testing/eula.spec.ts
@@ -16,6 +16,8 @@ test.beforeEach(async ({ page }) => {
   eulaConsentPage = new EulaConsentPage(page);
 });
 
+test.describe.configure({ mode: 'serial' });
+
 test('A user with an out of date EULA consent version is prompted with the EULA consent page', async ({
   page,
   getTestUser,


### PR DESCRIPTION
I don't know why this was ever added, I think this test passes fine. Unless the pipeline is about to prove me wrong...