### PR TITLE
make user role change only return its scope so that notifications dont consider roles that arent relevant as they are not part of the scope

### DIFF
--- a/src/api/Nhs.Appointments.Core/IUserStore.cs
+++ b/src/api/Nhs.Appointments.Core/IUserStore.cs
@@ -5,7 +5,7 @@ public interface IUserStore
     Task<User> GetUserAsync(string userId);
     Task<IEnumerable<RoleAssignment>> GetUserRoleAssignments(string userId);
     Task<string> GetApiUserSigningKey(string clientId);
-    Task<RoleAssignment[]> UpdateUserRoleAssignments(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
+    Task UpdateUserRoleAssignments(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
     Task<IEnumerable<User>> GetUsersAsync(string site);
     Task<User> GetOrDefaultAsync(string userId);
     Task<OperationResult> RemoveUserAsync(string userId, string siteId);

--- a/src/api/Nhs.Appointments.Core/IUserStore.cs
+++ b/src/api/Nhs.Appointments.Core/IUserStore.cs
@@ -1,4 +1,4 @@
-﻿namespace Nhs.Appointments.Core;
+namespace Nhs.Appointments.Core;
 
 public interface IUserStore
 {
@@ -6,7 +6,6 @@ public interface IUserStore
     Task<IEnumerable<RoleAssignment>> GetUserRoleAssignments(string userId);
     Task<string> GetApiUserSigningKey(string clientId);
     Task<RoleAssignment[]> UpdateUserRoleAssignments(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
-    Task SaveUserAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
     Task<IEnumerable<User>> GetUsersAsync(string site);
     Task<User> GetOrDefaultAsync(string userId);
     Task<OperationResult> RemoveUserAsync(string userId, string siteId);

--- a/src/api/Nhs.Appointments.Core/UserService.cs
+++ b/src/api/Nhs.Appointments.Core/UserService.cs
@@ -72,7 +72,7 @@ public class UserService(IUserStore userStore, IRolesStore rolesStore, IMessageB
     }
 
     public Task SaveUserAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
-        => userStore.SaveUserAsync(userId, scope, roleAssignments);
+        => userStore.UpdateUserRoleAssignments(userId, scope, roleAssignments);
 }
 
 public record UpdateUserRoleAssignmentsResult(bool success, string errorUser, IEnumerable<string> errorRoles)

--- a/src/api/Nhs.Appointments.Core/UserService.cs
+++ b/src/api/Nhs.Appointments.Core/UserService.cs
@@ -22,43 +22,59 @@ public class UserService(IUserStore userStore, IRolesStore rolesStore, IMessageB
 
     public async Task<UpdateUserRoleAssignmentsResult> UpdateUserRoleAssignmentsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
     {
+        var invalidRolesForScope = roleAssignments.Where(x => !x.Scope.Equals(scope));
+        if (invalidRolesForScope.Any()) 
+        {
+            throw new InvalidOperationException($"Invalid Role assignments based on the passed scope {scope}. Scopes not expected - {string.Join(", ", invalidRolesForScope.Select(x => x.Scope).Distinct())}");
+        }
+
         var allRoles = await rolesStore.GetRoles();
-        var lowerUserId = userId.ToLower();
         var invalidRoles = roleAssignments.Where(ra => !allRoles.Any(r => r.Id == ra.Role));
         if (invalidRoles.Any())
         {
             return new UpdateUserRoleAssignmentsResult(false, "", invalidRoles.Select(ra => ra.Role));
         }
 
-        var oldRoles = await userStore.UpdateUserRoleAssignments(lowerUserId, scope, roleAssignments);
+        var lowerUserId = userId.ToLower();
+
+        var user = await userStore.GetUserAsync(lowerUserId);
+
+        await userStore.UpdateUserRoleAssignments(lowerUserId, scope, roleAssignments);
+
+        if (!scope.Equals("*"))
+        {
+            await NotifyRoleAssignmentChanged(lowerUserId, Scope.GetValue("site", scope), user?.RoleAssignments.Where(x => x.Scope.Equals(scope)) ?? [], roleAssignments);
+        }
+
+        return new UpdateUserRoleAssignmentsResult(true, string.Empty, []);
+    }
+
+    private async Task NotifyRoleAssignmentChanged(string userId, string site, IEnumerable<RoleAssignment> oldAssignments, IEnumerable<RoleAssignment> newAssignments) 
+    {
         IEnumerable<RoleAssignment> rolesRemoved = [];
-        IEnumerable<RoleAssignment> rolesAdded;
+        IEnumerable<RoleAssignment> rolesAdded = [];
 
         // New user
-        if (oldRoles.Length == 0)
+        if (oldAssignments.Count() == 0)
         {
-            rolesAdded = roleAssignments;
+            rolesAdded = newAssignments;
         }
         else
         {
-            rolesRemoved = oldRoles.Where(old => !roleAssignments.Any(r => r.Role == old.Role));
-            rolesAdded = roleAssignments.Where(newRole => !oldRoles.Any(r => r.Role == newRole.Role));
+            rolesRemoved = oldAssignments.Where(old => !newAssignments.Any(r => r.Role == old.Role));
+            rolesAdded = newAssignments.Where(newRole => !oldAssignments.Any(r => r.Role == newRole.Role));
         }
 
-        var site = Scope.GetValue("site", scope);
-
-        if (lowerUserId.EndsWith("@nhs.net"))
+        if (userId.EndsWith("@nhs.net"))
         {
             //NHS user
-            await bus.Send(new UserRolesChanged { UserId = lowerUserId, SiteId = site, AddedRoleIds = rolesAdded.Select(r => r.Role).ToArray(), RemovedRoleIds = rolesRemoved.Select(r => r.Role).ToArray()});
+            await bus.Send(new UserRolesChanged { UserId = userId, SiteId = site, AddedRoleIds = rolesAdded.Select(r => r.Role).ToArray(), RemovedRoleIds = rolesRemoved.Select(r => r.Role).ToArray() });
         }
         else
         {
             //OKTA user
-            await bus.Send(new OktaUserRolesChanged { UserId = lowerUserId, SiteId = site, AddedRoleIds = rolesAdded.Select(r => r.Role).ToArray(), RemovedRoleIds = rolesRemoved.Select(r => r.Role).ToArray() });
+            await bus.Send(new OktaUserRolesChanged { UserId = userId, SiteId = site, AddedRoleIds = rolesAdded.Select(r => r.Role).ToArray(), RemovedRoleIds = rolesRemoved.Select(r => r.Role).ToArray() });
         }
-
-        return new UpdateUserRoleAssignmentsResult(true, string.Empty, []);
     }
 
     public Task<IEnumerable<User>> GetUsersAsync(string site) 

--- a/src/api/Nhs.Appointments.Persistance/UserStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/UserStore.cs
@@ -35,7 +35,7 @@ public class UserStore(ITypedDocumentCosmosStore<UserDocument> cosmosStore, IMap
     /// <param name="roleAssignments"></param>
     /// <returns>The original role assignments for the scope prior to completion of the update operation</returns>
     /// <exception cref="Exception"></exception>
-    public async Task<RoleAssignment[]> UpdateUserRoleAssignments(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
+    public async Task UpdateUserRoleAssignments(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
     {
         var originalDocument = await GetOrDefaultAsync(userId);
         if (originalDocument == null)
@@ -46,7 +46,6 @@ public class UserStore(ITypedDocumentCosmosStore<UserDocument> cosmosStore, IMap
                 RoleAssignments = roleAssignments.ToArray()
             };
             await InsertAsync(user);
-            return [];
         }
         else
         {
@@ -57,8 +56,6 @@ public class UserStore(ITypedDocumentCosmosStore<UserDocument> cosmosStore, IMap
                 .Concat(roleAssignments);
             var userDocumentPatch = PatchOperation.Add("/roleAssignments", newRoleAssignments);
             await cosmosStore.PatchDocument(documentType, userId, userDocumentPatch);
-
-            return originalDocument.RoleAssignments.Where(x => x.Scope == scope).ToArray();
         }
     }
 

--- a/src/api/Nhs.Appointments.Persistance/UserStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/UserStore.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Microsoft.Azure.Cosmos;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
@@ -33,7 +33,7 @@ public class UserStore(ITypedDocumentCosmosStore<UserDocument> cosmosStore, IMap
     /// <param name="userId"></param>
     /// <param name="scope"></param>
     /// <param name="roleAssignments"></param>
-    /// <returns>The original role assignments prior to completion of the update operation</returns>
+    /// <returns>The original role assignments for the scope prior to completion of the update operation</returns>
     /// <exception cref="Exception"></exception>
     public async Task<RoleAssignment[]> UpdateUserRoleAssignments(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
     {
@@ -58,33 +58,13 @@ public class UserStore(ITypedDocumentCosmosStore<UserDocument> cosmosStore, IMap
             var userDocumentPatch = PatchOperation.Add("/roleAssignments", newRoleAssignments);
             await cosmosStore.PatchDocument(documentType, userId, userDocumentPatch);
 
-
-            return originalDocument.RoleAssignments;
+            return originalDocument.RoleAssignments.Where(x => x.Scope == scope).ToArray();
         }
     }
 
     public async Task SaveUserAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
     {
-        var originalDocument = await GetOrDefaultAsync(userId);
-        if (originalDocument == null)
-        {
-            var user = new User
-            {
-                Id = userId,
-                RoleAssignments = roleAssignments.ToArray()
-            };
-            await InsertAsync(user);
-        }
-        else
-        {
-            var documentType = cosmosStore.GetDocumentType();
-            var originalRoleAssignments = originalDocument.RoleAssignments;
-            var newRoleAssignments = originalRoleAssignments
-                .Where(ra => ra.Scope != scope)
-                .Concat(roleAssignments);
-            var userDocumentPatch = PatchOperation.Add("/roleAssignments", newRoleAssignments);
-            await cosmosStore.PatchDocument(documentType, userId, userDocumentPatch);
-        }
+        await UpdateUserRoleAssignments(userId, scope, roleAssignments);
     }
 
     public async Task<OperationResult> RemoveUserAsync(string userId, string siteId)

--- a/src/api/Nhs.Appointments.Persistance/UserStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/UserStore.cs
@@ -62,11 +62,6 @@ public class UserStore(ITypedDocumentCosmosStore<UserDocument> cosmosStore, IMap
         }
     }
 
-    public async Task SaveUserAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
-    {
-        await UpdateUserRoleAssignments(userId, scope, roleAssignments);
-    }
-
     public async Task<OperationResult> RemoveUserAsync(string userId, string siteId)
     {
         var user = await GetOrDefaultAsync(userId);

--- a/tests/Nhs.Appointments.Core.UnitTests/UserServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/UserServiceTests.cs
@@ -20,11 +20,11 @@ namespace Nhs.Appointments.Core.UnitTests
         {
             const string userId = "user1";
             const string scope = "site:some-site";
-            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1" }];
+            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1", Scope = scope }];
             IEnumerable<Role> databaseRoles = [new Role { Id = "role1" }];
 
             _userStore.Setup(x => x.GetOrDefaultAsync(userId)).Returns(Task.FromResult<User>(new User { Id = userId }));
-            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>())).Returns(Task.FromResult<RoleAssignment[]>([new RoleAssignment { Role = "someoldrole"}]));
+            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>())).Returns(Task.FromResult<RoleAssignment[]>([new RoleAssignment { Role = "someoldrole", Scope = scope }]));
             _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult(databaseRoles));
             _messageBus.Setup(x => x.Send(It.Is<UserRolesChanged>(e => e.AddedRoleIds.Contains(newRoles[0].Role)))).Verifiable();
 
@@ -38,11 +38,11 @@ namespace Nhs.Appointments.Core.UnitTests
         {
             const string userId = "user1";
             const string scope = "site:some-site";
-            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1" }];
+            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1", Scope = scope }];
             IEnumerable<Role> databaseRoles = [new Role { Id = "role1" }];
 
-            _userStore.Setup(x => x.GetOrDefaultAsync(userId)).Returns(Task.FromResult<User>(new User { Id = userId }));
-            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>())).Returns(Task.FromResult<RoleAssignment[]>([new RoleAssignment { Role = "someoldrole" }]));
+            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>()));
+            _userStore.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(new User { Id = userId, RoleAssignments = [new RoleAssignment { Role = "someoldrole", Scope = scope }] });
             _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult(databaseRoles));
             _messageBus.Setup(x => x.Send(It.Is<UserRolesChanged>(e => e.RemovedRoleIds.Contains("someoldrole")))).Verifiable();
 
@@ -57,11 +57,11 @@ namespace Nhs.Appointments.Core.UnitTests
             const string userId = "user1";
             const string scope = "site:some-site";
             const string site = "some-site";
-            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1" }];
+            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1", Scope = scope }];
             IEnumerable<Role> databaseRoles = [new Role { Id = "role1" }];
 
             _userStore.Setup(x => x.GetOrDefaultAsync(userId)).Returns(Task.FromResult<User>(new User { Id = userId }));
-            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>())).Returns(Task.FromResult<RoleAssignment[]>([new RoleAssignment { Role = "someoldrole" }]));
+            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>())).Returns(Task.FromResult<RoleAssignment[]>([new RoleAssignment { Role = "someoldrole", Scope = scope }]));
             _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult(databaseRoles));
             _messageBus.Setup(x => x.Send(It.Is<UserRolesChanged>(e => e.SiteId == site))).Verifiable();
 
