### PR TITLE
APPT-639: Relax @nhs.net check on assign roles page

### DIFF
--- a/src/client/src/app/site/[site]/users/manage/assign-roles.test.tsx
+++ b/src/client/src/app/site/[site]/users/manage/assign-roles.test.tsx
@@ -44,6 +44,7 @@ describe('AssignRoles', () => {
     fetchUsersMock.mockResolvedValue(getMockUserAssignments(mockSiteId));
     fetchRolesMock.mockResolvedValue(mockRoles);
   });
+
   it('throws error when rendered without user', async () => {
     await expect(
       AssignRoles({
@@ -53,24 +54,19 @@ describe('AssignRoles', () => {
     ).rejects.toThrow('You must specify a valid NHS email address');
   });
 
-  it('throws error when rendered with non NHS email', async () => {
-    await expect(
-      AssignRoles({
+  it.each([['test@nhs.net'], ['test@gmail.com']])(
+    'displays the email address of the user',
+    async (email: string) => {
+      const jsx = await AssignRoles({
         params: { site: 'TEST' },
-        searchParams: { user: 'test@test.com' },
-      }),
-    ).rejects.toThrow('You must specify a valid NHS email address');
-  });
+        searchParams: { user: email },
+      });
+      render(jsx);
+      expect(screen.getByText('Email')).toBeVisible();
+      expect(screen.getByText(email));
+    },
+  );
 
-  it('displays the email address of the user', async () => {
-    const jsx = await AssignRoles({
-      params: { site: 'TEST' },
-      searchParams: { user: 'test@nhs.net' },
-    });
-    render(jsx);
-    expect(screen.getByText('Email')).toBeVisible();
-    expect(screen.getByText('test@nhs.net'));
-  });
   it('calls fetch users with the correct site id', async () => {
     const jsx = await AssignRoles({
       params: { site: 'TEST' },
@@ -79,6 +75,7 @@ describe('AssignRoles', () => {
     render(jsx);
     expect(fetchUsersMock).toHaveBeenCalledWith('TEST');
   });
+
   it('passes the correct props', async () => {
     const jsx = await AssignRoles({
       params: { site: 'TEST' },

--- a/src/client/src/app/site/[site]/users/manage/assign-roles.tsx
+++ b/src/client/src/app/site/[site]/users/manage/assign-roles.tsx
@@ -1,14 +1,15 @@
 ﻿import { UserPageProps } from './page';
-import { RoleAssignment } from '@types';
 import AssignRolesForm from './assign-roles-form';
 import React from 'react';
 import { fetchRoles, fetchUsers } from '@services/appointmentsService';
+import { notFound } from 'next/navigation';
 
 const AssignRoles = async ({ params, searchParams }: UserPageProps) => {
   const user = searchParams?.user;
 
-  if (user === undefined)
-    throw Error('You must specify a valid NHS email address');
+  if (user === undefined) {
+    return notFound();
+  }
 
   const [roles, users] = await Promise.all([
     fetchRoles(),
@@ -16,8 +17,11 @@ const AssignRoles = async ({ params, searchParams }: UserPageProps) => {
   ]);
 
   const currentUser = users.find(usr => usr.id === user);
-  const currentUserAssignments =
-    currentUser?.roleAssignments ?? ([] as RoleAssignment[]);
+  if (!currentUser) {
+    return notFound();
+  }
+
+  const currentUserAssignments = currentUser.roleAssignments;
 
   return (
     <>

--- a/src/client/src/app/site/[site]/users/manage/assign-roles.tsx
+++ b/src/client/src/app/site/[site]/users/manage/assign-roles.tsx
@@ -7,7 +7,7 @@ import { fetchRoles, fetchUsers } from '@services/appointmentsService';
 const AssignRoles = async ({ params, searchParams }: UserPageProps) => {
   const user = searchParams?.user;
 
-  if (user === undefined || !user.endsWith('@nhs.net'))
+  if (user === undefined)
     throw Error('You must specify a valid NHS email address');
 
   const [roles, users] = await Promise.all([

--- a/src/client/src/app/site/[site]/users/remove/remove-user-page.tsx
+++ b/src/client/src/app/site/[site]/users/remove/remove-user-page.tsx
@@ -33,10 +33,6 @@ const RemoveUserPage = ({ site, user }: { site: Site; user: string }) => {
       <p>This will:</p>
       <ul>
         <li>Revoke the user's access to this site only</li>
-        <li>
-          This will not affect their wider @nhs.net account - this will only
-          remove them from the National Booking System
-        </li>
         <li>This will not remove their access from any other sites</li>
       </ul>
 


### PR DESCRIPTION
The Assign Roles page is currently overly strict and throws an error if the user provided in the url parameters is not an @nhs.net user. This check should be relaxed to pave the way for Okta users. 

I've also changed the behaviour to throw a 404 if the user is missing or not found in the API response rather than throwing an error, as this feels more correct. 