### PR TITLE
APPT-742 - Enable functions in the correct function apps

### DIFF
--- a/infrastructure/resources/high_load_functions.tf
+++ b/infrastructure/resources/high_load_functions.tf
@@ -107,6 +107,14 @@ resource "azurerm_windows_function_app" "nbs_mya_high_load_func_app" {
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true
     "AzureWebJobs.SendBookingReminders.Disabled"                           = true
     "AzureWebJobs.RemoveUnconfirmedProvisionalBookings.Disabled"           = true
+    "AzureWebJobs.BulkImportFunction.Disabled"                             = true
+    "AzureWebJobs.GetFeatureFlagFunction.Disabled"                         = true
+    "AzureWebJobs.RemoveUserFunction.Disabled"                             = true
+    "AzureWebJobs.RenderOAuth2Redirect.Disabled"                           = true
+    "AzureWebJobs.RenderOpenApiDocument.Disabled"                          = true
+    "AzureWebJobs.RenderSwaggerDocument.Disabled"                          = true
+    "AzureWebJobs.RenderSwaggerUI.Disabled"                                = true
+    "AzureWebJobs.SetSiteDetailsFunction.Disabled"                         = true
   }
 
   sticky_settings {

--- a/infrastructure/resources/servicebus_functions.tf
+++ b/infrastructure/resources/servicebus_functions.tf
@@ -80,6 +80,15 @@ resource "azurerm_windows_function_app" "nbs_mya_service_bus_func_app" {
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true
     "AzureWebJobs.SendBookingReminders.Disabled"                           = true
     "AzureWebJobs.RemoveUnconfirmedProvisionalBookings.Disabled"           = true
+    "AzureWebJobs.BulkImportFunction.Disabled"                             = true
+    "AzureWebJobs.GetFeatureFlagFunction.Disabled"                         = true
+    "AzureWebJobs.RemoveUserFunction.Disabled"                             = true
+    "AzureWebJobs.RenderOAuth2Redirect.Disabled"                           = true
+    "AzureWebJobs.RenderOpenApiDocument.Disabled"                          = true
+    "AzureWebJobs.RenderSwaggerDocument.Disabled"                          = true
+    "AzureWebJobs.RenderSwaggerUI.Disabled"                                = true
+    "AzureWebJobs.SetSiteDetailsFunction.Disabled"                         = true
+
   }
 
   sticky_settings {

--- a/infrastructure/resources/timer_functions.tf
+++ b/infrastructure/resources/timer_functions.tf
@@ -86,6 +86,14 @@ resource "azurerm_windows_function_app" "nbs_mya_timer_func_app" {
     "AzureWebJobs.SetUserRoles.Disabled"                                   = true
     "AzureWebJobs.TriggerBookingReminders.Disabled"                        = true
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true
+    "AzureWebJobs.BulkImportFunction.Disabled"                             = true
+    "AzureWebJobs.GetFeatureFlagFunction.Disabled"                         = true
+    "AzureWebJobs.RemoveUserFunction.Disabled"                             = true
+    "AzureWebJobs.RenderOAuth2Redirect.Disabled"                           = true
+    "AzureWebJobs.RenderOpenApiDocument.Disabled"                          = true
+    "AzureWebJobs.RenderSwaggerDocument.Disabled"                          = true
+    "AzureWebJobs.RenderSwaggerUI.Disabled"                                = true
+    "AzureWebJobs.SetSiteDetailsFunction.Disabled"                         = true
   }
 
   sticky_settings {


### PR DESCRIPTION
Timer function app should only have time triggered functions

HTTP function app should have all HTTP functions enabled (apart from highload HTTP functions)

Highload function app should only have HTTP functions that are determined as highload.

Service Bus function app should only have service bus consumers enabled