@@ -75,11 +75,11 @@ namespace Nhs.Appointments.Core.UnitTests
         {
             const string userId = "user1";
             const string scope = "site:some-site";
-            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1" }];
+            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1", Scope = scope }];
             IEnumerable<Role> databaseRoles = [new Role { Id = "role1" }];
 
             _userStore.Setup(x => x.GetOrDefaultAsync(userId)).Returns(Task.FromResult<User>(new User { Id = userId }));
-            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>())).Returns(Task.FromResult<RoleAssignment[]>([new RoleAssignment { Role = "someoldrole" }]));
+            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>())).Returns(Task.FromResult<RoleAssignment[]>([new RoleAssignment { Role = "someoldrole", Scope = scope }]));
             _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult(databaseRoles));
             _messageBus.Setup(x => x.Send(It.Is<UserRolesChanged>(e => e.UserId == userId))).Verifiable();
 
@@ -93,11 +93,11 @@ namespace Nhs.Appointments.Core.UnitTests
         {
             const string userId = "user1";
             const string scope = "site:some-site";
-            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1" }, new RoleAssignment { Role = "not a role"}];
+            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1", Scope = scope }, new RoleAssignment { Role = "not a role", Scope = scope }];
             IEnumerable<Role> databaseRoles = [new Role { Id = "role1" }, new Role { Id = "role2"}];
 
             _userStore.Setup(x => x.GetOrDefaultAsync(userId)).Returns(Task.FromResult<User>(new User { Id = userId }));
-            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>())).Returns(Task.FromResult<RoleAssignment[]>([new RoleAssignment { Role = "someoldrole" }]));
+            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>())).Returns(Task.FromResult<RoleAssignment[]>([new RoleAssignment { Role = "someoldrole", Scope = scope }]));
             _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult(databaseRoles));
 
             var result = await _sut.UpdateUserRoleAssignmentsAsync(userId, scope, newRoles);
