### PR TITLE
APPT-678: Build number investigations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -323,5 +323,5 @@ stages:
           cosmosAccountName: nbs-mya-cdb-${{env}}-uks
           resourceGroup: nbs-mya-rg-${{env}}-uks
           serviceConnectionName: nbs-mya-rg-${{env}}
-          isMain: ${{eq(variables['Build.SourceBranch'], 'refs/heads/main')}}
+          isMain: "true"
           buildNumber: "$(Build.BuildNumber)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,6 +129,8 @@ stages:
               npm run build
               mv .next/static .next/standalone/.next/static
             displayName: "Build Web App"
+            env:
+              BUILD_NUMBER: "$(Build.BuildNumber)"
           - task: ArchiveFiles@2
             displayName: Zip Web Client
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -325,5 +325,5 @@ stages:
           cosmosAccountName: nbs-mya-cdb-${{env}}-uks
           resourceGroup: nbs-mya-rg-${{env}}-uks
           serviceConnectionName: nbs-mya-rg-${{env}}
-          isMain: "true"
+          isMain: ${{eq(variables['Build.SourceBranch'], 'refs/heads/main')}}
           buildNumber: "$(Build.BuildNumber)"

--- a/src/client/src/app/lib/components/build-number.test.tsx
+++ b/src/client/src/app/lib/components/build-number.test.tsx
@@ -1,0 +1,30 @@
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+import BuildNumber from './build-number';
+
+describe('Build Number', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('Renders the build number', () => {
+    process.env.BUILD_NUMBER = 'test-build-number';
+
+    render(<BuildNumber />);
+
+    expect(
+      screen.getByText('Build number: test-build-number'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Build number: test-build-number'),
+    ).not.toBeVisible();
+  });
+});

--- a/src/client/src/app/lib/components/build-number.tsx
+++ b/src/client/src/app/lib/components/build-number.tsx
@@ -1,0 +1,13 @@
+'use server';
+
+const BuildNumber = () => {
+  const buildNumberText = `Build number: ${process.env.BUILD_NUMBER}`;
+
+  return (
+    <span aria-hidden style={{ display: 'none' }}>
+      {buildNumberText}
+    </span>
+  );
+};
+
+export default BuildNumber;

--- a/src/client/src/app/lib/components/getBuildNumber.ts
+++ b/src/client/src/app/lib/components/getBuildNumber.ts
@@ -1,3 +1,0 @@
-'use server';
-
-export const buildNumber = () => process.env.BUILD_NUMBER;

--- a/src/client/src/app/lib/components/getBuildNumber.ts
+++ b/src/client/src/app/lib/components/getBuildNumber.ts
@@ -1,0 +1,3 @@
+'use server';
+
+export const buildNumber = () => process.env.BUILD_NUMBER;

--- a/src/client/src/app/lib/components/nhs-anonymous-page.tsx
+++ b/src/client/src/app/lib/components/nhs-anonymous-page.tsx
@@ -40,7 +40,7 @@ const NhsAnonymousPage = ({
         <NhsHeading title={title} caption={caption} />
         {children}
       </NhsMainContainer>
-      <NhsFooter />
+      <NhsFooter buildNumber={null} />
     </>
   );
 };

--- a/src/client/src/app/lib/components/nhs-footer.tsx
+++ b/src/client/src/app/lib/components/nhs-footer.tsx
@@ -30,7 +30,9 @@ const NhsFooter = ({ buildNumber }: NhsFooterProps) => {
         },
       ]}
     >
-      {buildNumber}
+      <span aria-hidden style={{ display: 'none' }}>
+        {buildNumber}
+      </span>
     </Footer>
   );
 };

--- a/src/client/src/app/lib/components/nhs-footer.tsx
+++ b/src/client/src/app/lib/components/nhs-footer.tsx
@@ -1,4 +1,6 @@
+'use server';
 import { Footer } from '@nhsuk-frontend-components';
