### PR TITLE
APPT-750 - lower staging throughput as perf now owns the high cost

### DIFF
--- a/infrastructure/environments/stag/main.tf
+++ b/infrastructure/environments/stag/main.tf
@@ -89,16 +89,4 @@ module "mya_application_stag" {
       failover_priority = 1
       zone_redundant    = false
   }]
-  cosmos_booking_autoscale_settings = [{
-    max_throughput = 60000
-  }]
-  cosmos_core_autoscale_settings = [{
-    max_throughput = 25000
-  }]
-  cosmos_index_autoscale_settings = [{
-    max_throughput = 4000
-  }]
-  cosmos_audit_autoscale_settings = [{
-    max_throughput = 2000
-  }]
 }


### PR DESCRIPTION
Removes the thoughput settings to staging as Perf has been created and now has this throughput. We'll only needed it to be this high for performance testing and as that's been moved to a new environment we can remove it from staging