@@ -111,12 +111,12 @@ namespace Nhs.Appointments.Core.UnitTests
         {
             const string userId = "user1";
             const string scope = "site:some-site";
-            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1" }];
+            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1", Scope = scope }];
             IEnumerable<Role> databaseRoles = [new Role { Id = "role1" }];
 
             _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult(databaseRoles));
-            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>()))
-                .ReturnsAsync([]);
+            _userStore.Setup(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>()));
+            _userStore.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync((User)null);
             _messageBus.Setup(x => x.Send(It.Is<UserRolesChanged>(e => e.AddedRoleIds.Length == 1 && e.AddedRoleIds.First() == "role1" && e.RemovedRoleIds.Length == 0))).Verifiable();
 
             await _sut.UpdateUserRoleAssignmentsAsync(userId, scope, newRoles);
@@ -131,11 +131,11 @@ namespace Nhs.Appointments.Core.UnitTests
         public async Task ConvertsUserIdToLowerCaseWhenCallingStore(string userId)
         {
             const string scope = "site:some-site";
-            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1" }];
+            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1", Scope = scope }];
             IEnumerable<Role> databaseRoles = [new Role { Id = "role1" }];
 
-            _userStore.Setup(x => x.UpdateUserRoleAssignments(It.IsAny<string>(), scope, It.IsAny<IEnumerable<RoleAssignment>>()))
-                .ReturnsAsync([new RoleAssignment { Role = "someoldrole" }]);
+            _userStore.Setup(x => x.UpdateUserRoleAssignments(It.IsAny<string>(), scope, It.IsAny<IEnumerable<RoleAssignment>>()));
+            _userStore.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(new User() { Id = userId, RoleAssignments = [new RoleAssignment { Role = "someoldrole", Scope = scope }] });
             _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult(databaseRoles));
 
             _ = await _sut.UpdateUserRoleAssignmentsAsync(userId, scope, newRoles);
