### PR TITLE
APPT-XXX: Add terraform install step

### DIFF
--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -40,6 +40,11 @@ stages:
         displayName: "Run Terraform Plan"
         steps:
           - checkout: none
+          - task: ms-devlabs.custom-terraform-tasks.custom-terraform-installer-task.TerraformInstaller@0
+            displayName: "Install Terraform"
+            inputs:
+              terraformVersion: "latest"
+
           - task: DownloadBuildArtifacts@0
             displayName: Download Terraform Artifact
             inputs:


### PR DESCRIPTION
`ubuntu-latest` is no longer recognising `terraform` as a valid CLI command. Either because it has been removed or because of some other build agent change. 

This PR adds in a manual step which installs terraform, using one of the terraform install extensions which has been added to our DevOps tenant. 

Ideally, this should be `TerraformInstaller@0`, but using this results in a conflict with the following message:

>The task name TerraformInstaller is ambiguous. Specify one of the following identifiers to resolve the ambiguity: ms-devlabs.custom-terraform-tasks.custom-terraform-installer-task.TerraformInstaller, JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller

I think this is because someone has added 2 separate installers to our DevOps tenant. I do not have the permission to edit this, nor would I as it could affect another team. I have instead been explicit and chosen `ms-devlabs.custom-terraform-tasks.custom-terraform-installer-task.TerraformInstaller@0`.