### PR TITLE
APPT-702 - Returning from NoCacheMiddleware if HttpContext is null

### DIFF
--- a/src/api/Nhs.Appointments.Api/Middleware/NoCacheMiddleware.cs
+++ b/src/api/Nhs.Appointments.Api/Middleware/NoCacheMiddleware.cs
@@ -9,7 +9,13 @@ public class NoCacheMiddleware : IFunctionsWorkerMiddleware
     {
         await next(context);
 
-        var response = context.GetHttpContext().Response;
+        var httpContext = context.GetHttpContext();
+        if (httpContext is null)
+        {
+            return;
+        }
+
+        var response = httpContext.Response;
         response.Headers["Cache-Control"] = "no-store, no-cache, max-age=0";
         response.Headers["Pragma"] = "no-cache";
     }


### PR DESCRIPTION
This was throwing a NullReferenceException when sending notifications causing a retry after they'd actually been sent out so we were seeing 10 notifications instead of 1.