@@ -144,6 +144,52 @@ namespace Nhs.Appointments.Core.UnitTests
 
             _messageBus.Verify(x => x.Send(It.Is<UserRolesChanged>(e => e.UserId.Equals(expectedUserId))));
             _userStore.Verify(x => x.UpdateUserRoleAssignments(expectedUserId, scope, It.IsAny<IEnumerable<RoleAssignment>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WhenMultipleScopes_ShouldThrowInvalidException()
+        {
+            const string userId = "test@nhs.net";
+            const string scope = "site:some-site";
+            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1", Scope = "site:some-other-site" }];
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _sut.UpdateUserRoleAssignmentsAsync(userId, scope, newRoles));
+        }
+
+        [Fact]
+        public async Task WhenUserGainsRole_AndHasAnotherScope_NotificationOnlySendForThatScope()
+        {
+            const string userId = "test@nhs.net";
+            const string scope = "site:some-site";
+            RoleAssignment[] newRoles = [new RoleAssignment { Role = "role1", Scope = scope }];
+            IEnumerable<Role> databaseRoles = [new Role { Id = "role1" }];
+
+            _userStore.Setup(x => x.UpdateUserRoleAssignments(It.IsAny<string>(), scope, It.IsAny<IEnumerable<RoleAssignment>>()));
+            _userStore.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(new User() { Id = userId, RoleAssignments = [new RoleAssignment { Role = "role1", Scope = "someotherscope" }] });
+            _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult(databaseRoles));
+
+            _ = await _sut.UpdateUserRoleAssignmentsAsync(userId, scope, newRoles);
+
+            _messageBus.Verify(x => x.Send(It.Is<UserRolesChanged>(e => e.AddedRoleIds.Contains("role1") && e.AddedRoleIds.Length == 1 && e.RemovedRoleIds.Length == 0)));
+            _userStore.Verify(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WhenUserLosesRole_AndHasAnotherScope_NotificationOnlySendForThatScope()
+        {
+            const string userId = "test@nhs.net";
+            const string scope = "site:some-site";
+            RoleAssignment[] newRoles = [];
+            IEnumerable<Role> databaseRoles = [new Role { Id = "role1" }];
+
+            _userStore.Setup(x => x.UpdateUserRoleAssignments(It.IsAny<string>(), scope, It.IsAny<IEnumerable<RoleAssignment>>()));
+            _userStore.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(new User() { Id = userId, RoleAssignments = [new RoleAssignment { Role = "role1", Scope = scope }, new RoleAssignment { Role = "role1", Scope = "someotherscope" }] });
+            _rolesStore.Setup(x => x.GetRoles()).Returns(Task.FromResult(databaseRoles));
+
+            _ = await _sut.UpdateUserRoleAssignmentsAsync(userId, scope, newRoles);
+
+            _messageBus.Verify(x => x.Send(It.Is<UserRolesChanged>(e => e.RemovedRoleIds.Contains("role1") && e.RemovedRoleIds.Length == 1 && e.AddedRoleIds.Length == 0)));
+            _userStore.Verify(x => x.UpdateUserRoleAssignments(userId, scope, It.IsAny<IEnumerable<RoleAssignment>>()), Times.Once);
         }
     }
 }

