### PR TITLE
APPT-672 Add registration of IConfigurationRefresher.

### DIFF
--- a/src/api/Nhs.Appointments.Api/Features/FeatureConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/Features/FeatureConfigurationExtensions.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.FeatureManagement;
+using Microsoft.FeatureManagement.FeatureFilters;
+
+namespace Nhs.Appointments.Api.Features;
+
+public static class FeatureConfigurationExtensions
+{
+    public static IHostBuilder ConfigureFeatureDependencies(this IHostBuilder builder)
+    {
+        IConfigurationRefresher configRefresher = null;
+
+        builder.ConfigureAppConfiguration((_, cfg) =>
+        {
+            var azureAppConfigConnection = Environment.GetEnvironmentVariable("APP_CONFIG_CONNECTION");
+            if (azureAppConfigConnection == "local")
+            {
+                configRefresher = new LocalConfigurationRefresher();
+                var configPath = Path.Combine(AppContext.BaseDirectory, "local.feature.flags.json");
+                cfg.AddJsonFile(configPath, optional: false, reloadOnChange: true);
+            }
+            else
+            {
+                cfg.AddAzureAppConfiguration(options =>
+                {
+                    options.Connect(azureAppConfigConnection)
+                        .UseFeatureFlags()
+                        .ConfigureRefresh(refresh =>
+                        {
+                            refresh.RegisterAll()
+                                .SetRefreshInterval(TimeSpan.FromMinutes(10));
+                        });
+
+                    //capture refresher and register it
+                    configRefresher = options.GetRefresher();
+                });
+            }
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            services
+                .AddFeatureManagement()
+                .AddFeatureFilter<PercentageFilter>()
+                .AddFeatureFilter<TargetingFilter>()
+                .AddFeatureFilter<TimeWindowFilter>();
+
+            services.AddSingleton(configRefresher);
+            services.AddSingleton<ITargetingContextAccessor, DefaultContextAccessor>();
+        });
+        
+        return builder;
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Features/FeatureToggleHelper.cs
+++ b/src/api/Nhs.Appointments.Api/Features/FeatureToggleHelper.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.FeatureManagement;
 using Microsoft.FeatureManagement.FeatureFilters;
 
 namespace Nhs.Appointments.Api.Features;
 
-public class FeatureToggleHelper(IFeatureManager featureManager) : IFeatureToggleHelper
+public class FeatureToggleHelper(IFeatureManager featureManager, IConfigurationRefresher configRefresher) : IFeatureToggleHelper
 {
     public async Task<bool> IsFeatureEnabled(string featureFlag)
     {
@@ -13,6 +14,10 @@ public class FeatureToggleHelper(IFeatureManager featureManager) : IFeatureToggl
         {
             throw new ArgumentException("FeatureFlag cannot be null or empty.");
         }
+        
+        // fire and forget to not block execution
+        // means a slight delay in applying the very latest configuration, but its worth it to not block every time this is invoked
+        _ = configRefresher.RefreshAsync();
         
         return await featureManager.IsEnabledAsync(featureFlag);
     }
@@ -31,6 +36,10 @@ public class FeatureToggleHelper(IFeatureManager featureManager) : IFeatureToggl
 
         var targetingContext = new TargetingContext { UserId = userId };
 
+        // fire and forget to not block execution
+        // means a slight delay in applying the very latest configuration, but its worth it to not block every time this is invoked
+        _ = configRefresher.RefreshAsync();
+        
         return await featureManager.IsEnabledAsync(featureFlag, targetingContext);
     }
 
@@ -48,6 +57,10 @@ public class FeatureToggleHelper(IFeatureManager featureManager) : IFeatureToggl
 
         var targetingContext = new TargetingContext { Groups = [$"Site:{siteId}"] };
 
+        // fire and forget to not block execution
+        // means a slight delay in applying the very latest configuration, but its worth it to not block every time this is invoked
+        _ = configRefresher.RefreshAsync();
+        
         return await featureManager.IsEnabledAsync(featureFlag, targetingContext);
     }
 }

