### PR TITLE
APPT-802: Synchronise global roles and add user manager to admin permissions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,8 @@ stages:
           csvDataToolTestProjectPath: "tests/CsvDataTool.UnitTests/CsvDataTool.UnitTests.csproj"
           bookingExtractsTestProjectPath: "tests/BookingDataExtracts.UnitTests/BookingDataExtracts.UnitTests.csproj"
           capacityExtractsTestProjectPath: "tests/CapacityDataExtracts.UnitTests/CapacityDataExtracts.UnitTests.csproj"
+          apiClientUnitTestProjectPath: "tests/Nhs.Appointments.Api.Client.UnitTests/Nhs.Appointments.Api.Client.UnitTests.csproj"
+          cosmosDbSeederTestProjectPath: "tests/CosmosDbSeederTests/CosmosDbSeederTests.csproj"
         steps:
           - task: SonarCloudPrepare@3
             displayName: "Prepare analysis on SonarCloud"
@@ -83,6 +85,18 @@ stages:
             inputs:
               command: "test"
               projects: $(capacityExtractsTestProjectPath)
+              arguments: '--collect "XPlat Code Coverage;Format=opencover"'
+          - task: DotNetCoreCLI@2
+            displayName: "Run API Client unit tests"
+            inputs:
+              command: "test"
+              projects: $(apiClientUnitTestProjectPath)
+              arguments: '--collect "XPlat Code Coverage;Format=opencover"'
+          - task: DotNetCoreCLI@2
+            displayName: "Run Cosmos Db Seeder tests"
+            inputs:
+              command: "test"
+              projects: $(cosmosDbSeederTestProjectPath)
               arguments: '--collect "XPlat Code Coverage;Format=opencover"'
           - task: SonarCloudAnalyze@3
             displayName: "Run Code Analysis"

--- a/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
@@ -67,7 +67,8 @@
         "site:get-meta-data",
         "site:manage",
         "site:manage:admin",
