### PR TITLE
Prevent the feature toggles pipeline from running on PRs

### DIFF
--- a/azure-pipelines-feature-toggles.yml
+++ b/azure-pipelines-feature-toggles.yml
@@ -1,10 +1,6 @@
-trigger:
-  paths:
-    include:
-    - features/*
-  branches:
-    include:
-    - main
+trigger: none
+pr: none
+
 pool:
   vmImage: "ubuntu-latest"
 


### PR DESCRIPTION
We're currently triggering the feature toggles pipeline when a PR is made or when a PR is merged into main. This pipeline should only ever be ran manually through the DevOps UI, so this PR removes the automatic triggers. 