### PR TITLE
APPT-885: Fix Okta provisioning bug

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/SetUserRolesFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/SetUserRolesFunction.cs
@@ -51,6 +51,7 @@ public class SetUserRolesFunction(
     {
         if (userContextProvider.UserPrincipal.Claims.GetUserEmail() == request.User)
         {
+            logger.LogError("Failed to set user roles. Reason: A user may not edit their own roles.");
             return Failed(HttpStatusCode.BadRequest,
                 "You cannot update the role assignments of the currently logged in user.");
         }
@@ -61,6 +62,7 @@ public class SetUserRolesFunction(
 
             if (!isOktaEnabled)
             {
+                logger.LogError("Failed to set user roles. Reason: Okta is disabled.");
                 return Failed(HttpStatusCode.NotImplemented, "Okta is disabled.");
             }
 
@@ -68,6 +70,7 @@ public class SetUserRolesFunction(
             var externalDirectoryResult = await oktaService.CreateIfNotExists(request.User, request.FirstName, request.LastName);
             if (!externalDirectoryResult.Success)
             {
+                logger.LogError("Failed to set user roles. Reason: {reason}", externalDirectoryResult.FailureReason);
                 return Failed(HttpStatusCode.BadRequest, externalDirectoryResult.FailureReason);
             }
         }

--- a/src/api/Nhs.Appointments.Core/Okta/OktaService.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaService.cs
@@ -1,6 +1,6 @@
 namespace Nhs.Appointments.Core.Okta;
 
-public class OktaService(IOktaUserDirectory oktaUserDirectory) : IOktaService
+public class OktaService(IOktaUserDirectory oktaUserDirectory, TimeProvider timeProvider) : IOktaService
 {
     public async Task<UserProvisioningStatus> CreateIfNotExists(string userEmail, string firstName, string lastName)
     {
@@ -57,7 +57,7 @@ public class OktaService(IOktaUserDirectory oktaUserDirectory) : IOktaService
             return UserState.UserDoesNotExist;
         }
 
-        var isOlderThanOneDay = DateTime.UtcNow - user.Created > TimeSpan.FromDays(1);
+        var isOlderThanOneDay = timeProvider.GetUtcNow() - user.Created > TimeSpan.FromDays(1);
         if (user.IsProvisioned && isOlderThanOneDay)
         {
             return UserState.UserWasProvisionedButOver24HoursAgo;

--- a/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
@@ -1,6 +1,6 @@
 using Nhs.Appointments.Core.Okta;
 
-namespace Nhs.Appointments.UserManagement.Okta.UnitTests;
+namespace Nhs.Appointments.Core.UnitTests;
 
 public class OktaServiceTests
 {

--- a/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Nhs.Appointments.Core.Okta;
 
 namespace Nhs.Appointments.UserManagement.Okta.UnitTests;
@@ -7,15 +6,13 @@ public class OktaServiceTests
 {
     private readonly OktaService _sut;
     private readonly Mock<IOktaUserDirectory> _oktaUserDirectory = new();
+    private readonly Mock<TimeProvider> _timeProvider = new();
 
     private readonly string userEmail = "test@okta.com";
     private readonly string firstName = "first";
     private readonly string lastName = "last";
 
-    public OktaServiceTests()
-    {
-        _sut = new OktaService(_oktaUserDirectory.Object);
-    }
+    public OktaServiceTests() => _sut = new OktaService(_oktaUserDirectory.Object, _timeProvider.Object);
 
     [Fact]
     public async Task CreateIfNotExists_CreateUser_UserCreated()
@@ -46,7 +43,7 @@ public class OktaServiceTests
 
         Assert.Multiple(
             () => result.Success.Should().BeFalse(),
-            () => result.FailureReason.Should().Be("User could not be created"),
+            () => result.FailureReason.Should().Be("Failed to create the user"),
             () => _oktaUserDirectory.Verify(x => x.CreateUserAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once),
             () => _oktaUserDirectory.Verify(x => x.ReactivateUserAsync(It.IsAny<string>()), Times.Never)
@@ -73,6 +70,8 @@ public class OktaServiceTests
     [Fact]
     public async Task CreateIfNotExists_ReactivateUser()
     {
+        _timeProvider.Setup(x => x.GetUtcNow()).Returns(new DateTime(2025, 3, 20, 20, 0, 59));
+
         var oktaUserResponse = new OktaUserResponse
         {
             Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero),
@@ -89,6 +88,32 @@ public class OktaServiceTests
             () => _oktaUserDirectory.Verify(x => x.CreateUserAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never),
             () => _oktaUserDirectory.Verify(x => x.ReactivateUserAsync(It.IsAny<string>()), Times.Once)
+        );
+    }
+
+    [Fact]
+    public async Task CreateIfNotExists_UserWasProvisionedLessThan24HoursAgo()
+    {
+        _timeProvider.Setup(x => x.GetUtcNow()).Returns(new DateTime(2025, 3, 15, 20, 0, 59));
+
+        var oktaUserResponse = new OktaUserResponse
+        {
+            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero),
+            IsProvisioned = true,
+            IsActive = false
+        };
+
+        _oktaUserDirectory.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(oktaUserResponse);
+        _oktaUserDirectory.Setup(x => x.ReactivateUserAsync(It.IsAny<string>())).ReturnsAsync(true);
+
+        var result = await _sut.CreateIfNotExists(userEmail, firstName, lastName);
+
+        Assert.Multiple(
+            () => result.Success.Should().BeTrue(),
+            () => result.FailureReason.Should().BeNullOrEmpty(),
+            () => _oktaUserDirectory.Verify(x => x.CreateUserAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never),
+            () => _oktaUserDirectory.Verify(x => x.ReactivateUserAsync(It.IsAny<string>()), Times.Never)
         );
     }
 }


### PR DESCRIPTION
Attempting to add or edit an Okta user with 24 hours of first creating them is causing an error. 

This is because of a bug in some OktaService logic which assesses if they're provisioned (i.e. invited to okta but not yet activated), and re-activates that provisioning request if it's expired (i.e. they didn't activate their account within 24 hours). This logic was returning an unsuccessful result if they were provisioned but within that 24 hour period, but it should've been returning a success. 

This PR fixes this bug and also re-writes the service to be a bit clearer/more readable. 