### PR TITLE
APPT-880 - Enabling the high load function for Bulk Import

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -70,6 +70,7 @@ module "mya_application_dev" {
   storage_account_replication_type               = "LRS"
   cosmos_automatic_failover_enabled              = false
   cosmos_synapse_enabled                         = true
+  disable_bulk_import_function                   = false
   cosmos_geo_locations = [{
     location          = "uksouth"
     failover_priority = 0

--- a/infrastructure/environments/int/main.tf
+++ b/infrastructure/environments/int/main.tf
@@ -70,6 +70,7 @@ module "mya_application_int" {
   storage_account_replication_type               = "LRS"
   cosmos_automatic_failover_enabled              = false
   cosmos_synapse_enabled                         = false
+  disable_bulk_import_function                   = false
   cosmos_geo_locations = [{
     location          = "uksouth"
     failover_priority = 0

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -78,6 +78,7 @@ module "mya_application_prod" {
   storage_account_replication_type               = "ZRS"
   cosmos_automatic_failover_enabled              = true
   cosmos_synapse_enabled                         = false
+  disable_bulk_import_function                   = true
   cosmos_geo_locations = [{
     location          = "uksouth"
     failover_priority = 0

--- a/infrastructure/environments/stag-ukw/main.tf
+++ b/infrastructure/environments/stag-ukw/main.tf
@@ -81,6 +81,7 @@ module "mya_application_stag_ukw" {
   storage_account_replication_type               = "LRS"
   cosmos_automatic_failover_enabled              = false
   cosmos_synapse_enabled                         = false
+  disable_bulk_import_function                   = false
   cosmos_booking_autoscale_settings = [{
     max_throughput = 60000
   }]

--- a/infrastructure/environments/stag/main.tf
+++ b/infrastructure/environments/stag/main.tf
@@ -78,6 +78,7 @@ module "mya_application_stag" {
   storage_account_replication_type               = "ZRS"
   cosmos_automatic_failover_enabled              = true
   cosmos_synapse_enabled                         = false
+  disable_bulk_import_function                   = true
   cosmos_geo_locations = [{
     location          = "uksouth"
     failover_priority = 0

--- a/infrastructure/resources/high_load_functions.tf
+++ b/infrastructure/resources/high_load_functions.tf
@@ -107,7 +107,6 @@ resource "azurerm_windows_function_app" "nbs_mya_high_load_func_app" {
     "AzureWebJobs.TriggerUnconfirmedProvisionalBookingsCollector.Disabled" = true
     "AzureWebJobs.SendBookingReminders.Disabled"                           = true
     "AzureWebJobs.RemoveUnconfirmedProvisionalBookings.Disabled"           = true
-    "AzureWebJobs.BulkImportFunction.Disabled"                             = true
     "AzureWebJobs.RenderOAuth2Redirect.Disabled"                           = true
     "AzureWebJobs.RenderOpenApiDocument.Disabled"                          = true
     "AzureWebJobs.RenderSwaggerDocument.Disabled"                          = true

--- a/infrastructure/resources/http_functions.tf
+++ b/infrastructure/resources/http_functions.tf
@@ -78,6 +78,7 @@ resource "azurerm_windows_function_app" "nbs_mya_http_func_app" {
     "AzureWebJobs.RemoveUnconfirmedProvisionalBookings.Disabled"   = true
     "AzureWebJobs.ClearLocalFeatureFlagOverridesFunction.Disabled" = true
     "AzureWebJobs.SetLocalFeatureFlagOverrideFunction.Disabled"    = true
+    "AzureWebJobs.BulkImportFunction.Disabled"                     = var.disable_bulk_import_function
   }
 
   sticky_settings {
@@ -160,6 +161,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_http_func_app_preview" {
     "AzureWebJobs.RemoveUnconfirmedProvisionalBookings.Disabled"   = true
     "AzureWebJobs.ClearLocalFeatureFlagOverridesFunction.Disabled" = true
     "AzureWebJobs.SetLocalFeatureFlagOverrideFunction.Disabled"    = true
+    "AzureWebJobs.BulkImportFunction.Disabled"                     = var.disable_bulk_import_function
   }
 
   identity {

--- a/infrastructure/resources/servicebus_functions.tf
+++ b/infrastructure/resources/servicebus_functions.tf
@@ -91,6 +91,7 @@ resource "azurerm_windows_function_app" "nbs_mya_service_bus_func_app" {
     "AzureWebJobs.SetLocalFeatureFlagOverrideFunction.Disabled"            = true
     "AzureWebJobs.GetFeatureFlagFunction.Disabled"                         = true
     "AzureWebJobs.ProposePotentialUserFunction.Disabled"                   = true
+    "AzureWebJobs.BulkImportFunction.Disabled"                             = true
   }
 
   sticky_settings {
@@ -191,6 +192,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_service_bus_func_app_previ
     "AzureWebJobs.GetFeatureFlagFunction.Disabled"                         = true
     "AzureWebJobs.GetClinicalServicesFunction.Disabled"                    = true
     "AzureWebJobs.ProposePotentialUserFunction.Disabled"                   = true
+    "AzureWebJobs.BulkImportFunction.Disabled"                             = true
   }
 
   identity {

--- a/infrastructure/resources/timer_functions.tf
+++ b/infrastructure/resources/timer_functions.tf
@@ -96,6 +96,7 @@ resource "azurerm_windows_function_app" "nbs_mya_timer_func_app" {
     "AzureWebJobs.GetFeatureFlagFunction.Disabled"                         = true
     "AzureWebJobs.GetClinicalServicesFunction.Disabled"                    = true
     "AzureWebJobs.ProposePotentialUserFunction.Disabled"                   = true
+    "AzureWebJobs.BulkImportFunction.Disabled"                             = true
   }
 
   sticky_settings {
@@ -192,6 +193,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_timer_func_app_preview" {
     "AzureWebJobs.SetLocalFeatureFlagOverrideFunction.Disabled"            = true
     "AzureWebJobs.GetFeatureFlagFunction.Disabled"                         = true
     "AzureWebJobs.ProposePotentialUserFunction.Disabled"                   = true
+    "AzureWebJobs.BulkImportFunction.Disabled"                             = true
   }
 
   identity {

--- a/infrastructure/resources/variables.tf
+++ b/infrastructure/resources/variables.tf
@@ -272,3 +272,7 @@ variable "app_config_connection" {
   default = ""
   sensitive = true
 }
+
+variable "disable_bulk_import_function" {
+  type = bool
+}


### PR DESCRIPTION
We hit an issue on int where uploading 244 Okta users caused the BulkImportFunction to hit it's default timeout (5 minutes) so for staging / production we want to enable the high load function for this which has a longer timeout (30 minutes as default).

Once we've figured out a limit on staging for high load, I will work with Anna to workout a plan over a number of weeks to upload all users (both nhs & Okta) so that we don't hit the timeout.