### PR TITLE
APPT-912: Fix summary links when editing user

### DIFF
--- a/src/client/src/app/lib/components/nhsuk-frontend/summary-list.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/summary-list.tsx
@@ -68,7 +68,7 @@ const SummaryList = ({ items, borders = true }: Props) => {
                 {item.action.renderingStrategy === 'server' ? (
                   <Link href={item.action.href}>{item.action.text}</Link>
                 ) : (
-                  <Link href={''} onClick={item.action.onClick}>
+                  <Link href={''} onClick={item.action.onClick} role="button">
                     {item.action.text}
                   </Link>
                 )}

--- a/src/client/src/app/site/[site]/users/manage/wizard-steps/summary-step.test.tsx
+++ b/src/client/src/app/site/[site]/users/manage/wizard-steps/summary-step.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import render from '@testing/render';
 import { useRouter } from 'next/navigation';
 import MockForm from '@testing/mockForm';
@@ -243,5 +243,25 @@ describe('Summary Step', () => {
 
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(mockPush).toHaveBeenCalledWith('/route-to-cancel-back-to');
+  });
+
+  it('moves back to the role steps when Change (roles) is clicked', async () => {
+    const { user } = render(
+      <MockForm<SetUserRolesFormValues>
+        submitHandler={jest.fn()}
+        defaultValues={formState}
+        schema={setUserRolesFormSchema}
+      >
+        <SummaryStep
+          {...defaultProps}
+          returnRouteUponCancellation="/route-to-cancel-back-to"
+        />
+      </MockForm>,
+    );
+
+    const rolesRow = screen.getByRole('listitem', { name: 'Roles summary' });
+    await user.click(within(rolesRow).getByRole('button', { name: 'Change' }));
+
+    expect(mockGoToPreviousStep).toHaveBeenCalled();
   });
 });

--- a/src/client/src/app/site/[site]/users/manage/wizard-steps/summary-step.tsx
+++ b/src/client/src/app/site/[site]/users/manage/wizard-steps/summary-step.tsx
@@ -44,6 +44,8 @@ const SummaryStep = ({
     userIdentityStatus?.identityProvider === 'Okta' &&
     userIdentityStatus?.extantInIdentityProvider === false;
 
+  const isEditingExistingUser = userIdentityStatus.extantInSite;
+
   const nameSummary: SummaryListItem[] = isCreatingNewOktaUser
     ? [
         {
@@ -64,13 +66,15 @@ const SummaryStep = ({
     {
       title: 'Email address',
       value: email,
-      action: {
-        renderingStrategy: 'client',
-        text: 'Change',
-        onClick: () => {
-          setCurrentStep(1);
-        },
-      },
+      action: isEditingExistingUser
+        ? undefined
+        : {
+            renderingStrategy: 'client',
+            text: 'Change',
+            onClick: () => {
+              setCurrentStep(1);
+            },
+          },
     },
     {
       title: 'Roles',
@@ -79,7 +83,7 @@ const SummaryStep = ({
         renderingStrategy: 'client',
         text: 'Change',
         onClick: () => {
-          setCurrentStep(3);
+          goToPreviousStep();
         },
       },
     },


### PR DESCRIPTION
DRAFT PR until ticket AC are confirmed!

Fixes some bugs on the summary screen when editing users: 

- The "Change" button for roles now correctly moves to the roles step
- The "Change" button for email address is hidden if you're editing an existing user (but still shows if creating a new one)
- The `{user} will be sent information about how to log in.` is now idden if you're editing an existing user (but still shows if creating a new one)