### PR TITLE
APPT-290: Stop trying to reduce soft retention days

### DIFF
--- a/infrastructure/resources/app_configuration.tf
+++ b/infrastructure/resources/app_configuration.tf
@@ -4,7 +4,6 @@ resource "azurerm_app_configuration" "nbs_mya_app_configuration" {
   resource_group_name = data.azurerm_resource_group.nbs_mya_resource_group.name
   location            = var.location
   sku                 = "standard"
-  soft_delete_retention_days = 1
 
   replica {
     name     = "replicaukw"


### PR DESCRIPTION
I was trying to lessen our continual problems with Azure App Configuration by reducing the soft delete retention days to the minimum permitted number, 1. 

This forces terraform to re-create the resource (as seen in screenshot below), which we're not allowed to do because we're not allowed to delete this god-awful thing. 

So hopefully by allowing this value to remain at its default (7), terraform can update rather then re-create what I think might be the worst steaming pile of manure Azure has ever created.

<img width="467" alt="image" src="https://github.com/user-attachments/assets/a712b2a0-8b32-4912-8f37-45f1a944948f" />