-        "users:view"
+        "users:view",
+        "users:manage"
       ]
     },
     {

--- a/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
@@ -56,34 +56,6 @@
       ]
     },
     {
-      "id": "system:api-user",
-      "name": "Api User",
-      "description": "This is a dedicated NBS role",
-      "permissions": [
-        "availability:query",
-        "booking:make",
-        "booking:cancel",
-        "booking:query",
-        "sites:query",
-        "site:view",
-        "site:view:preview",
-        "site:get-meta-data"
-      ]
-    },
-    {
-      "id": "system:auditer",
-      "name": "Auditer",
-      "description": "A user who can see everything (including admin-level data) but take no actions. This is a read-only role.",
-      "permissions": [
-        "site:get-meta-data",
-        "availability:query",
-        "booking:query",
-        "users:view",
-        "site:view",
-        "site:view:preview"
-      ]
-    },
-    {
       "id": "system:admin-user",
       "name": "Admin User",
       "description": "Admin user can view all areas that exist in MYA.",
@@ -96,6 +68,21 @@
         "site:manage",
         "site:manage:admin",
         "users:view"
+      ]
+    },
+    {
+      "id": "system:api-user",
+      "name": "Api User",
+      "description": "This is a dedicated NBS role",
+      "permissions": [
+        "availability:query",
+        "booking:make",
+        "booking:cancel",
+        "booking:query",
+        "sites:query",
+        "site:view",
+        "site:view:preview",
+        "site:get-meta-data"
       ]
     },
     {
@@ -125,9 +112,7 @@
       "id": "system:data-importer",
       "name": "Data Importer",
       "description": "System role used for the bulk importing of users and sites",
-      "permissions": [
-        "system:data-importer"
-      ]
+      "permissions": ["system:data-importer"]
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/int/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/int/core_data/global_roles.json
@@ -56,21 +56,6 @@
       ]
     },
     {
-      "id": "system:api-user",
-      "name": "Api User",
-      "description": "This is a dedicated NBS role",
-      "permissions": [
-        "availability:query",
-        "booking:make",
-        "booking:cancel",
-        "booking:query",
-        "sites:query",
-        "site:view",
-        "site:view:preview",
-        "site:get-meta-data"
-      ]
-    },
-    {
       "id": "system:admin-user",
       "name": "Admin User",
       "description": "Admin user can view all areas that exist in MYA.",
@@ -83,6 +68,21 @@
         "site:manage",
         "site:manage:admin",
         "users:view"
+      ]
+    },
+    {
+      "id": "system:api-user",
+      "name": "Api User",
+      "description": "This is a dedicated NBS role",
+      "permissions": [
+        "availability:query",
+        "booking:make",
+        "booking:cancel",
+        "booking:query",
+        "sites:query",
+        "site:view",
+        "site:view:preview",
+        "site:get-meta-data"
       ]
     },
     {
@@ -112,9 +112,7 @@
       "id": "system:data-importer",
       "name": "Data Importer",
       "description": "System role used for the bulk importing of users and sites",
-      "permissions": [
-        "system:data-importer"
-      ]
+      "permissions": ["system:data-importer"]
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/int/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/int/core_data/global_roles.json
@@ -67,7 +67,8 @@
         "site:get-meta-data",
         "site:manage",
         "site:manage:admin",
-        "users:view"
+        "users:view",
+        "users:manage"
       ]
     },
     {

--- a/data/CosmosDbSeeder/items/local/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/local/core_data/global_roles.json
@@ -67,8 +67,7 @@
         "site:get-meta-data",
         "site:manage",
         "site:manage:admin",
-        "users:view",
-        "system:data-importer"
+        "users:view"
       ]
     },
     {
@@ -84,19 +83,6 @@
         "site:view",
         "site:view:preview",
         "site:get-meta-data"
-      ]
-    },
-    {
-      "id": "system:auditer",
-      "name": "Auditer",
-      "description": "A user who can see everything (including admin-level data) but take no actions. This is a read-only role.",
-      "permissions": [
-        "site:get-meta-data",
-        "availability:query",
-        "booking:query",
-        "users:view",
-        "site:view",
-        "site:view:preview"
       ]
     },
     {
@@ -119,8 +105,7 @@
         "site:manage",
         "site:manage:admin",
         "system:run-reminders",
-        "system:run-provisional-sweep",
-        "system:admin-user"
+        "system:run-provisional-sweep"
       ]
     },
     {
@@ -149,9 +134,7 @@
       "id": "system:data-importer",
       "name": "Data Importer",
       "description": "System role used for the bulk importing of users and sites",
-      "permissions": [
-        "system:data-importer"
-      ]
+      "permissions": ["system:data-importer"]
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/local/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/local/core_data/global_roles.json
@@ -67,7 +67,8 @@
         "site:get-meta-data",
         "site:manage",
         "site:manage:admin",
-        "users:view"
+        "users:view",
+        "users:manage"
       ]
     },
     {

--- a/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_2.json
+++ b/data/CosmosDbSeeder/items/local/core_data/zzz_test_user_2.json
@@ -4,7 +4,7 @@
   "latestAcceptedEulaVersion": "2024-12-01",
   "roleAssignments": [
     {
-      "role": "system:auditer",
+      "role": "canned:user-manager",
       "scope": "site:5914b64a-66bb-4ee2-ab8a-94958c1fdfcb"
     },
     {

--- a/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
@@ -67,7 +67,8 @@
         "site:get-meta-data",
         "site:manage",
         "site:manage:admin",
-        "users:view"
+        "users:view",
+        "users:manage"
       ]
     },
     {

--- a/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
@@ -56,21 +56,6 @@
       ]
     },
     {
-      "id": "system:api-user",
-      "name": "Api User",
-      "description": "This is a dedicated NBS role",
-      "permissions": [
-        "availability:query",
-        "booking:make",
-        "booking:cancel",
-        "booking:query",
-        "sites:query",
-        "site:view",
-        "site:view:preview",
-        "site:get-meta-data"
-      ]
-    },
-    {
       "id": "system:admin-user",
       "name": "Admin User",
       "description": "Admin user can view all areas that exist in MYA.",
@@ -86,8 +71,23 @@
       ]
     },
     {
+      "id": "system:api-user",
+      "name": "Api User",
+      "description": "This is a dedicated NBS role",
+      "permissions": [
+        "availability:query",
+        "booking:make",
+        "booking:cancel",
+        "booking:query",
+        "sites:query",
+        "site:view",
+        "site:view:preview",
+        "site:get-meta-data"
+      ]
+    },
+    {
       "id": "system:all-permissions",
-      "name": "All permissions",
+      "name": "All Permissions",
       "description": "System role used for full api access for development and test purposes (ONLY FOR USE IN TEST ENVIRONMENTS).",
       "permissions": [
         "site:get-meta-data",
@@ -112,9 +112,7 @@
       "id": "system:data-importer",
       "name": "Data Importer",
       "description": "System role used for the bulk importing of users and sites",
-      "permissions": [
-        "system:data-importer"
-      ]
+      "permissions": ["system:data-importer"]
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
@@ -67,7 +67,8 @@
         "site:get-meta-data",
         "site:manage",
         "site:manage:admin",
-        "users:view"
+        "users:view",
+        "users:manage"
       ]
     },
     {

--- a/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
@@ -56,21 +56,6 @@
       ]
     },
     {
-      "id": "system:api-user",
-      "name": "Api User",
-      "description": "This is a dedicated NBS role",
-      "permissions": [
-        "availability:query",
-        "booking:make",
-        "booking:cancel",
-        "booking:query",
-        "sites:query",
-        "site:view",
-        "site:view:preview",
-        "site:get-meta-data"
-      ]
-    },
-    {
       "id": "system:admin-user",
       "name": "Admin User",
       "description": "Admin user can view all areas that exist in MYA.",
@@ -86,8 +71,23 @@
       ]
     },
     {
+      "id": "system:api-user",
+      "name": "Api User",
+      "description": "This is a dedicated NBS role",
+      "permissions": [
+        "availability:query",
+        "booking:make",
+        "booking:cancel",
+        "booking:query",
+        "sites:query",
+        "site:view",
+        "site:view:preview",
+        "site:get-meta-data"
+      ]
+    },
+    {
       "id": "system:all-permissions",
-      "name": "All permissions",
+      "name": "All Permissions",
       "description": "System role used for full api access for development and test purposes (ONLY FOR USE IN TEST ENVIRONMENTS).",
       "permissions": [
         "site:get-meta-data",
@@ -112,9 +112,7 @@
       "id": "system:data-importer",
       "name": "Data Importer",
       "description": "System role used for the bulk importing of users and sites",
-      "permissions": [
-        "system:data-importer"
-      ]
+      "permissions": ["system:data-importer"]
     }
   ]
 }

