### PR TITLE
APPT-655 - Added cache control headers

### DIFF
--- a/src/api/Nhs.Appointments.Api/Middleware/NoCacheMiddleware.cs
+++ b/src/api/Nhs.Appointments.Api/Middleware/NoCacheMiddleware.cs
@@ -1,0 +1,16 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using System.Threading.Tasks;
+
+namespace Nhs.Appointments.Api.Middleware;
+public class NoCacheMiddleware : IFunctionsWorkerMiddleware
+{
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        await next(context);
+
+        var response = context.GetHttpContext().Response;
+        response.Headers["Cache-Control"] = "no-store, no-cache, max-age=0";
+        response.Headers["Pragma"] = "no-cache";
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Program.cs
+++ b/src/api/Nhs.Appointments.Api/Program.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting;
 using Nhs.Appointments.Api;
 using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Logger;
+using Nhs.Appointments.Api.Middleware;
 using Nhs.Appointments.Audit;
 
 var host = new HostBuilder()
@@ -11,6 +12,7 @@ var host = new HostBuilder()
             .UseMiddleware<TypeDecoratorMiddleware>()
             .UseMiddleware<AuthenticationMiddleware>()
             .UseMiddleware<AuthorizationMiddleware>()
+            .UseMiddleware<NoCacheMiddleware>()
             .AddAudit()
             .ConfigureFunctionDependencies();
     })

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/NoCache/NoCache.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/NoCache/NoCache.feature
@@ -1,0 +1,6 @@
+Feature: No Cache Headers
+
+  Scenario: API response contains no cache headers
+    Given the site is configured for MYA
+    When I query for a site
+    Then the call should be 200 with no cache headers

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/NoCache/NoCacheSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/NoCache/NoCacheSteps.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Nhs.Appointments.Api.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit.Gherkin.Quick;
+
+namespace Nhs.Appointments.Api.Integration.Scenarios.NoCache;
+
+[FeatureFile("./Scenarios/NoCache/NoCache.feature")]
+public sealed class NoCacheSteps : BaseFeatureSteps
+{
+    private HttpResponseMessage _response;
+    private HttpStatusCode _statusCode;
+    private List<Core.Booking> _actualResponse;
+
+    [When(@"I query for a site")]
+    public async Task QuerySite()
+    {
+        _response = await Http.GetAsync($"http://localhost:7071/api/booking?nhsNumber={NhsNumber}");
+        _statusCode = _response.StatusCode;
+        (_, _actualResponse) = await JsonRequestReader.ReadRequestAsync<List<Core.Booking>>(await _response.Content.ReadAsStreamAsync());
+        
+    }
+
+    [Then("the call should be 200 with no cache headers")]
+    public async Task AssertHeaders()
+    {
+        var headers = _response.Headers; 
+
+        headers.CacheControl.NoCache.Should().BeTrue();
+        headers.CacheControl.NoStore.Should().BeTrue();
+        headers.CacheControl.MaxAge.Should().Be(new TimeSpan(0, 0, 0));
+        headers.Pragma.First().Name.Should().Be("no-cache");
+
+        _statusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/Audit/FunctionMiddlewareTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Audit/FunctionMiddlewareTests.cs
@@ -1,14 +1,14 @@
-using System.Collections.Immutable;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Middleware;
 using Moq;
 using Nhs.Appointments.Api.Functions;
-using Nhs.Appointments.Audit.Functions;
 using Nhs.Appointments.Audit.Services;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Core.Inspectors;
 using Nhs.Appointments.Core.UnitTests;
+using System.Collections.Immutable;
+using FunctionMiddleware = Nhs.Appointments.Audit.Functions.Middleware;
 
 namespace Nhs.Appointments.Api.Tests.Audit;
 
@@ -19,7 +19,7 @@ public class FunctionMiddlewareTests
     private readonly Mock<FunctionExecutionDelegate> _functionExecutionDelegate = new();
     private readonly Mock<IServiceProvider> _serviceProvider = new();
     private readonly Mock<IUserContextProvider> _userContextProvider = new();
-    private Middleware _sut;
+    private FunctionMiddleware _sut;
 
     [Fact]
     public async Task Invoke_RecordFunctionThrows_MiddlewareNotStopped()
@@ -162,7 +162,7 @@ public class FunctionMiddlewareTests
         _serviceProvider.Setup(x => x.GetService(typeof(IUserContextProvider))).Returns(_userContextProvider.Object);
         _userContextProvider.Setup(x => x.UserPrincipal).Returns(userPrincipal);
 
-        _sut = new Middleware(_auditWriteService.Object);
+        _sut = new FunctionMiddleware(_auditWriteService.Object);
     }
 
     private class MockFunctionDefinition(string name, string entrypoint, string pathToAssembly) : FunctionDefinition


### PR DESCRIPTION
A new middleware has been implemented to add multiple headers to HTTP responses. 
These headers are designed to prevent Akamai from caching API responses.