### PR TITLE
APPT-749 Fix dateTime issue when the API is ran in a different timezone

### DIFF
--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -401,18 +401,6 @@ export const setSiteInformationForCitizen = async (
   revalidatePath(`/site/${site}/details`);
 };
 
-export const fetchAvailability = async (payload: FetchAvailabilityRequest) => {
-  const response = await appointmentsApi.post<AvailabilityResponse[]>(
-    'availability/query',
-    JSON.stringify(payload),
-    {
-      next: { tags: ['fetchAvailability'] },
-    },
-  );
-
-  return handleBodyResponse(response);
-};
-
 export const fetchBookings = async (payload: FetchBookingsRequest) => {
   const response = await appointmentsApi.post<Booking[]>(
     'booking/query',

--- a/src/client/src/app/lib/services/availabilityCalculatorService.ts
+++ b/src/client/src/app/lib/services/availabilityCalculatorService.ts
@@ -39,8 +39,8 @@ export const summariseWeek = async (
       ukWeekEnd.format(dateFormat),
     ),
     fetchBookings({
-      from: ukWeekStart.format('YYYY-MM-DD HH:mm:ss'),
-      to: ukWeekEnd.endOf('day').format('YYYY-MM-DD HH:mm:ss'),
+      from: ukWeekStart.format(dateTimeFormat),
+      to: ukWeekEnd.endOf('day').format(dateTimeFormat),
       site: siteId,
     }),
   ]);

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
@@ -9,7 +9,7 @@ import { DailyAppointmentsPage } from './daily-appointments-page';
 import { FetchBookingsRequest } from '@types';
 import { Tab, Tabs } from '@nhsuk-frontend-components';
 import { NavigationByHrefProps } from '@components/nhsuk-frontend/back-link';
-import { addToUkDatetime, parseToUkDatetime } from '@services/timeService';
+import { dateTimeFormat, parseToUkDatetime } from '@services/timeService';
 
 type PageProps = {
   searchParams: {
@@ -25,12 +25,12 @@ type PageProps = {
 const Page = async ({ params, searchParams }: PageProps) => {
   await assertPermission(params.site, 'availability:query');
 
-  const date = parseToUkDatetime(searchParams.date);
-  const toDate = addToUkDatetime(date, 1, 'day');
+  const fromDate = parseToUkDatetime(searchParams.date);
+  const toDate = fromDate.endOf('day');
 
   const fetchBookingsRequest: FetchBookingsRequest = {
-    from: date.format('YYYY-MM-DDTHH:mm:ssZ'),
-    to: toDate.format('YYYY-MM-DDTHH:mm:ssZ'),
+    from: fromDate.format(dateTimeFormat),
+    to: toDate.format(dateTimeFormat),
     site: params.site,
   };
 
@@ -64,7 +64,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
 
   return (
     <NhsPage
-      title={date.format('dddd D MMMM')}
+      title={fromDate.format('dddd D MMMM')}
       caption={site.name}
       backLink={backLink}
       originPage="view-availability-daily-appointments"

--- a/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/view-week-availability-page.tsx
@@ -2,7 +2,12 @@ import { Pagination, Spinner } from '@components/nhsuk-frontend';
 import { Site } from '@types';
 import { Suspense } from 'react';
 import { DayCardList } from './day-card-list';
-import { addToUkDatetime, DayJsType, dateFormat } from '@services/timeService';
+import {
+  addToUkDatetime,
+  DayJsType,
+  dateFormat,
+  dateTimeFormat,
+} from '@services/timeService';
 
 type Props = {
   ukWeekStart: DayJsType;
@@ -56,10 +61,7 @@ export const ViewWeekAvailabilityPage = async ({
   return (
     <>
       <Pagination previous={previous} next={next} />
-      <Suspense
-        key={ukWeekStart.format('YYYY-MM-DDTHH:mm:ssZZ')}
-        fallback={<Spinner />}
-      >
+      <Suspense key={ukWeekStart.format(dateTimeFormat)} fallback={<Spinner />}>
         <DayCardList
           site={site}
           ukWeekStart={ukWeekStart}


### PR DESCRIPTION
Small missed edge case from me with the previous PR https://github.com/NHSDigital/nbs-appointments-management-service/pull/638 

When running the API in a different timezone also, I wanted to double check that the comprehensive combination of node timezone and the session tests still passed.

I noticed that the DailyAppointments page fails the tests in this case. This is because it passes the datetime info into the booking query to the API in UTC format, when it should be in the datetime timezone unspecified format (secretly UK datetime).

Fundamentally, datetimes passed to the backend and parsed as a C# DateTime should be in the EXACT same format as the database string format: i.e "from": "2025-07-01T09:40:00".

We don't specify in the API that datetime objects are UK or do any conversions, but so long as we always pass things around consistently it should be okay. The backend code: 
```
using (metricsRecorder.BeginScope("GetBookingsInDateRange"))
        {
            return await bookingStore.RunQueryAsync<Booking>(b => b.DocumentType == "booking" && b.Site == site && b.From >= from && b.From <= to);
        }
```
needs to have the DB datetime and the Query datetime in the same format to work. I am not suggesting any changes to the backend for now 👍 

Also fixed 'endOf(day)' as is more in line with a previous fix, and removed the fetchAvailability method as it isnt used by frontend.

**No new tests need to be written**, as my previous PRs tests catch this, its only when the API is in a different timezone does this become an issue. I have reran all the combination tests I ran before (node server in multiple different TZs, browser in multiple different TZs, and NOW the API in multiple different TZs!)

PS - I imagine this COULD have eventually had an impact to LIVE MYA due to UK/UTC differences, in the case of sessions/bookings being near midnight (1 hour shift crossing day threshold), but I suspect we dont have the data combination in it at the moment where this is an issue.
