### PR TITLE
APPT-XXX: Disable functions and fix local errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     environment:
       - AzureWebJobsStorage="UseDevelopmentStorage=true"
       - AzureWebJobs.NotifyUserRolesChanged.Disabled=true
+      - AzureWebJobs.NotifyOktaUserRolesChanged.Disabled=true
       - AzureWebJobs.NotifyBookingMade.Disabled=true
       - AzureWebJobs.NotifyBookingRescheduled.Disabled=true
       - AzureWebJobs.NotifyBookingCancelled.Disabled = true

--- a/infrastructure/resources/high_load_functions.tf
+++ b/infrastructure/resources/high_load_functions.tf
@@ -68,6 +68,7 @@ resource "azurerm_windows_function_app" "nbs_mya_high_load_func_app" {
     "AzureWebJobs.NotifyBookingReminder.Disabled"                          = true
     "AzureWebJobs.NotifyBookingRescheduled.Disabled"                       = true
     "AzureWebJobs.NotifyUserRolesChanged.Disabled"                         = true
+    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"                     = true
     "AzureWebJobs.ApplyAvailabilityTemplateFunction.Disabled"              = true
     "AzureWebJobs.AuthenticateCallbackFunction.Disabled"                   = true
     "AzureWebJobs.AuthenticateFunction.Disabled"                           = true
@@ -98,6 +99,8 @@ resource "azurerm_windows_function_app" "nbs_mya_high_load_func_app" {
     "AzureWebJobs.SetBookingStatusFunction.Disabled"                       = true
     "AzureWebJobs.SetSiteAccessibilitiesFunction.Disabled"                 = true
     "AzureWebJobs.SetSiteInformationForCitizensFunction.Disabled"          = true
+    "AzureWebJobs.SetSiteDetailsFunction.Disabled"                         = true
+    "AzureWebJobs.SetSiteReferenceDetailsFunction.Disabled"                = true
     "AzureWebJobs.SetUserRoles.Disabled"                                   = true
     "AzureWebJobs.TriggerBookingReminders.Disabled"                        = true
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true
@@ -174,6 +177,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_high_load_func_app_preview
     "AzureWebJobs.NotifyBookingReminder.Disabled"                          = true
     "AzureWebJobs.NotifyBookingRescheduled.Disabled"                       = true
     "AzureWebJobs.NotifyUserRolesChanged.Disabled"                         = true
+    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"                     = true
     "AzureWebJobs.ApplyAvailabilityTemplateFunction.Disabled"              = true
     "AzureWebJobs.AuthenticateCallbackFunction.Disabled"                   = true
     "AzureWebJobs.AuthenticateFunction.Disabled"                           = true
@@ -202,6 +206,8 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_high_load_func_app_preview
     "AzureWebJobs.SetAvailabilityFunction.Disabled"                        = true
     "AzureWebJobs.SetBookingStatusFunction.Disabled"                       = true
     "AzureWebJobs.SetSiteAttributesFunction.Disabled"                      = true
+    "AzureWebJobs.SetSiteDetailsFunction.Disabled"                         = true
+    "AzureWebJobs.SetSiteReferenceDetailsFunction.Disabled"                = true
     "AzureWebJobs.SetUserRoles.Disabled"                                   = true
     "AzureWebJobs.TriggerBookingReminders.Disabled"                        = true
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true

--- a/infrastructure/resources/http_functions.tf
+++ b/infrastructure/resources/http_functions.tf
@@ -68,6 +68,7 @@ resource "azurerm_windows_function_app" "nbs_mya_http_func_app" {
     "AzureWebJobs.NotifyBookingReminder.Disabled"                = true
     "AzureWebJobs.NotifyBookingRescheduled.Disabled"             = true
     "AzureWebJobs.NotifyUserRolesChanged.Disabled"               = true
+    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"           = true
     "AzureWebJobs.SendBookingReminders.Disabled"                 = true
     "AzureWebJobs.RemoveUnconfirmedProvisionalBookings.Disabled" = true
   }
@@ -142,6 +143,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_http_func_app_preview" {
     "AzureWebJobs.NotifyBookingReminder.Disabled"                = true
     "AzureWebJobs.NotifyBookingRescheduled.Disabled"             = true
     "AzureWebJobs.NotifyUserRolesChanged.Disabled"               = true
+    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"           = true
     "AzureWebJobs.SendBookingReminders.Disabled"                 = true
     "AzureWebJobs.RemoveUnconfirmedProvisionalBookings.Disabled" = true
   }

--- a/infrastructure/resources/servicebus_functions.tf
+++ b/infrastructure/resources/servicebus_functions.tf
@@ -72,6 +72,8 @@ resource "azurerm_windows_function_app" "nbs_mya_service_bus_func_app" {
     "AzureWebJobs.SetBookingStatusFunction.Disabled"                       = true
     "AzureWebJobs.SetSiteAccessibilitiesFunction.Disabled"                 = true
     "AzureWebJobs.SetSiteInformationForCitizensFunction.Disabled"          = true
+    "AzureWebJobs.SetSiteDetailsFunction.Disabled"                         = true
+    "AzureWebJobs.SetSiteReferenceDetailsFunction.Disabled"                = true
     "AzureWebJobs.SetUserRoles.Disabled"                                   = true
     "AzureWebJobs.TriggerBookingReminders.Disabled"                        = true
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true
@@ -89,7 +91,8 @@ resource "azurerm_windows_function_app" "nbs_mya_service_bus_func_app" {
       "AzureWebJobs.NotifyBookingMade.Disabled",
       "AzureWebJobs.NotifyBookingReminder.Disabled",
       "AzureWebJobs.NotifyBookingRescheduled.Disabled",
-      "AzureWebJobs.NotifyUserRolesChanged.Disabled"
+      "AzureWebJobs.NotifyUserRolesChanged.Disabled",
+      "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"
 
     ]
   }
@@ -133,6 +136,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_service_bus_func_app_previ
     "AzureWebJobs.NotifyBookingReminder.Disabled"                          = true
     "AzureWebJobs.NotifyBookingRescheduled.Disabled"                       = true
     "AzureWebJobs.NotifyUserRolesChanged.Disabled"                         = true
+    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"                     = true
     "AzureWebJobs.ApplyAvailabilityTemplateFunction.Disabled"              = true
     "AzureWebJobs.AuthenticateCallbackFunction.Disabled"                   = true
     "AzureWebJobs.AuthenticateFunction.Disabled"                           = true
@@ -162,6 +166,8 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_service_bus_func_app_previ
     "AzureWebJobs.SetAvailabilityFunction.Disabled"                        = true
     "AzureWebJobs.SetBookingStatusFunction.Disabled"                       = true
     "AzureWebJobs.SetSiteAttributesFunction.Disabled"                      = true
+    "AzureWebJobs.SetSiteDetailsFunction.Disabled"                         = true
+    "AzureWebJobs.SetSiteReferenceDetailsFunction.Disabled"                = true
     "AzureWebJobs.SetUserRoles.Disabled"                                   = true
     "AzureWebJobs.TriggerBookingReminders.Disabled"                        = true
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true

--- a/infrastructure/resources/timer_functions.tf
+++ b/infrastructure/resources/timer_functions.tf
@@ -48,6 +48,7 @@ resource "azurerm_windows_function_app" "nbs_mya_timer_func_app" {
     "AzureWebJobs.NotifyBookingReminder.Disabled"                          = true
     "AzureWebJobs.NotifyBookingRescheduled.Disabled"                       = true
     "AzureWebJobs.NotifyUserRolesChanged.Disabled"                         = true
+    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"                     = true
     "AzureWebJobs.ApplyAvailabilityTemplateFunction.Disabled"              = true
     "AzureWebJobs.AuthenticateCallbackFunction.Disabled"                   = true
     "AzureWebJobs.AuthenticateFunction.Disabled"                           = true
@@ -79,6 +80,8 @@ resource "azurerm_windows_function_app" "nbs_mya_timer_func_app" {
     "AzureWebJobs.SetBookingStatusFunction.Disabled"                       = true
     "AzureWebJobs.SetSiteAccessibilitiesFunction.Disabled"                 = true
     "AzureWebJobs.SetSiteInformationForCitizensFunction.Disabled"          = true
+    "AzureWebJobs.SetSiteDetailsFunction.Disabled"                         = true
+    "AzureWebJobs.SetSiteReferenceDetailsFunction.Disabled"                = true
     "AzureWebJobs.SetUserRoles.Disabled"                                   = true
     "AzureWebJobs.TriggerBookingReminders.Disabled"                        = true
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true
@@ -136,6 +139,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_timer_func_app_preview" {
     "AzureWebJobs.NotifyBookingReminder.Disabled"                          = true
     "AzureWebJobs.NotifyBookingRescheduled.Disabled"                       = true
     "AzureWebJobs.NotifyUserRolesChanged.Disabled"                         = true
+    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"                         = true
     "AzureWebJobs.ApplyAvailabilityTemplateFunction.Disabled"              = true
     "AzureWebJobs.AuthenticateCallbackFunction.Disabled"                   = true
     "AzureWebJobs.AuthenticateFunction.Disabled"                           = true
@@ -165,6 +169,8 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_timer_func_app_preview" {
     "AzureWebJobs.SetAvailabilityFunction.Disabled"                        = true
     "AzureWebJobs.SetBookingStatusFunction.Disabled"                       = true
     "AzureWebJobs.SetSiteAttributesFunction.Disabled"                      = true
+    "AzureWebJobs.SetSiteDetailsFunction.Disabled"                         = true
+    "AzureWebJobs.SetSiteReferenceDetailsFunction.Disabled"                = true
     "AzureWebJobs.SetUserRoles.Disabled"                                   = true
     "AzureWebJobs.TriggerBookingReminders.Disabled"                        = true
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true

--- a/infrastructure/resources/timer_functions.tf
+++ b/infrastructure/resources/timer_functions.tf
@@ -139,7 +139,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_timer_func_app_preview" {
     "AzureWebJobs.NotifyBookingReminder.Disabled"                          = true
     "AzureWebJobs.NotifyBookingRescheduled.Disabled"                       = true
     "AzureWebJobs.NotifyUserRolesChanged.Disabled"                         = true
-    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"                         = true
+    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled"                     = true
     "AzureWebJobs.ApplyAvailabilityTemplateFunction.Disabled"              = true
     "AzureWebJobs.AuthenticateCallbackFunction.Disabled"                   = true
     "AzureWebJobs.AuthenticateFunction.Disabled"                           = true

--- a/src/api/Nhs.Appointments.Api/Functions/NotifyOktaUserRolesChangedFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/NotifyOktaUserRolesChangedFunction.cs
@@ -13,8 +13,8 @@ public class NotifyOktaUserRolesChangedFunction(IMessageReceiver receiver)
 
     [Function("NotifyOktaUserRolesChanged")]
     [AllowAnonymous]
-    public Task NotifyUserRolesChangedAsync([ServiceBusTrigger(QueueName, Connection = "ServiceBusConnectionString")] ServiceBusReceivedMessage message, CancellationToken cancellationToken)
+    public Task NotifyOktaUserRolesChangedAsync([ServiceBusTrigger(QueueName, Connection = "ServiceBusConnectionString")] ServiceBusReceivedMessage message, CancellationToken cancellationToken)
     {
-        return receiver.HandleConsumer<UserRolesChangedConsumer>(QueueName, message, cancellationToken);
+        return receiver.HandleConsumer<OktaUserRolesChangedConsumer>(QueueName, message, cancellationToken);
     }
 }

--- a/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
@@ -47,6 +47,7 @@ public static class ServiceRegistration
                     .AddScoped<NotifyBookingCancelledFunction>()
                     .AddScoped<ScheduledBookingRemindersFunction>()
                     .AddScoped<NotifyBookingRescheduledFunction>()
+                    .AddScoped<NotifyOktaUserRolesChangedFunction>()
                     .AddMassTransitForAzureFunctions(cfg =>
                         {
                             EndpointConvention.Map<UserRolesChanged>(new Uri($"queue:{NotifyUserRolesChangedFunction.QueueName}"));

--- a/src/api/Nhs.Appointments.Api/local.settings.json
+++ b/src/api/Nhs.Appointments.Api/local.settings.json
@@ -3,6 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobs.NotifyUserRolesChanged.Disabled": true,
+    "AzureWebJobs.NotifyOktaUserRolesChanged.Disabled": true,
     "AzureWebJobs.NotifyBookingMade.Disabled": true,
     "AzureWebJobs.NotifyBookingRescheduled.Disabled": true,
     "AzureWebJobs.NotifyBookingCancelled.Disabled": true,
@@ -33,7 +34,7 @@
     "Auth__Providers__1__ClientCodeExchangeUri": "http://localhost:3000/manage-your-appointments/auth/set-cookie?provider=okta-test",
     "Auth__Providers__1__ReturnUri": "http://localhost:7071/api/auth-return?provider=okta-test",
     "Auth__Providers__1__RequiresStateForAuthorize": true,
-    "Auth__Providers__1__ClientSecret":"J1CU4uhngKVkj9yCVXHbou9RQupiu7y4BiRvwB67wkiQj5uQaKgKQc_cRJwibm8X",
+    "Auth__Providers__1__ClientSecret": "J1CU4uhngKVkj9yCVXHbou9RQupiu7y4BiRvwB67wkiQj5uQaKgKQc_cRJwibm8X",
     "Notifications_Provider": "local",
     "GovNotifyApiKey": "test",
     "BookingRemindersCronSchedule": "0 0 8 * * *",


### PR DESCRIPTION
`NotifyOktaUserRolesChanged`, `SetSiteDetailsFunction`, and `SetSiteReferenceDetailsFunction` are currently enabled in all resources, including the high load functions which cost more. This PR disables `SetSiteDetailsFunction` and `SetSiteReferenceDetailsFunction` for all but http functions and `NotifyOktaUserRolesChanged` for all but the service bus functions.

Also fixes some bugs with the Okta user roles function, namely that it was using the wrong consumer and wasn't being registered.

Also disables the Okta notification function locally to prevent the following console errors:
![image](https://github.com/user-attachments/assets/4fd0745c-ba58-476a-a996-42d2ae8bf1c0)


