### PR TITLE
error code updated to 410 for joint bookings plus 412 to the swagger document

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
@@ -44,6 +44,12 @@ public class ConfirmProvisionalBookingFunction(
         Description = "Request failed due to insufficient permissions")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Gone, "application/json", typeof(ErrorMessageResponseItem),
         Description = "Request failed because the provisional booking has expired")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Gone, "application/json", typeof(ErrorMessageResponseItem),
+        Description = "The booking cannot be confirmed because group references are not valid")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.PreconditionFailed, "application/json", typeof(ErrorMessageResponseItem),
+        Description = "The nhs number for the provisional booking and the booking to be rescheduled do not match")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.PreconditionFailed, "application/json", typeof(ErrorMessageResponseItem),
+        Description = "The booking cannot be confirmed because it is not provisional")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, "application/json", typeof(ErrorMessageResponseItem),
         Description = "Request failed because a provisional booking with matching reference could not be found")]
     [RequiresPermission(Permissions.MakeBooking, typeof(SiteFromPathInspector))]
@@ -88,7 +94,7 @@ public class ConfirmProvisionalBookingFunction(
                 return Failed(HttpStatusCode.PreconditionFailed,
                     "The booking cannot be confirmed because it is not provisional");
             case BookingConfirmationResult.GroupBookingInvalid:
-                return Failed(HttpStatusCode.PreconditionFailed,
+                return Failed(HttpStatusCode.Gone,
                     "The booking cannot be confirmed because group references are not valid");
             case BookingConfirmationResult.Success:
                 return Success();

--- a/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
@@ -44,12 +44,8 @@ public class ConfirmProvisionalBookingFunction(
         Description = "Request failed due to insufficient permissions")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Gone, "application/json", typeof(ErrorMessageResponseItem),
         Description = "Request failed because the provisional booking has expired")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Gone, "application/json", typeof(ErrorMessageResponseItem),
-        Description = "The booking cannot be confirmed because group references are not valid")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.PreconditionFailed, "application/json", typeof(ErrorMessageResponseItem),
-        Description = "The nhs number for the provisional booking and the booking to be rescheduled do not match")]
-    [OpenApiResponseWithBody(statusCode: HttpStatusCode.PreconditionFailed, "application/json", typeof(ErrorMessageResponseItem),
-        Description = "The booking cannot be confirmed because it is not provisional")]
+        Description = "Request failed because the provisional booking and the booking to be rescheduled do not match")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, "application/json", typeof(ErrorMessageResponseItem),
         Description = "Request failed because a provisional booking with matching reference could not be found")]
     [RequiresPermission(Permissions.MakeBooking, typeof(SiteFromPathInspector))]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBooking.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBooking.feature
@@ -112,7 +112,7 @@ Feature: Book an appointment
        | Date     | From  | Until | Services | Slot Length | Capacity |
        | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
      When I confirm the bookings
-     Then the call should fail with 412
+     Then the call should fail with 410
  
    Scenario: JB:Cannot confirm a provisional appointment that has expired
      Given the site is configured for MYA
@@ -124,7 +124,7 @@ Feature: Book an appointment
        | Tomorrow | 09:00 | 5        | COVID   |
        | Tomorrow | 09:05 | 5        | COVID   |
      When I confirm the bookings
-     Then the call should fail with 412
+     Then the call should fail with 410
  
    Scenario: JB:A provisional booking expires
      Given the site is configured for MYA
@@ -149,4 +149,4 @@ Feature: Book an appointment
        | Tomorrow | 09:00 | 5        | COVID   |
        | Tomorrow | 09:05 | 5        | COVID   |
      When I confirm the bookings
-     Then the call should fail with 412
+     Then the call should fail with 410


### PR DESCRIPTION
Updated joint bookings error to match single bookings with 410 status code "the requested resource is no longer available and has been removed permanently".

Also added 412 to the swagger document as this was missing