### PR TITLE
Add --strict to feature toggles import

### DIFF
--- a/azure-pipelines-feature-toggles.yml
+++ b/azure-pipelines-feature-toggles.yml
@@ -14,4 +14,4 @@ stages:
       - template: "features/scripts/deploy-feature-toggles.yml"
         parameters:
           env: ${{env}}
-          isMain: ${{eq(variables['Build.SourceBranch'], 'refs/heads/main')}}
+          isMain: true

--- a/azure-pipelines-feature-toggles.yml
+++ b/azure-pipelines-feature-toggles.yml
@@ -14,4 +14,4 @@ stages:
       - template: "features/scripts/deploy-feature-toggles.yml"
         parameters:
           env: ${{env}}
-          isMain: true
+          isMain: ${{eq(variables['Build.SourceBranch'], 'refs/heads/main')}}

--- a/features/dev.feature.flags.json
+++ b/features/dev.feature.flags.json
@@ -2,7 +2,7 @@
   "FeatureManagement": {
     "OktaEnabled": true,
     "TestFeatureEnabled": true,
-    "JointBookings": true,
+    "JointBookings": false,
     "BulkImport": true,
     "MultipleServices": true,
     "TestFeaturePercentageEnabled": {

--- a/features/int.feature.flags.json
+++ b/features/int.feature.flags.json
@@ -1,7 +1,7 @@
 {
   "FeatureManagement": {
     "OktaEnabled": false,
-    "JointBookings": true,
+    "JointBookings": false,
     "BulkImport": true,
     "MultipleServices": true
   }

--- a/features/scripts/import-flags.ps1
+++ b/features/scripts/import-flags.ps1
@@ -13,4 +13,5 @@ az appconfig kv import `
         --source file `
         --path $sourceFile `
         --format json `
+        --scrict `
         --yes

--- a/features/scripts/import-flags.ps1
+++ b/features/scripts/import-flags.ps1
@@ -13,5 +13,5 @@ az appconfig kv import `
         --source file `
         --path $sourceFile `
         --format json `
-        --scrict `
+        --strict `
         --yes

--- a/features/stag.feature.flags.json
+++ b/features/stag.feature.flags.json
@@ -1,7 +1,7 @@
 {
   "FeatureManagement": {
     "OktaEnabled": false,
-    "JointBookings": true,
+    "JointBookings": false,
     "BulkImport": false,
     "MultipleServices": false
   }


### PR DESCRIPTION
There is no Jira ticket associated with this. The purpose of this PR is to clean up the feature toggles (disable joint bookings) and to add the --strict param to the import flags script. This new param means that it will override all of the config in the app config. Meaning flags that are not present in the imported json will be removed from app config.