### PR TITLE
APPT-717 - Adding a try catch in the CSV processor and reporting it

### DIFF
--- a/src/api/Nhs.Appointments.Core/CsvProcessor.cs
+++ b/src/api/Nhs.Appointments.Core/CsvProcessor.cs
@@ -44,19 +44,27 @@ public class CsvProcessor<TDocument, TMap>(
         {
             csv.Context.RegisterClassMap<TMap>();
 
-            var imported = csv.GetRecords<TDocument>();
-
-            foreach (var item in imported)
+            try
             {
-                try
+                var imported = csv.GetRecords<TDocument>();
+
+                foreach (var item in imported)
                 {
-                    await processRow(item);
-                    report.Add(new ReportItem(index, getItemName(item), true, ""));
+                    try
+                    {
+                        await processRow(item);
+                        report.Add(new ReportItem(index, getItemName(item), true, ""));
+                    }
+                    catch (Exception ex)
+                    {
+                        report.Add(new ReportItem(index, getItemName(item), false, ex.Message));
+                    }
                 }
-                catch (Exception ex)
-                {
-                    report.Add(new ReportItem(index, getItemName(item), false, ex.Message));
-                }
+
+            }
+            catch (Exception ex)
+            {
+                report.Add(new ReportItem(index, "Error trying to parse CSV file.", false, $"Error trying to parse CSV file: {ex.Message}"));
             }
         }
 

--- a/tests/Nhs.Appointments.Core.UnitTests/SiteDataImporterHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/SiteDataImporterHandlerTests.cs
@@ -196,6 +196,28 @@ public class SiteDataImporterHandlerTests
         report.Last().Message.Should().Contain($"Latitude: {invalidLatitudeLower} is not a valid UK latitude.");
     }
 
+    [Fact]
+    public async Task DataReportsMissingColumns()
+    {
+        const string invalidHeaders = "Id,Name,Address,Longitude,Latitude,ICB,Region,accessible_toilet,car_parking,induction_loop,sign_language_service,step_free_access,text_relay,wheelchair_access";
+
+        string[] inputRows =
+        [
+            $"\"{Guid.NewGuid()}\",\"site1\",\"123 test street\",\"0.50\",\"60.0\",\"test icb1\",\"Yorkshire\",true,True,False,false,true,false,true",
+            $"\"{Guid.NewGuid()}\",\"site2\",\"321 test street\",\"0.75\",\"59.5\",\"test icb1\",\"Yorkshire\",true,True,False,false,true,false,true"
+        ];
+
+        var input = CsvFileBuilder.BuildInputCsv(invalidHeaders, inputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var report = await _sut.ProcessFile(file);
+
+        report.Count().Should().Be(1);
+        report.First().Message.Should().Contain("Error trying to parse CSV file: Header with name 'OdsCode'[0] was not found");
+    }
+
     private readonly string[] ValidInputRows =
     [
         $"\"{Guid.NewGuid()}\",\"site1\",\"test site 1\",\"123 test street\",\"01234 567890\",\"1.0\",\"60.0\",\"test icb1\",\"Yorkshire\",,true,True,False,false,\"true\",false,true,true,false",

--- a/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
@@ -114,6 +114,28 @@ public class UserDataImportHandlerTests
         report.First().Message.Should().Contain("Invalid bool string format:  test");
     }
 
+    [Fact]
+    public async Task DataReportsMissingColumns()
+    {
+        const string invalidHeaders = "Site,appointment-manager,availability-manager,site-details-manager";
+
+        string[] inputRows =
+        [
+            "d3793464-b421-41f3-9bfa-53b06e7b3d19, false, true, true",
+            "308d515c-2002-450e-b248-4ba36f6667bb, true, false, true"
+        ];
+
+        var input = CsvFileBuilder.BuildInputCsv(invalidHeaders, inputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var report = await _sut.ProcessFile(file);
+
+        report.Count().Should().Be(1);
+        report.First().Message.Should().Contain("Error trying to parse CSV file: Header with name 'User'[0] was not found");
+    }
+
     private List<Site> GetSites()
     {
         var sites = new List<Site>();


### PR DESCRIPTION
The try catch is placed where it is because in some instances an exception is only thrown on the foreach (...) line e.g. when a mandatory column is missing.