### PR TITLE
APPT-704/706/605 - Minor updates to meet AC

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/SetUserRolesFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/SetUserRolesFunction.cs
@@ -61,7 +61,7 @@ public class SetUserRolesFunction(
 
             if (!isOktaEnabled)
             {
-                return Failed(HttpStatusCode.ServiceUnavailable, "Okta is disabled.");
+                return Failed(HttpStatusCode.NotImplemented, "Okta is disabled.");
             }
 
             // user is not an nhs mail user, check with okta service to determine if user exists and send an invite if they don't

--- a/src/client/src/app/site/[site]/users/manage/wizard-steps/email-step.test.tsx
+++ b/src/client/src/app/site/[site]/users/manage/wizard-steps/email-step.test.tsx
@@ -236,7 +236,9 @@ describe('Email step', () => {
     );
 
     expect(
-      await screen.findByText('Enter a valid email address'),
+      await screen.findByText(
+        'Email address must be nhs.net or an authorised email domain',
+      ),
     ).toBeVisible();
   });
 });

--- a/src/client/src/app/site/[site]/users/manage/wizard-steps/email-step.tsx
+++ b/src/client/src/app/site/[site]/users/manage/wizard-steps/email-step.tsx
@@ -57,7 +57,9 @@ const NamesStep = ({
     }
 
     if (!proposedUser.meetsWhitelistRequirements) {
-      setError('email', { message: 'Enter a valid email address' });
+      setError('email', {
+        message: 'Email address must be nhs.net or an authorised email domain',
+      });
       return;
     }
 

--- a/src/client/src/app/site/[site]/users/page.tsx
+++ b/src/client/src/app/site/[site]/users/page.tsx
@@ -5,6 +5,7 @@ import {
   fetchPermissions,
   fetchUserProfile,
   assertAnyPermissions,
+  fetchFeatureFlag,
 } from '@services/appointmentsService';
 import NhsPage from '@components/nhs-page';
 import { UsersPage } from './users-page';
@@ -17,13 +18,14 @@ type PageProps = {
 
 const Page = async ({ params }: PageProps) => {
   await assertAnyPermissions(params.site, ['users:view', 'users:view']);
-  const [userProfile, users, rolesResponse, site, permissions] =
+  const [userProfile, users, rolesResponse, site, permissions, oktaEnabled] =
     await Promise.all([
       fetchUserProfile(),
       fetchUsers(params.site),
       fetchRoles(),
       fetchSite(params.site),
       fetchPermissions(params.site),
+      fetchFeatureFlag('OktaEnabled'),
     ]);
 
   return (
@@ -33,6 +35,7 @@ const Page = async ({ params }: PageProps) => {
         users={users}
         roles={rolesResponse}
         permissions={permissions}
+        oktaEnabled={oktaEnabled.enabled}
       />
     </NhsPage>
   );

--- a/src/client/src/app/site/[site]/users/users-page.test.tsx
+++ b/src/client/src/app/site/[site]/users/users-page.test.tsx
@@ -1,6 +1,7 @@
 ﻿import { render, screen, waitFor } from '@testing-library/react';
 import { UsersPage } from './users-page';
 import {
+  getMockOktaUserAssignments,
   getMockUserAssignments,
   mockAllPermissions,
   mockAuditerPermissions,
@@ -20,6 +21,7 @@ describe('Users Page', () => {
         users={getMockUserAssignments(mockSiteId)}
         roles={mockRoles}
         permissions={mockAllPermissions}
+        oktaEnabled={true}
       />,
     );
 
@@ -37,6 +39,7 @@ describe('Users Page', () => {
         users={getMockUserAssignments(mockSiteId)}
         roles={mockRoles}
         permissions={mockAllPermissions}
+        oktaEnabled={true}
       />,
     );
 
@@ -68,6 +71,7 @@ describe('Users Page', () => {
         users={getMockUserAssignments(mockSiteId)}
         roles={mockRoles}
         permissions={mockAllPermissions}
+        oktaEnabled={true}
       />,
     );
 
@@ -87,6 +91,7 @@ describe('Users Page', () => {
         users={getMockUserAssignments(mockSiteId)}
         roles={mockRoles}
         permissions={mockAuditerPermissions}
+        oktaEnabled={true}
       />,
     );
 
@@ -106,6 +111,7 @@ describe('Users Page', () => {
         users={getMockUserAssignments(mockSiteId)}
         roles={mockRoles}
         permissions={mockAllPermissions}
+        oktaEnabled={true}
       />,
     );
 
@@ -119,6 +125,27 @@ describe('Users Page', () => {
     ).toHaveAttribute('href', 'users/remove?user=test.two@nhs.net');
 
     // Guard against changes in mock data by providing the current user is included in the list of mock users
+    expect(getMockUserAssignments(mockSiteId).map(_ => _.id)).toContain(
+      mockUserProfile.emailAddress,
+    );
+  });
+
+  it('Does not display the edit or remove buttons for okta users if okta is disabled - but does display them for nhs users', async () => {
+    render(
+      <UsersPage
+        userProfile={mockUserProfile}
+        users={getMockOktaUserAssignments(mockSiteId)}
+        roles={mockRoles}
+        permissions={mockAllPermissions}
+        oktaEnabled={false}
+      />,
+    );
+
+    expect(
+      screen.queryAllByRole('link', { name: 'Remove from this site' }),
+    ).toHaveLength(1);
+    expect(screen.queryAllByRole('link', { name: 'Edit' }).length).toBe(1);
+
     expect(getMockUserAssignments(mockSiteId).map(_ => _.id)).toContain(
       mockUserProfile.emailAddress,
     );

--- a/src/client/src/app/site/[site]/users/users-page.tsx
+++ b/src/client/src/app/site/[site]/users/users-page.tsx
@@ -8,6 +8,7 @@ type Props = {
   users: User[];
   roles: Role[];
   permissions: string[];
+  oktaEnabled: boolean;
 };
 
 export const UsersPage = ({
@@ -15,6 +16,7 @@ export const UsersPage = ({
   users,
   roles,
   permissions,
+  oktaEnabled,
 }: Props) => {
   const isVisibleRole = (role: string) =>
     roles.find(r => r.id === role) !== undefined;
@@ -24,6 +26,10 @@ export const UsersPage = ({
   const canSeeAdminControls = useMemo(() => {
     return permissions.includes('users:manage');
   }, [permissions]);
+
+  const canEditUser = (email: string): boolean => {
+    return email.endsWith('@nhs.net') || oktaEnabled;
+  };
 
   return (
     <>
@@ -49,7 +55,8 @@ export const UsersPage = ({
               ?.join(' | '),
             ...(canSeeAdminControls
               ? [
-                  ...(userProfile.emailAddress === user.id
+                  ...(userProfile.emailAddress === user.id ||
+                  !canEditUser(user.id)
                     ? ['', '']
                     : [
                         <EditRoleAssignmentsButton

--- a/src/client/src/app/testing/data.ts
+++ b/src/client/src/app/testing/data.ts
@@ -43,6 +43,36 @@ const getMockUserAssignments = (site: string): User[] => [
   },
 ];
 
+const getMockOktaUserAssignments = (site: string): User[] => [
+  {
+    id: 'nhs.user@nhs.net',
+    roleAssignments: [
+      { role: 'role-1', scope: `site:${site}` },
+      { role: 'role-2', scope: `site:${site}` },
+    ],
+    firstName: 'first1',
+    lastName: 'last1',
+  },
+  {
+    id: 'test.one@nhs.net',
+    roleAssignments: [
+      { role: 'role-1', scope: `site:${site}` },
+      { role: 'role-2', scope: `site:${site}` },
+    ],
+    firstName: 'first1',
+    lastName: 'last1',
+  },
+  {
+    id: 'test.one@okta.net',
+    roleAssignments: [
+      { role: 'role-1', scope: `site:${site}` },
+      { role: 'role-2', scope: `site:${site}` },
+    ],
+    firstName: 'first1',
+    lastName: 'last1',
+  },
+];
+
 const mockRoles: Role[] = [
   {
     displayName: 'Beta Role',
@@ -658,4 +688,5 @@ export {
   mockEmptyDays,
   mockWeekAvailability,
   mockWellKnownOdsCodeEntries,
+  getMockOktaUserAssignments,
 };

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/SetUserRolesFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/SetUserRolesFunctionTests.cs
@@ -124,7 +124,7 @@ public class SetUserRolesFunctionTests
         var response = await _sut.Invoke(request);
 
         Assert.Multiple(
-            () => response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable),
+            () => response.StatusCode.Should().Be(HttpStatusCode.NotImplemented),
             () => response.IsSuccess.Should().BeFalse(),
             () => _userService.Verify(),
             () => _oktaService.Verify(x => x.CreateIfNotExists(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never),


### PR DESCRIPTION
Small changes to match AC on 605/704/706

- Update validation message to match
- Hide Edit / Remove button on Okta users if they've been added and then the feature flag has been disabled again

Edge case but had a discussion with Dave E on point 2 as previously it would show an error on the front end if trying to edit an Okta user when the Okta feature flag has been disabled again.

![image](https://github.com/user-attachments/assets/01ad0647-1b96-4459-b2ee-31bed370a932)
