### PR TITLE
Appt 833/roles name bugs

### DIFF
--- a/src/client/src/app/site/[site]/users/user-summary/user-summary.test.tsx
+++ b/src/client/src/app/site/[site]/users/user-summary/user-summary.test.tsx
@@ -30,22 +30,22 @@ describe('User Summary Page', () => {
         user: isOkta ? 'test@okta.net' : 'test@nhs.net',
         firstName: firstName,
         lastName: lastName,
-        roles: ['Admin', 'Viewer'],
+        roles: ['role-1', 'role-2'],
         isEdit: false,
       }),
     );
 
     render(<UserSummary roles={mockRoles} />);
 
-    const ddElement = screen.getByLabelText('Name-description');
+    const ddElement = screen.queryByLabelText('Name-description');
 
     isOkta
       ? expect(ddElement).toHaveTextContent(firstName + ' ' + lastName)
-      : expect(ddElement).toHaveTextContent('');
+      : expect(ddElement).not.toBeInTheDocument();
   });
 
   it.each([
-    [true, true, true, false, true],
+    [true, true, false, false, true],
     [true, false, false, false, true],
     [false, true, true, true, true],
     [false, false, false, true, true],
@@ -66,7 +66,7 @@ describe('User Summary Page', () => {
           user: isOkta ? 'test@okta.net' : 'test@nhs.net',
           firstName: 'firstName',
           lastName: 'lastName',
-          roles: ['Admin', 'Viewer'],
+          roles: ['role-1', 'role-2'],
           isEdit: isEdit,
         }),
       );
@@ -111,7 +111,7 @@ describe('User Summary Page', () => {
           user: isOkta ? 'test@okta.net' : 'test@nhs.net',
           firstName: 'firstName',
           lastName: 'lastName',
-          roles: ['Admin', 'Viewer'],
+          roles: ['role-1', 'role-2'],
           isEdit: isEdit,
         }),
       );
@@ -123,6 +123,26 @@ describe('User Summary Page', () => {
       expect(submitionNote).toHaveTextContent(expectedMessage);
     },
   );
+
+  it('renders expected roles', async () => {
+    sessionStorage.setItem(
+      'userFormData',
+      JSON.stringify({
+        site: '123',
+        user: 'test@nhs.net',
+        firstName: '',
+        lastName: '',
+        roles: ['role-1', 'role-2'],
+        isEdit: false,
+      }),
+    );
+
+    render(<UserSummary roles={mockRoles} />);
+
+    const roleElement = screen.getByLabelText('Roles-description');
+
+    expect(roleElement).toHaveTextContent('Beta Role, Charlie Role');
+  });
 
   it('redirects if sessionStorage is empty', async () => {
     render(<UserSummary roles={mockRoles} />);

--- a/src/client/src/app/site/[site]/users/user-summary/user-summary.test.tsx
+++ b/src/client/src/app/site/[site]/users/user-summary/user-summary.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import UserSummary from './user-summary';
 import { useRouter } from 'next/navigation';
+import { mockRoles } from '@testing/data';
 
 // Mock next/navigation
 jest.mock('next/navigation', () => ({
@@ -34,7 +35,7 @@ describe('User Summary Page', () => {
       }),
     );
 
-    render(<UserSummary />);
+    render(<UserSummary roles={mockRoles} />);
 
     const ddElement = screen.getByLabelText('Name-description');
 
@@ -70,7 +71,7 @@ describe('User Summary Page', () => {
         }),
       );
 
-      render(<UserSummary />);
+      render(<UserSummary roles={mockRoles} />);
 
       const nameChangeBtn = screen.queryByLabelText('Name-description-action');
       const emailChangeBtn = screen.queryByLabelText(
@@ -115,7 +116,7 @@ describe('User Summary Page', () => {
         }),
       );
 
-      render(<UserSummary />);
+      render(<UserSummary roles={mockRoles} />);
 
       const submitionNote = screen.getByLabelText('submition-note');
 
@@ -124,7 +125,7 @@ describe('User Summary Page', () => {
   );
 
   it('redirects if sessionStorage is empty', async () => {
-    render(<UserSummary />);
+    render(<UserSummary roles={mockRoles} />);
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/');

--- a/src/client/src/app/site/[site]/users/user-summary/user-summary.tsx
+++ b/src/client/src/app/site/[site]/users/user-summary/user-summary.tsx
@@ -9,10 +9,14 @@ import {
   LinkActionProps,
   OnClickActionProps,
 } from '@components/nhsuk-frontend';
+import { Role } from '@types';
+import { sortRolesByName } from '@sorting';
 
-const UserSummary = () => {
+const UserSummary = ({ roles }: { roles: Role[] }) => {
   const { push } = useRouter();
   const [formData, setFormData] = useState<UserDetails | null>(null);
+
+  const sortedRoles = roles.toSorted(sortRolesByName);
 
   type UserDetails = {
     site: string;
@@ -66,12 +70,15 @@ const UserSummary = () => {
     };
   };
 
-  const userDetails: SummaryListItem[] = [
+  const oktaCreateSummary: SummaryListItem[] = [
     {
       title: 'Name',
-      value: isNhsUser ? '' : `${formData?.firstName} ${formData?.lastName}`,
+      value: `${formData?.firstName} ${formData?.lastName}`,
       action: changeAction(userDetailsPagePath, isNhsUser),
     },
+  ];
+
+  const userDetails: SummaryListItem[] = [
     {
       title: 'Email address',
       value: formData?.user,
@@ -79,7 +86,10 @@ const UserSummary = () => {
     },
     {
       title: 'Roles',
-      value: formData?.roles.join(', '),
+      value: sortedRoles
+        .filter(sr => formData?.roles.includes(sr.id))
+        .map(x => x.displayName)
+        .join(', '),
       action: changeAction(userDetailsPagePath, false),
     },
   ];
@@ -100,7 +110,14 @@ const UserSummary = () => {
 
   return (
     <div>
-      {userDetails && <SummaryList items={userDetails}></SummaryList>}
+      {userDetails && (
+        <SummaryList
+          items={[
+            ...(formData?.isEdit || isNhsUser ? [] : oktaCreateSummary),
+            ...userDetails,
+          ]}
+        ></SummaryList>
+      )}
 
       <p aria-label="submition-note">{getSubmissionNote()}</p>
 


### PR DESCRIPTION
This is resolves some of the bugs on the summary screen for user summary - 

conditional display of the name field needs to meet the AC
Display names of roles should not include 'canned:'