--- a/nbs-manage-your-appointments.sln
+++ b/nbs-manage-your-appointments.sln
@@ -64,6 +64,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CapacityDataExtracts.Integr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CapacityDataExtracts.UnitTests", "tests\CapacityDataExtracts.UnitTests\CapacityDataExtracts.UnitTests.csproj", "{6A0DFBAD-1712-42C2-BE22-6F0F58FAE8AE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosDbSeederTests", "tests\CosmosDbSeederTests\CosmosDbSeederTests.csproj", "{51BB5BE7-DEA6-4C21-A257-D013956EBFB2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -162,6 +164,10 @@ Global
 		{6A0DFBAD-1712-42C2-BE22-6F0F58FAE8AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A0DFBAD-1712-42C2-BE22-6F0F58FAE8AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A0DFBAD-1712-42C2-BE22-6F0F58FAE8AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51BB5BE7-DEA6-4C21-A257-D013956EBFB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51BB5BE7-DEA6-4C21-A257-D013956EBFB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51BB5BE7-DEA6-4C21-A257-D013956EBFB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51BB5BE7-DEA6-4C21-A257-D013956EBFB2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -192,6 +198,7 @@ Global
 		{3B2BC975-7992-408F-BE91-9ED8D0888916} = {0AC295FA-EAA0-473D-8A38-0C5CAB7612E4}
 		{4EAEDFEA-533A-4C5B-B165-D61DD2AEA095} = {C4AAF10B-178C-42F1-B081-22E8D5324355}
 		{6A0DFBAD-1712-42C2-BE22-6F0F58FAE8AE} = {C4AAF10B-178C-42F1-B081-22E8D5324355}
+		{51BB5BE7-DEA6-4C21-A257-D013956EBFB2} = {C4AAF10B-178C-42F1-B081-22E8D5324355}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F16CD335-B2DF-4C77-9801-5DB5B9AAFADA}

--- a/src/client/testing/tests/manage-user/user-management-permissions.spec.ts
+++ b/src/client/testing/tests/manage-user/user-management-permissions.spec.ts
@@ -45,20 +45,6 @@ test.beforeEach(async ({ page, getTestSite }) => {
   viewMonthAvailabilityPage = new MonthViewAvailabilityPage(page);
 });
 
-test('A user with the appropriate permission can view other users at a site but not edit them', async ({
-  getTestUser,
-}) => {
-  await rootPage.goto();
-  await rootPage.pageContentLogInButton.click();
-  await oAuthPage.signIn(getTestUser(2));
-  await siteSelectionPage.selectSite('Robin Lane Medical Centre');
-  await sitePage.userManagementCard.click();
-  await expect(usersPage.title).toBeVisible();
-  await expect(usersPage.emailColumn).toBeVisible();
-  await expect(usersPage.manageColumn).not.toBeVisible();
-  await expect(usersPage.addUserButton).not.toBeVisible();
-});
-
 test('A user with the appropriate permission can view other users at a site and also edit them', async () => {
   await rootPage.goto();
   await rootPage.pageContentLogInButton.click();
@@ -122,8 +108,8 @@ test('permissions are applied per site', async ({ getTestUser }) => {
 
   await siteSelectionPage.selectSite(site1.name);
 
-  await sitePage.userManagementCard.click();
-  await expect(usersPage.manageColumn).not.toBeVisible();
+  await sitePage.siteManagementCard.click();
+  await expect(siteDetailsPage1.editSiteDetailsButton).not.toBeVisible();
 });
 
 test('Verify user manager cannot edit or remove self account', async ({

--- a/tests/CosmosDbSeederTests/CosmosDbSeederTests.csproj
+++ b/tests/CosmosDbSeederTests/CosmosDbSeederTests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+        <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\data\CosmosDbSeeder\CosmosDbSeeder.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="..\..\data\CosmosDbSeeder\items\*\**">
+        <Link>items\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
+</Project>

--- a/tests/CosmosDbSeederTests/CosmosDbSeederTests.csproj
+++ b/tests/CosmosDbSeederTests/CosmosDbSeederTests.csproj
@@ -28,7 +28,7 @@
     <ItemGroup>
       <None Include="..\..\data\CosmosDbSeeder\items\*\**">
         <Link>items\%(RecursiveDir)%(Filename)%(Extension)</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>
 

--- a/tests/CosmosDbSeederTests/GlobalRolesDocument.cs
+++ b/tests/CosmosDbSeederTests/GlobalRolesDocument.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json.Serialization;
+
+namespace CosmosDbSeederTests;
+
+public class GlobalRolesDocument
+{
+    [JsonPropertyName("id")] public required string Id { get; set; }
+
+    [JsonPropertyName("docType")] public required string DocType { get; set; }
+
+    [JsonPropertyName("roles")] public required Role[] Roles { get; set; }
+}
+
+public class Role
+{
+    [JsonPropertyName("id")] public required string Id { get; set; }
+
+    [JsonPropertyName("name")] public required string Name { get; set; }
+
+    [JsonPropertyName("description")] public required string Description { get; set; }
+
+    [JsonPropertyName("permissions")] public required string[] Permissions { get; set; }
+}

--- a/tests/CosmosDbSeederTests/GlobalRolesTests.cs
+++ b/tests/CosmosDbSeederTests/GlobalRolesTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+
+namespace CosmosDbSeederTests;
+
+public class GlobalRolesTests
+{
+    private static object ReadGlobalRoles(string environment)
+    {
+        var globalRoles = JsonConvert.DeserializeObject(File.ReadAllText(Path.Combine(
+            AppDomain.CurrentDomain.BaseDirectory,
+            $"items/{environment}/core_data/global_roles.json")));
+
+        return globalRoles ?? throw new Exception($"Could not read global_roles.json from {environment} environment");
+    }
+
+    [Fact]
+    public void GlobalRolesShouldBeTheSameInEachEnvironment()
+    {
+        var localGlobalRoles = ReadGlobalRoles("local");
+        var devGlobalRoles = ReadGlobalRoles("dev");
+        var intGlobalRoles = ReadGlobalRoles("int");
+        var stagGlobalRoles = ReadGlobalRoles("stag");
+        var prodGlobalRoles = ReadGlobalRoles("prod");
+
+        devGlobalRoles.Should().BeEquivalentTo(intGlobalRoles);
+        intGlobalRoles.Should().BeEquivalentTo(stagGlobalRoles);
+        stagGlobalRoles.Should().BeEquivalentTo(prodGlobalRoles);
+    }
+}

--- a/tests/CosmosDbSeederTests/GlobalRolesTests.cs
+++ b/tests/CosmosDbSeederTests/GlobalRolesTests.cs
@@ -5,9 +5,9 @@ namespace CosmosDbSeederTests;
 
 public class GlobalRolesTests
 {
-    private static object ReadGlobalRoles(string environment)
+    private static GlobalRolesDocument ReadGlobalRoles(string environment)
     {
-        var globalRoles = JsonConvert.DeserializeObject(File.ReadAllText(Path.Combine(
+        var globalRoles = JsonConvert.DeserializeObject<GlobalRolesDocument>(File.ReadAllText(Path.Combine(
             AppDomain.CurrentDomain.BaseDirectory,
             $"items/{environment}/core_data/global_roles.json")));
 
@@ -26,5 +26,17 @@ public class GlobalRolesTests
         devGlobalRoles.Should().BeEquivalentTo(intGlobalRoles);
         intGlobalRoles.Should().BeEquivalentTo(stagGlobalRoles);
         stagGlobalRoles.Should().BeEquivalentTo(prodGlobalRoles);
+
+        localGlobalRoles.Roles =
+            localGlobalRoles.Roles.Where(role => role.Id != "system:integration-test-user").ToArray();
+        localGlobalRoles.Should().BeEquivalentTo(devGlobalRoles);
+    }
+
+    [Fact(DisplayName = "APPT-802: Admin User roles should include user manager")]
+    public void AdminUserRolesShouldIncludeManageUsers()
+    {
+        var adminRoles = ReadGlobalRoles("local").Roles.Single(role => role.Id == "system:admin-user");
+
+        adminRoles.Permissions.Should().Contain("users:manage");
     }
 }


### PR DESCRIPTION
This PR adds `users:manage` to the list of permissions given to admin users. 

It also clears up some inconsistencies between global roles in each environment and adds tests to assert their equivalence. The list of changes is described [on the ticket](https://nhsd-jira.digital.nhs.uk/browse/APPT-802) and also here:

- The system:auditer role has been deleted entirely
- The system:admin-user has been removed from system:all-permissions
- The system-run-reminders and system:run-provisional-sweep roles have been added to system:all-permissions in all environments
- The system:data-importer has been removed from system:admin-user in all environments