### PR TITLE
APPT-617 email notification for okta users

### DIFF
--- a/data/CosmosDbSeeder/items/dev/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/notification_config.json
@@ -9,6 +9,12 @@
       "eventType": "UserRolesChanged"
     },
     {
+      "services": [],
+      "emailTemplate": "a93ca4e5-00bd-47b6-9936-4f935c422309",
+      "smsTemplate": "",
+      "eventType": "OktaUserRolesChanged"
+    },
+    {
       "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
       "emailTemplate": "5028cb32-6168-41ee-8773-2493d073f369",
       "smsTemplate": "1203db45-e5fc-479d-a64e-079c5723b1c3",

--- a/data/CosmosDbSeeder/items/int/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/int/core_data/notification_config.json
@@ -9,6 +9,12 @@
       "eventType": "UserRolesChanged"
     },
     {
+      "services": [],
+      "emailTemplate": "a93ca4e5-00bd-47b6-9936-4f935c422309",
+      "smsTemplate": "",
+      "eventType": "OktaUserRolesChanged"
+    },
+    {
       "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
       "emailTemplate": "5028cb32-6168-41ee-8773-2493d073f369",
       "smsTemplate": "1203db45-e5fc-479d-a64e-079c5723b1c3",

--- a/data/CosmosDbSeeder/items/local/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/local/core_data/notification_config.json
@@ -9,6 +9,12 @@
       "eventType": "UserRolesChanged"
     },
     {
+      "services": [],
+      "emailTemplate": "a93ca4e5-00bd-47b6-9936-4f935c422309",
+      "smsTemplate": "",
+      "eventType": "OktaUserRolesChanged"
+    },
+    {
       "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
       "emailTemplate": "5028cb32-6168-41ee-8773-2493d073f369",
       "smsTemplate": "1203db45-e5fc-479d-a64e-079c5723b1c3",

--- a/src/api/Nhs.Appointments.Api/Consumers/OktaUserRolesChangedConsumer.cs
+++ b/src/api/Nhs.Appointments.Api/Consumers/OktaUserRolesChangedConsumer.cs
@@ -1,0 +1,13 @@
+using MassTransit;
+using Nhs.Appointments.Api.Notifications;
+using Nhs.Appointments.Core.Messaging.Events;
+using System.Threading.Tasks;
+
+namespace Nhs.Appointments.Api.Consumers;
+public class OktaUserRolesChangedConsumer(IUserRolesChangedNotifier notifier) : IConsumer<OktaUserRolesChanged>
+{
+    public Task Consume(ConsumeContext<OktaUserRolesChanged> context)
+    {
+        return notifier.Notify(nameof(OktaUserRolesChanged), context.Message.UserId, context.Message.SiteId, context.Message.AddedRoleIds, context.Message.RemovedRoleIds);
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Consumers/UserRolesChangedConsumer.cs
+++ b/src/api/Nhs.Appointments.Api/Consumers/UserRolesChangedConsumer.cs
@@ -1,4 +1,4 @@
-﻿using MassTransit;
+using MassTransit;
 using Nhs.Appointments.Api.Notifications;
 using Nhs.Appointments.Core.Messaging.Events;
 using System.Threading.Tasks;

--- a/src/api/Nhs.Appointments.Api/Functions/NotifyOktaUserRolesChangedFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/NotifyOktaUserRolesChangedFunction.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using MassTransit;
+using Microsoft.Azure.Functions.Worker;
+using Azure.Messaging.ServiceBus;
+using System.Threading;
+using Nhs.Appointments.Api.Consumers;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Nhs.Appointments.Api.Functions;
+public class NotifyOktaUserRolesChangedFunction(IMessageReceiver receiver)
+{
+    public const string QueueName = "okta-user-roles-changed";
+
+    [Function("NotifyOktaUserRolesChanged")]
+    [AllowAnonymous]
+    public Task NotifyUserRolesChangedAsync([ServiceBusTrigger(QueueName, Connection = "ServiceBusConnectionString")] ServiceBusReceivedMessage message, CancellationToken cancellationToken)
+    {
+        return receiver.HandleConsumer<UserRolesChangedConsumer>(QueueName, message, cancellationToken);
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Notifications/ConsoleLogNotifications.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ConsoleLogNotifications.cs
@@ -1,4 +1,4 @@
-﻿using MassTransit;
+using MassTransit;
 using Nhs.Appointments.Core.Messaging;
 using Nhs.Appointments.Core.Messaging.Events;
 using System;
@@ -32,10 +32,23 @@ public class ConsoleLogNotifications : IMessageBus
     protected virtual void ProcessMessage<T>(T message) { }
 }
 
-public class ConsoleLogWithMessageDelivery(IConsumer<UserRolesChanged> userRolesChangedConsumer, IConsumer<BookingMade> bookingMadeConsumer, IConsumer<BookingReminder> bookingReminderConsumer, IConsumer<BookingCancelled> bookingCancelledConsumer, IConsumer<BookingRescheduled> bookingRescheduledConsumer) : ConsoleLogNotifications
+public class ConsoleLogWithMessageDelivery(
+    IConsumer<OktaUserRolesChanged> oktaUserRolesChangedConsumer,
+    IConsumer<UserRolesChanged> userRolesChangedConsumer, 
+    IConsumer<BookingMade> bookingMadeConsumer, 
+    IConsumer<BookingReminder> bookingReminderConsumer, 
+    IConsumer<BookingCancelled> bookingCancelledConsumer, 
+    IConsumer<BookingRescheduled> bookingRescheduledConsumer
+) : ConsoleLogNotifications
 {
     protected override void ProcessMessage<T>(T message)
     {
+        if(message is OktaUserRolesChanged oktaUserRolesChanged)
+        {
+            oktaUserRolesChangedConsumer.Consume(new DummyConsumeContext<OktaUserRolesChanged>() { Message = oktaUserRolesChanged });
+            return;
+        }
+
         if(message is UserRolesChanged userRolesChanged)
         {
             userRolesChangedConsumer.Consume(new DummyConsumeContext<UserRolesChanged>() { Message = userRolesChanged });

--- a/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
@@ -27,6 +27,7 @@ public static class ServiceRegistration
             case "local":
                 services
                     .AddScoped<IConsumer<UserRolesChanged>, UserRolesChangedConsumer>()
+                    .AddScoped<IConsumer<OktaUserRolesChanged>, OktaUserRolesChangedConsumer>()
                     .AddScoped<IConsumer<BookingMade>, BookingMadeConsumer>()
                     .AddScoped<IConsumer<BookingCancelled>, BookingCancelledConsumer>()
                     .AddScoped<IConsumer<BookingReminder>, BookingReminderConsumer>()
@@ -49,11 +50,13 @@ public static class ServiceRegistration
                     .AddMassTransitForAzureFunctions(cfg =>
                         {
                             EndpointConvention.Map<UserRolesChanged>(new Uri($"queue:{NotifyUserRolesChangedFunction.QueueName}"));
+                            EndpointConvention.Map<OktaUserRolesChanged>(new Uri($"queue:{NotifyOktaUserRolesChangedFunction.QueueName}"));
                             EndpointConvention.Map<BookingMade>(new Uri($"queue:{NotifyBookingMadeFunction.QueueName}"));
                             EndpointConvention.Map<BookingRescheduled>(new Uri($"queue:{NotifyBookingRescheduledFunction.QueueName}"));
                             EndpointConvention.Map<BookingCancelled>(new Uri($"queue:{NotifyBookingCancelledFunction.QueueName}"));
                             EndpointConvention.Map<BookingReminder>(new Uri($"queue:{NotifyBookingReminderFunction.QueueName}"));
                             cfg.AddConsumer<UserRolesChangedConsumer>();
+                            cfg.AddConsumer<OktaUserRolesChangedConsumer>();
                             cfg.AddConsumer<BookingReminderConsumer>();
                             cfg.AddConsumer<BookingMadeConsumer>();
                             cfg.AddConsumer<BookingCancelledConsumer>();

--- a/src/api/Nhs.Appointments.Api/Notifications/UserRolesChangedNotifier.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/UserRolesChangedNotifier.cs
@@ -7,7 +7,12 @@ using System.Threading.Tasks;
 namespace Nhs.Appointments.Api.Notifications;
 
 // Depends on an email template hosted in Gov Notify. See template.txt for details 
-public class UserRolesChangedNotifier(ISendNotifications notificationClient, INotificationConfigurationService notificationConfigurationService, IRolesStore rolesStore, ISiteService siteService) : IUserRolesChangedNotifier
+public class UserRolesChangedNotifier(
+    ISendNotifications notificationClient, 
+    INotificationConfigurationService notificationConfigurationService, 
+    IRolesStore rolesStore, 
+    ISiteService siteService
+) : IUserRolesChangedNotifier
 {
     public async Task Notify(string eventType, string user, string siteId, string[] rolesAdded, string[] rolesRemoved)
     {

--- a/src/api/Nhs.Appointments.Core/Messaging/Events/OktaUserRolesChanged.cs
+++ b/src/api/Nhs.Appointments.Core/Messaging/Events/OktaUserRolesChanged.cs
@@ -1,0 +1,2 @@
+namespace Nhs.Appointments.Core.Messaging.Events;
+public class OktaUserRolesChanged : UserRolesChanged {}

--- a/src/api/Nhs.Appointments.Core/UserService.cs
+++ b/src/api/Nhs.Appointments.Core/UserService.cs
@@ -45,7 +45,17 @@ public class UserService(IUserStore userStore, IRolesStore rolesStore, IMessageB
         }
 
         var site = Scope.GetValue("site", scope);
-        await bus.Send(new UserRolesChanged { UserId = userId, SiteId = site, AddedRoleIds = rolesAdded.Select(r => r.Role).ToArray(), RemovedRoleIds = rolesRemoved.Select(r => r.Role).ToArray()});
+
+        if (userId.ToLower().EndsWith("@nhs.net"))
+        {
+            //NHS user
+            await bus.Send(new UserRolesChanged { UserId = userId, SiteId = site, AddedRoleIds = rolesAdded.Select(r => r.Role).ToArray(), RemovedRoleIds = rolesRemoved.Select(r => r.Role).ToArray()});
+        }
+        else
+        {
+            //OKTA user
+            await bus.Send(new OktaUserRolesChanged { UserId = userId, SiteId = site, AddedRoleIds = rolesAdded.Select(r => r.Role).ToArray(), RemovedRoleIds = rolesRemoved.Select(r => r.Role).ToArray() });
+        }
 
         return new UpdateUserRoleAssignmentsResult(true, string.Empty, []);
     }

--- a/tests/Nhs.Appointments.Api.UnitTests/Consumers/OktaUserRolesChangedConsumerTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Consumers/OktaUserRolesChangedConsumerTests.cs
@@ -1,0 +1,37 @@
+using MassTransit;
+using Moq;
+using Nhs.Appointments.Api.Consumers;
+using Nhs.Appointments.Api.Notifications;
+using Nhs.Appointments.Core.Messaging.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nhs.Appointments.Api.Tests.Consumers;
+public class OktaUserRolesChangedConsumerTests
+{
+    private OktaUserRolesChangedConsumer _sut;
+    private readonly Mock<IUserRolesChangedNotifier> _notifier = new();
+    public OktaUserRolesChangedConsumerTests()
+    {
+        _sut = new OktaUserRolesChangedConsumer(_notifier.Object);
+    }
+
+    [Fact]
+    public async Task NotifiesUserOnEventReceipt()
+    {
+        const string user = "test@tempuri.org";
+        const string site = "site1";
+        string[] rolesAdded = ["role1"];
+        string[] rolesRemoved = ["role2"];
+        _notifier.Setup(x => x.Notify(nameof(OktaUserRolesChanged), user, site, It.Is<string[]>(r => Enumerable.SequenceEqual(r, rolesAdded)), It.Is<string[]>(r => Enumerable.SequenceEqual(r, rolesRemoved)))).Verifiable();
+        var ctx = new Mock<ConsumeContext<OktaUserRolesChanged>>();
+        ctx.SetupGet(x => x.Message).Returns(new OktaUserRolesChanged { UserId = user, SiteId = site, AddedRoleIds = rolesAdded, RemovedRoleIds = rolesRemoved });
+
+        await _sut.Consume(ctx.Object);
+
+        _notifier.Verify();
+    }
+}


### PR DESCRIPTION
When calling the SetUserRolesFunction endpoint, we currently send out the "UserRolesChanged" event. We have introduced a new event, "OktaUserRolesChanged", specifically for Okta users. This ensures that Okta users receive a different email from NHS users.