--- a/src/api/Nhs.Appointments.Api/Features/LocalConfigurationRefresher.cs
+++ b/src/api/Nhs.Appointments.Api/Features/LocalConfigurationRefresher.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+
+namespace Nhs.Appointments.Api.Features;
+
+public class LocalConfigurationRefresher : IConfigurationRefresher
+{
+    public Task<bool> TryRefreshAsync(CancellationToken cancellationToken = default) => Task.FromResult(true);
+
+    public void ProcessPushNotification(PushNotification pushNotification, TimeSpan? maxDelay = null) { }
+
+    public Uri AppConfigurationEndpoint => new(string.Empty);
+
+    public Task RefreshAsync(CancellationToken cancellationToken = new()) => Task.CompletedTask;
+}

--- a/src/api/Nhs.Appointments.Api/Program.cs
+++ b/src/api/Nhs.Appointments.Api/Program.cs
@@ -1,10 +1,4 @@
-using System;
-using System.IO;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.FeatureManagement;
-using Microsoft.FeatureManagement.FeatureFilters;
 using Nhs.Appointments.Api;
 using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Features;
@@ -13,38 +7,7 @@ using Nhs.Appointments.Api.Middleware;
 using Nhs.Appointments.Audit;
 
 var host = new HostBuilder()
-    .ConfigureAppConfiguration((ctx, cfg) =>
-    {
-        var azureAppConfigConnection = Environment.GetEnvironmentVariable("APP_CONFIG_CONNECTION");
-        if (azureAppConfigConnection == "local")
-        {
-            var configPath = Path.Combine(AppContext.BaseDirectory, "local.feature.flags.json");
-            cfg.AddJsonFile(configPath, optional: false, reloadOnChange: true);
-        }
-        else
-        {
-            cfg.AddAzureAppConfiguration(options =>
-            {
-                options
-                    .Connect(azureAppConfigConnection)
-                    .UseFeatureFlags()
-                    .ConfigureRefresh(refresh =>
-                    {
-                        refresh.RegisterAll().SetRefreshInterval(TimeSpan.FromMinutes(1));
-                    });
-            });
-        }
-    })
-    .ConfigureServices(services =>
-    {
-        services
-            .AddFeatureManagement()
-            .AddFeatureFilter<PercentageFilter>()
-            .AddFeatureFilter<TargetingFilter>()
-            .AddFeatureFilter<TimeWindowFilter>();
-
-        services.AddSingleton<ITargetingContextAccessor, DefaultContextAccessor>();
-    })
+    .ConfigureFeatureDependencies()
     .ConfigureFunctionsWebApplication(builder =>
     {
         builder

--- a/tests/Nhs.Appointments.Api.UnitTests/Features/FeatureToggleHelperTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Features/FeatureToggleHelperTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.FeatureManagement;
 using Microsoft.FeatureManagement.FeatureFilters;
 using Moq;
@@ -10,6 +11,7 @@ public class FeatureToggleHelperTests
 {
     private static readonly string TestFlag = "testFlag";
     private readonly Mock<IFeatureManager> _featureManager = new();
+    private readonly Mock<IConfigurationRefresher> _configRefresher = new();
 
     [Theory]
     [InlineData(false)]
@@ -18,7 +20,7 @@ public class FeatureToggleHelperTests
     {
         _featureManager.Setup(x => x.IsEnabledAsync(TestFlag)).ReturnsAsync(isEnabled);
 
-        var sut = new FeatureToggleHelper(_featureManager.Object);
+        var sut = new FeatureToggleHelper(_featureManager.Object, _configRefresher.Object);
         var result = await sut.IsFeatureEnabled(TestFlag);
         result.Should().Be(isEnabled);
     }
@@ -30,7 +32,7 @@ public class FeatureToggleHelperTests
     {
         _featureManager.Setup(x => x.IsEnabledAsync(TestFlag)).ReturnsAsync(true);
 
-        var sut = new FeatureToggleHelper(_featureManager.Object);
+        var sut = new FeatureToggleHelper(_featureManager.Object, _configRefresher.Object);
         var featureEnabled = async () => { await sut.IsFeatureEnabled(flag); };
         await featureEnabled.Should().ThrowAsync<ArgumentException>().WithMessage("FeatureFlag cannot be null or empty.");
     }
@@ -42,7 +44,7 @@ public class FeatureToggleHelperTests
     {
         _featureManager.Setup(x => x.IsEnabledAsync(TestFlag)).ReturnsAsync(true);
 
-        var sut = new FeatureToggleHelper(_featureManager.Object);
+        var sut = new FeatureToggleHelper(_featureManager.Object, _configRefresher.Object);
         var featureEnabled = async () => { await sut.IsFeatureEnabledForUser(flag, "testUser"); };
         await featureEnabled.Should().ThrowAsync<ArgumentException>().WithMessage("FeatureFlag cannot be null or empty.");
     }
@@ -54,7 +56,7 @@ public class FeatureToggleHelperTests
     {
         _featureManager.Setup(x => x.IsEnabledAsync(TestFlag)).ReturnsAsync(true);
 
-        var sut = new FeatureToggleHelper(_featureManager.Object);
+        var sut = new FeatureToggleHelper(_featureManager.Object, _configRefresher.Object);
         var featureEnabled = async () => { await sut.IsFeatureEnabledForUser(TestFlag, user); };
         await featureEnabled.Should().ThrowAsync<ArgumentException>().WithMessage("UserId cannot be null or empty.");
     }
@@ -66,7 +68,7 @@ public class FeatureToggleHelperTests
     {
         _featureManager.Setup(x => x.IsEnabledAsync(TestFlag)).ReturnsAsync(true);
 
-        var sut = new FeatureToggleHelper(_featureManager.Object);
+        var sut = new FeatureToggleHelper(_featureManager.Object, _configRefresher.Object);
         var featureEnabled = async () => { await sut.IsFeatureEnabledForSite(flag, "testUser"); };
         await featureEnabled.Should().ThrowAsync<ArgumentException>().WithMessage("FeatureFlag cannot be null or empty.");
     }
@@ -78,7 +80,7 @@ public class FeatureToggleHelperTests
     {
         _featureManager.Setup(x => x.IsEnabledAsync(TestFlag)).ReturnsAsync(true);
 
-        var sut = new FeatureToggleHelper(_featureManager.Object);
+        var sut = new FeatureToggleHelper(_featureManager.Object, _configRefresher.Object);
         var featureEnabled = async () => { await sut.IsFeatureEnabledForSite(TestFlag, site); };
         await featureEnabled.Should().ThrowAsync<ArgumentException>().WithMessage("SiteId cannot be null or empty.");
     }
@@ -94,7 +96,7 @@ public class FeatureToggleHelperTests
             .Setup(x => x.IsEnabledAsync(TestFlag,
                 It.Is<TargetingContext>(y => y.Groups == null && y.UserId == testUser))).ReturnsAsync(isEnabled);
 
-        var sut = new FeatureToggleHelper(_featureManager.Object);
+        var sut = new FeatureToggleHelper(_featureManager.Object, _configRefresher.Object);
         var result = await sut.IsFeatureEnabledForUser(TestFlag, testUser);
         result.Should().Be(isEnabled);
     }
@@ -113,7 +115,7 @@ public class FeatureToggleHelperTests
                 It.Is<TargetingContext>(y => y.Groups.SequenceEqual(array) && y.UserId == null)))
             .ReturnsAsync(isEnabled);
 
-        var sut = new FeatureToggleHelper(_featureManager.Object);
+        var sut = new FeatureToggleHelper(_featureManager.Object, _configRefresher.Object);
         var result = await sut.IsFeatureEnabledForSite(TestFlag, testSite);
         result.Should().Be(isEnabled);
     }


### PR DESCRIPTION
The app has the ability to call the refresh when a feature toggle state is requested. Fire off without awaiting to avoid execution delay. Register local config refresher. Refactor all feature related registration into a single place.