--- a/tests/Nhs.Appointments.Persistance.UnitTests/UserStoreTests.cs
+++ b/tests/Nhs.Appointments.Persistance.UnitTests/UserStoreTests.cs
@@ -1,0 +1,128 @@
+using AutoMapper;
+using Microsoft.Azure.Cosmos;
+using Nhs.Appointments.Persistance.Models;
+
+namespace Nhs.Appointments.Persistance.UnitTests
+{
+    public class UserStoreTests
+    {
+        private readonly Mock<ITypedDocumentCosmosStore<UserDocument>> _cosmosStore = new();
+        private readonly Mock<IMapper> _mapper = new();
+        private readonly UserStore _sut;
+
+        public UserStoreTests()
+        {
+            _sut = new UserStore(
+                _cosmosStore.Object,
+                _mapper.Object
+                );
+        }
+
+        [Fact]
+        public async Task UpdateUserRoleAssignments_WhenNoUser_CreatesUserAndReturnsEmptyArray() 
+        {
+            _cosmosStore.Setup(x => x.GetByIdOrDefaultAsync<User>(It.IsAny<string>())).ReturnsAsync((User)null);
+            _cosmosStore.Setup(x => x.ConvertToDocument(It.IsAny<Core.User>())).Returns(default(UserDocument));
+            _cosmosStore.Setup(x => x.GetDocumentType()).Returns("user");
+            _cosmosStore.Setup(x => x.WriteAsync(It.IsAny<UserDocument>()));
+
+            var roleAssignments = new List<Core.RoleAssignment>() { new() { Role = "test", Scope = "*" } };
+
+            var result = await _sut.UpdateUserRoleAssignments("test", "*", roleAssignments);
+
+            Assert.Equal([], result);
+            _cosmosStore.Verify(x => x.GetByIdOrDefaultAsync<Core.User>(It.IsAny<string>()), Times.Once);
+            _cosmosStore.Verify(x => x.ConvertToDocument(It.IsAny<Core.User>()), Times.Once);
+            _cosmosStore.Setup(x => x.GetDocumentType()).Returns("user");
+            _cosmosStore.Verify(x => x.WriteAsync(It.IsAny<UserDocument>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateUserRoleAssignments_WhenAddRoles_CreatesUserAndReturnsOriginalRoles()
+        {
+            var user = new Core.User() 
+            {
+                Id = "test",
+                RoleAssignments = [new() { Role = "test", Scope = "*" }]
+            };
+
+            _cosmosStore.Setup(x => x.GetByIdOrDefaultAsync<Core.User>(It.IsAny<string>())).ReturnsAsync(user);
+            _cosmosStore.Setup(x => x.GetDocumentType()).Returns("user");
+            _cosmosStore.Setup(x => x.PatchDocument(It.Is<string>(d => d.Equals("user")), It.IsAny<string>(), It.IsAny<PatchOperation[]>())).ReturnsAsync(default(UserDocument));
+
+            var roleAssignments = new List<Core.RoleAssignment>() { new() { Role = "test", Scope = "*" }, new() { Role = "test-2", Scope = "*" } };
+
+            var result = await _sut.UpdateUserRoleAssignments("test", "*", roleAssignments);
+
+            Assert.Equal(user.RoleAssignments, result);
+            _cosmosStore.Verify(x => x.GetByIdOrDefaultAsync<Core.User>(It.IsAny<string>()), Times.Once);
+            _cosmosStore.Verify(x => x.PatchDocument(It.Is<string>(d => d.Equals("user")), It.IsAny<string>(), It.IsAny<PatchOperation[]>()));
+        }
+
+        [Fact]
+        public async Task UpdateUserRoleAssignments_WhenRemoveRoles_CreatesUserAndReturnsOriginalRoles()
+        {
+            var user = new Core.User()
+            {
+                Id = "test",
+                RoleAssignments = [new() { Role = "test", Scope = "*" }, new() { Role = "test-2", Scope = "*" }]
+            };
+
+            _cosmosStore.Setup(x => x.GetByIdOrDefaultAsync<Core.User>(It.IsAny<string>())).ReturnsAsync(user);
+            _cosmosStore.Setup(x => x.GetDocumentType()).Returns("user");
+            _cosmosStore.Setup(x => x.PatchDocument(It.Is<string>(d => d.Equals("user")), It.IsAny<string>(), It.IsAny<PatchOperation[]>())).ReturnsAsync(default(UserDocument));
+
+            var roleAssignments = new List<Core.RoleAssignment>() { new() { Role = "test", Scope = "*" } };
+
+            var result = await _sut.UpdateUserRoleAssignments("test", "*", roleAssignments);
+
+            Assert.Equal(user.RoleAssignments, result);
+            _cosmosStore.Verify(x => x.GetByIdOrDefaultAsync<Core.User>(It.IsAny<string>()), Times.Once);
+            _cosmosStore.Verify(x => x.PatchDocument(It.Is<string>(d => d.Equals("user")), It.IsAny<string>(), It.IsAny<PatchOperation[]>()));
+        }
+
+        [Fact]
+        public async Task UpdateUserRoleAssignments_WhenUserHasMultipleScopesAndAddRoles_CreatesUserAndReturnsOriginalRoles()
+        {
+            var user = new Core.User()
+            {
+                Id = "test",
+                RoleAssignments = [new Core.RoleAssignment() { Role = "test", Scope = "*" }, new() { Role = "test", Scope = "2" }, new() { Role = "test-2", Scope = "2" }]
+            };
+
+            _cosmosStore.Setup(x => x.GetByIdOrDefaultAsync<Core.User>(It.IsAny<string>())).ReturnsAsync(user);
+            _cosmosStore.Setup(x => x.GetDocumentType()).Returns("user");
+            _cosmosStore.Setup(x => x.PatchDocument(It.Is<string>(d => d.Equals("user")), It.IsAny<string>(), It.IsAny<PatchOperation[]>())).ReturnsAsync(default(UserDocument));
+
+            var roleAssignments = new List<Core.RoleAssignment>() { new() { Role = "test", Scope = "*" }, new() { Role = "test-2", Scope = "*" } };
+
+            var result = await _sut.UpdateUserRoleAssignments("test", "*", roleAssignments);
+
+            Assert.Equal(user.RoleAssignments.Where(x => x.Scope.Equals("*")), result);
+            _cosmosStore.Verify(x => x.GetByIdOrDefaultAsync<Core.User>(It.IsAny<string>()), Times.Once);
+            _cosmosStore.Verify(x => x.PatchDocument(It.Is<string>(d => d.Equals("user")), It.IsAny<string>(), It.IsAny<PatchOperation[]>()));
+        }
+
+        [Fact]
+        public async Task UpdateUserRoleAssignments_WhenUserHasMultipleScopesAndRemoveRoles_CreatesUserAndReturnsOriginalRoles()
+        {
+            var user = new Core.User()
+            {
+                Id = "test",
+                RoleAssignments = [new() { Role = "test", Scope = "*" }, new() { Role = "test-2", Scope = "*" }, new() { Role = "test", Scope = "2" }, new() { Role = "test-2", Scope = "2" }]
+            };
+
+            _cosmosStore.Setup(x => x.GetByIdOrDefaultAsync<Core.User>(It.IsAny<string>())).ReturnsAsync(user);
+            _cosmosStore.Setup(x => x.GetDocumentType()).Returns("user");
+            _cosmosStore.Setup(x => x.PatchDocument(It.Is<string>(d => d.Equals("user")), It.IsAny<string>(), It.IsAny<PatchOperation[]>())).ReturnsAsync(default(UserDocument));
+
+            var roleAssignments = new List<Core.RoleAssignment>() { new() { Role = "test", Scope = "*" } };
+
+            var result = await _sut.UpdateUserRoleAssignments("test", "*", roleAssignments);
+
+            Assert.Equal(user.RoleAssignments.Where(x => x.Scope.Equals("*")), result);
+            _cosmosStore.Verify(x => x.GetByIdOrDefaultAsync<Core.User>(It.IsAny<string>()), Times.Once);
+            _cosmosStore.Verify(x => x.PatchDocument(It.Is<string>(d => d.Equals("user")), It.IsAny<string>(), It.IsAny<PatchOperation[]>()));
+        }
+    }
+}


### PR DESCRIPTION
The notifications are being sent with the wrong information. This is due to Users having the same roles at different sites. This changes makes the store works in a single scope, returning only the original roles that are relevant for change (scope).