+import { buildNumber } from './getBuildNumber';
 
 const NhsFooter = () => {
   const buildNumberText = `Build number: ${process.env.BUILD_NUMBER}`;
@@ -29,6 +31,9 @@ const NhsFooter = () => {
     >
       <span aria-hidden style={{ display: 'none' }}>
         {buildNumberText}
+      </span>
+      <span aria-hidden style={{ display: 'none' }}>
+        {buildNumber()}
       </span>
     </Footer>
   );

--- a/src/client/src/app/lib/components/nhs-footer.tsx
+++ b/src/client/src/app/lib/components/nhs-footer.tsx
@@ -1,10 +1,11 @@
-'use server';
 import { Footer } from '@nhsuk-frontend-components';
-import { buildNumber } from './getBuildNumber';
+import { ReactNode } from 'react';
 
-const NhsFooter = () => {
-  const buildNumberText = `Build number: ${process.env.BUILD_NUMBER}`;
+type NhsFooterProps = {
+  buildNumber: ReactNode;
+};
 
+const NhsFooter = ({ buildNumber }: NhsFooterProps) => {
   return (
     <Footer
       supportLinks={[
@@ -29,12 +30,7 @@ const NhsFooter = () => {
         },
       ]}
     >
-      <span aria-hidden style={{ display: 'none' }}>
-        {buildNumberText}
-      </span>
-      <span aria-hidden style={{ display: 'none' }}>
-        {buildNumber()}
-      </span>
+      {buildNumber}
     </Footer>
   );
 };

--- a/src/client/src/app/lib/components/nhs-page.tsx
+++ b/src/client/src/app/lib/components/nhs-page.tsx
@@ -16,6 +16,7 @@ import { Site } from '@types';
 import { fetchPermissions } from '@services/appointmentsService';
 import BackLink, { NavigationByHrefProps } from './nhsuk-frontend/back-link';
 import FeedbackBanner from '@components/feedback-banner';
+import BuildNumber from './build-number';
 
 type Props = {
   children: ReactNode;
@@ -70,7 +71,7 @@ const NhsPage = async ({
         <NotificationBanner notification={notification} />
         {children}
       </NhsMainContainer>
-      <NhsFooter />
+      <NhsFooter buildNumber={<BuildNumber />} />
     </>
   );
 };

--- a/src/client/src/app/login/page.tsx
+++ b/src/client/src/app/login/page.tsx
@@ -23,11 +23,6 @@ const Page = async ({ searchParams }: LoginPageProps) => {
         You are currently not signed in. You must sign in to access this
         service.
       </p>
-      <p style={{ display: 'none' }} aria-hidden>
-        <span>Auth: {process.env.AUTH_HOST}</span>
-        <span>Base Url: {process.env.NBS_API_BASE_URL}</span>
-        <span>Build Number: {process.env.BUILD_NUMBER}</span>
-      </p>
       <LogInButton
         redirectUrl={redirectUrl}
         provider={'nhs-mail'}

--- a/src/client/src/app/login/page.tsx
+++ b/src/client/src/app/login/page.tsx
@@ -23,8 +23,10 @@ const Page = async ({ searchParams }: LoginPageProps) => {
         You are currently not signed in. You must sign in to access this
         service.
       </p>
-      <p style={{ display: 'none' }}>
-        Auth: {process.env.AUTH_HOST} Base Url: {process.env.NBS_API_BASE_URL}
+      <p style={{ display: 'none' }} aria-hidden>
+        <span>Auth: {process.env.AUTH_HOST}</span>
+        <span>Base Url: {process.env.NBS_API_BASE_URL}</span>
+        <span>Build Number: {process.env.BUILD_NUMBER}</span>
       </p>
       <LogInButton
         redirectUrl={redirectUrl}

--- a/src/client/testing/tests/build-number.spec.ts
+++ b/src/client/testing/tests/build-number.spec.ts
@@ -1,13 +1,17 @@
-import { RootPage } from '@testing-page-objects';
+import { RootPage, OAuthLoginPage } from '@testing-page-objects';
 import { test, expect } from '../fixtures';
 import env from '../testEnvironment';
 
 let rootPage: RootPage;
+let oAuthPage: OAuthLoginPage;
 
 test.beforeEach(async ({ page }) => {
   rootPage = new RootPage(page);
+  oAuthPage = new OAuthLoginPage(page);
 
   await rootPage.goto();
+  await rootPage.pageContentLogInButton.click();
+  await oAuthPage.signIn();
 });
 
 test('The build number is surfaced in the footer but is not visible', async () => {


### PR DESCRIPTION
I admit this PR is a bit of a hail mary, I only want to see this get as far as the DEV environment. 

We know the `BUILD_NUMBER` is correctly set as an ENV var in the Azure web app resource, yet isn't pulling through like `AUTH_HOST` and `NBS_API_BASE_URL`. Frustratingly, it does when it's set as an ENV var during docker-compose and started locally, so I can't replicate this issue locally. It might be something to do with us running NextJS as a standalone app. 

Screenshots to prove problem:
<img width="507" alt="Screenshot 2025-03-14 091236" src="https://github.com/user-attachments/assets/07bc95ee-86a5-47eb-a8c3-034caf5672a3" />
<img width="597" alt="Screenshot 2025-03-14 091352" src="https://github.com/user-attachments/assets/c869a2a2-9098-4034-a2e9-b66af53a2b76" />
