### PR TITLE
SRE-402: Enable joint bookings in staging

### DIFF
--- a/features/stag.feature.flags.json
+++ b/features/stag.feature.flags.json
@@ -2,7 +2,7 @@
   "FeatureManagement": {
     "OktaEnabled": false,
     "MultiServiceAvailabilityCalculations": false,
-    "JointBookings": false,
+    "JointBookings": true,
     "BulkImport": false
   }
 }


### PR DESCRIPTION
We need to performance test Joint Bookings. In order to do this, we need to enable its feature flag in Staging. 

For various reasons, this can currently only be done in Staging and can't be done in Int. I don't like letting Staging deviate from what's in Production, but frankly it already has and until we get a separate perf environment this is the world we're in. 