### PR TITLE
APPT-898: Okta bug fixes

### DIFF
--- a/src/api/Nhs.Appointments.Core/Okta/IOktaUserDirectory.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/IOktaUserDirectory.cs
@@ -4,5 +4,5 @@ public interface IOktaUserDirectory
 {
     Task<OktaUserResponse?> GetUserAsync(string user);
     Task<bool> ReactivateUserAsync(string user);
-    Task<bool> CreateUserAsync(string user, string? firstName, string? lastName);
+    Task<bool> CreateUserAsync(string user, string firstName, string lastName);
 }

--- a/src/api/Nhs.Appointments.Core/Okta/OktaLocalUserDirectory.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaLocalUserDirectory.cs
@@ -5,13 +5,13 @@ public class OktaLocalUserDirectory : IOktaUserDirectory
     private bool UserAlreadyExistsOnImaginaryOktaServer(string user) => user.StartsWith("test.provisioned.okta.user");
     public async Task<bool> ReactivateUserAsync(string user) => await Task.FromResult(true);
 
-    public async Task<bool> CreateUserAsync(string user, string? firstName, string? lastName) =>
+    public async Task<bool> CreateUserAsync(string user, string firstName, string lastName) =>
         await Task.FromResult(!UserAlreadyExistsOnImaginaryOktaServer(user));
 
-    public async Task<OktaUserResponse?> GetUserAsync(string user) => user.StartsWith("test.provisioned.okta.user")
+    public async Task<OktaUserResponse> GetUserAsync(string user) => user.StartsWith("test.provisioned.okta.user")
         ? await Task.FromResult(new OktaUserResponse
         {
-            Created = DateTimeOffset.Now.AddDays(-7), IsActive = true, IsProvisioned = true
+            Created = DateTimeOffset.Now.AddDays(-7), Status = OktaUserStatus.Active
         })
         : null;
 }

--- a/src/api/Nhs.Appointments.Core/Okta/OktaService.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaService.cs
@@ -4,21 +4,35 @@ public class OktaService(IOktaUserDirectory oktaUserDirectory, TimeProvider time
 {
     public async Task<UserProvisioningStatus> CreateIfNotExists(string userEmail, string firstName, string lastName)
     {
-        var userState = await GetUserState(userEmail);
-        return userState switch
+        var oktaUser = await oktaUserDirectory.GetUserAsync(userEmail);
+
+        switch (oktaUser?.Status)
         {
-            UserState.UserDoesNotExist => await CreateUser(userEmail, firstName, lastName),
-            UserState.UserWasProvisionedButOver24HoursAgo => await ReactivateUser(userEmail),
-            UserState.UserWasProvisionedButUnder24HoursAgo or UserState.UserIsActive => new UserProvisioningStatus
-            {
-                Success = true
-            },
-            _ => new UserProvisioningStatus
-            {
-                Success = false, FailureReason = "Failed to identify if user was active, provisioned or not extant."
-            }
-        };
+            case null:
+                return await CreateUser(userEmail, firstName, lastName);
+            case OktaUserStatus.Active:
+                return new UserProvisioningStatus { Success = true };
+            case OktaUserStatus.Provisioned:
+                {
+                    var isOlderThanOneDay = timeProvider.GetUtcNow() - oktaUser.Created > TimeSpan.FromDays(1);
+                    if (isOlderThanOneDay)
+                    {
+                        return await ReactivateUser(userEmail);
+                    }
+
+                    return new UserProvisioningStatus { Success = true };
+                }
+            case OktaUserStatus.Deactivated:
+                return new UserProvisioningStatus { Success = false, FailureReason = "User account is deactivated." };
+            default:
+                return new UserProvisioningStatus
+                {
+                    Success = false,
+                    FailureReason = "Failed to identify if user was active, provisioned or not extant."
+                };
+        }
     }
+
 
     private async Task<UserProvisioningStatus> CreateUser(string email, string firstName, string lastName)
     {
@@ -38,38 +52,5 @@ public class OktaService(IOktaUserDirectory oktaUserDirectory, TimeProvider time
             Success = reactivatedSuccessfully,
             FailureReason = !reactivatedSuccessfully ? "Failed to reactivate the user" : string.Empty
         };
-    }
-
-    private async Task<UserState> GetUserState(string userEmail)
-    {
-        var user = await oktaUserDirectory.GetUserAsync(userEmail);
-        if (user is null)
-        {
-            return UserState.UserDoesNotExist;
-        }
-
-        if (user.IsProvisioned)
-        {
-            return GetProvisionedState(user.Created);
-        }
-
-        return user.IsActive ? UserState.UserIsActive : UserState.Unknown;
-    }
-
-    private UserState GetProvisionedState(DateTimeOffset created)
-    {
-        var isOlderThanOneDay = timeProvider.GetUtcNow() - created > TimeSpan.FromDays(1);
-        return isOlderThanOneDay
-            ? UserState.UserWasProvisionedButOver24HoursAgo
-            : UserState.UserWasProvisionedButUnder24HoursAgo;
-    }
-
-    private enum UserState
-    {
-        Unknown,
-        UserDoesNotExist,
-        UserWasProvisionedButOver24HoursAgo,
-        UserWasProvisionedButUnder24HoursAgo,
-        UserIsActive
     }
 }

--- a/src/api/Nhs.Appointments.Core/Okta/OktaService.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaService.cs
@@ -9,6 +9,7 @@ public class OktaService(IOktaUserDirectory oktaUserDirectory, TimeProvider time
         switch (oktaUser?.Status)
         {
             case null:
+            case OktaUserStatus.Deactivated:
                 return await CreateUser(userEmail, firstName, lastName);
             case OktaUserStatus.Active:
                 return new UserProvisioningStatus { Success = true };
@@ -22,8 +23,6 @@ public class OktaService(IOktaUserDirectory oktaUserDirectory, TimeProvider time
 
                     return new UserProvisioningStatus { Success = true };
                 }
-            case OktaUserStatus.Deactivated:
-                return new UserProvisioningStatus { Success = false, FailureReason = "User account is deactivated." };
             default:
                 return new UserProvisioningStatus
                 {

--- a/src/api/Nhs.Appointments.Core/Okta/OktaUnimplementedUserDirectory.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaUnimplementedUserDirectory.cs
@@ -1,0 +1,11 @@
+namespace Nhs.Appointments.Core.Okta;
+
+public class OktaUnimplementedUserDirectory : IOktaUserDirectory
+{
+    public Task<bool> ReactivateUserAsync(string user) => throw new NotImplementedException();
+
+    public Task<bool> CreateUserAsync(string user, string firstName, string lastName) =>
+        throw new NotImplementedException();
+
+    public Task<OktaUserResponse> GetUserAsync(string user) => throw new NotImplementedException();
+}

--- a/src/api/Nhs.Appointments.Core/Okta/OktaUserResponse.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaUserResponse.cs
@@ -2,7 +2,7 @@ namespace Nhs.Appointments.Core.Okta;
 
 public class OktaUserResponse
 {
-    public bool IsProvisioned { get; set; }
-    public bool IsActive { get; set; }
     public DateTimeOffset Created { get; set; }
+
+    public OktaUserStatus Status { get; set; }
 }

--- a/src/api/Nhs.Appointments.Core/Okta/OktaUserStatus.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaUserStatus.cs
@@ -1,0 +1,25 @@
+﻿namespace Nhs.Appointments.Core.Okta;
+
+public enum OktaUserStatus
+{
+    /// <summary>
+    ///     A fallback case. If this value is ever used we probably have a bug.
+    /// </summary>
+    Unknown,
+
+    /// <summary>
+    ///     The user has an existing account in Okta. It may be in various states of password recovery / suspension, but it
+    ///     exists and requires no action from MYA.
+    /// </summary>
+    Active,
+
+    /// <summary>
+    ///     The user has been sent an email requesting them to complete their registration. This will go stale after 24 hours.
+    /// </summary>
+    Provisioned,
+
+    /// <summary>
+    ///     The user's account has been deprovisioned or deactivated by an Okta admin.
+    /// </summary>
+    Deactivated
+}

--- a/src/api/Nhs.Appointments.Core/Okta/ServiceProviderExtensions.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/ServiceProviderExtensions.cs
@@ -23,6 +23,14 @@ public static class ServiceProviderExtensions
             return services;
         }
 
+        if (oktaConfig is null || string.IsNullOrEmpty(oktaConfig.Domain) ||
+            string.IsNullOrEmpty(oktaConfig.ManagementId) ||
+            string.IsNullOrEmpty(oktaConfig.PEM) || string.IsNullOrEmpty(oktaConfig.PrivateKeyKid))
+        {
+            services.AddSingleton<IOktaUserDirectory, OktaUnimplementedUserDirectory>();
+            return services;
+        }
+
         services.AddSingleton<IOktaUserDirectory, OktaUserDirectory>();
         services.AddSingleton<UserApi>(sp =>
         {

--- a/tests/Nhs.Appointments.Core.UnitTests/OktaServiceNotImplementedTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/OktaServiceNotImplementedTests.cs
@@ -1,0 +1,25 @@
+using Nhs.Appointments.Core.Okta;
+
+namespace Nhs.Appointments.Core.UnitTests;
+
+public class OktaServiceNotImplementedTests
+{
+    private readonly OktaService _sut;
+    private readonly Mock<TimeProvider> _timeProvider = new();
+
+    private readonly string userEmail = "test@okta.com";
+    private readonly string firstName = "first";
+    private readonly string lastName = "last";
+
+    public OktaServiceNotImplementedTests() =>
+        _sut = new OktaService(new OktaUnimplementedUserDirectory(), _timeProvider.Object);
+
+    [Fact(DisplayName =
+        "Always throws a NotImplementedException if the IOktaUserDirectory injects the unimplemented store")]
+    public async Task CreateIfNotExists_ThrowsNotImplementedException()
+    {
+        await Assert.ThrowsAsync<NotImplementedException>(async () =>
+            await _sut.CreateIfNotExists(userEmail, firstName, lastName)
+        );
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/OktaServiceProviderExtensionsTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/OktaServiceProviderExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nhs.Appointments.Core.Okta;
+
+namespace Nhs.Appointments.Core.UnitTests;
+
+public class OktaServiceProviderExtensionsTests
+{
+    private readonly IServiceCollection _serviceCollection = new ServiceCollection();
+
+    // This is a meaningless token generated with dummy data.
+    // It has never been used by any of our Okta instances on any environment.
+    private readonly string mockWellFormedPemToken =
+        "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC7VJTUt9Us8cKj\nMzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu\nNMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZ\nqgtzJ6GR3eqoYSW9b9UMvkBpZODSctWSNGj3P7jRFDO5VoTwCQAWbFnOjDfH5Ulg\np2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlR\nZVEiR2BwpZOOkE/Z0/BVnhZYL71oZV34bKfWjQIt6V/isSMahdsAASACp4ZTGtwi\nVuNd9tybAgMBAAECggEBAKTmjaS6tkK8BlPXClTQ2vpz/N6uxDeS35mXpqasqskV\nlaAidgg/sWqpjXDbXr93otIMLlWsM+X0CqMDgSXKejLS2jx4GDjI1ZTXg++0AMJ8\nsJ74pWzVDOfmCEQ/7wXs3+cbnXhKriO8Z036q92Qc1+N87SI38nkGa0ABH9CN83H\nmQqt4fB7UdHzuIRe/me2PGhIq5ZBzj6h3BpoPGzEP+x3l9YmK8t/1cN0pqI+dQwY\ndgfGjackLu/2qH80MCF7IyQaseZUOJyKrCLtSD/Iixv/hzDEUPfOCjFDgTpzf3cw\nta8+oE4wHCo1iI1/4TlPkwmXx4qSXtmw4aQPz7IDQvECgYEA8KNThCO2gsC2I9PQ\nDM/8Cw0O983WCDY+oi+7JPiNAJwv5DYBqEZB1QYdj06YD16XlC/HAZMsMku1na2T\nN0driwenQQWzoev3g2S7gRDoS/FCJSI3jJ+kjgtaA7Qmzlgk1TxODN+G1H91HW7t\n0l7VnL27IWyYo2qRRK3jzxqUiPUCgYEAx0oQs2reBQGMVZnApD1jeq7n4MvNLcPv\nt8b/eU9iUv6Y4Mj0Suo/AU8lYZXm8ubbqAlwz2VSVunD2tOplHyMUrtCtObAfVDU\nAhCndKaA9gApgfb3xw1IKbuQ1u4IF1FJl3VtumfQn//LiH1B3rXhcdyo3/vIttEk\n48RakUKClU8CgYEAzV7W3COOlDDcQd935DdtKBFRAPRPAlspQUnzMi5eSHMD/ISL\nDY5IiQHbIH83D4bvXq0X7qQoSBSNP7Dvv3HYuqMhf0DaegrlBuJllFVVq9qPVRnK\nxt1Il2HgxOBvbhOT+9in1BzA+YJ99UzC85O0Qz06A+CmtHEy4aZ2kj5hHjECgYEA\nmNS4+A8Fkss8Js1RieK2LniBxMgmYml3pfVLKGnzmng7H2+cwPLhPIzIuwytXywh\n2bzbsYEfYx3EoEVgMEpPhoarQnYPukrJO4gwE2o5Te6T5mJSZGlQJQj9q4ZB2Dfz\net6INsK0oG8XVGXSpQvQh3RUYekCZQkBBFcpqWpbIEsCgYAnM3DQf3FJoSnXaMhr\nVBIovic5l0xFkEHskAjFTevO86Fsz1C2aSeRKSqGFoOQ0tmJzBEs1R6KqnHInicD\nTQrKhArgLXX4v3CddjfTRJkFWDbE/CkvKZNOrcf1nhaGCPspRJj2KUkj1Fhl9Cnc\ndn/RsYEONbwQSjIfMPkvxF+8HQ==\n-----END PRIVATE KEY-----";
+
+    [Fact(DisplayName = "Registers the Okta store if Okta config is valid")]
+    public void OktaRegistration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "Okta:Domain", "https://local.okta.com" },
+                { "Okta:ManagementId", "1234abc" },
+                { "Okta:PrivateKeyKid", "1234abc" },
+                { "Okta:PEM", mockWellFormedPemToken }
+            })
+            .Build();
+
+        var services = _serviceCollection.AddLogging().AddOktaUserDirectory(configuration);
+
+
+        var serviceProvider = services.BuildServiceProvider();
+        var oktaService = serviceProvider.GetService(typeof(IOktaUserDirectory));
+
+        oktaService.Should().BeOfType<OktaUserDirectory>();
+    }
+
+    [Fact(DisplayName = "Registers a local stub of the Okta store if Okta config is local")]
+    public void OktaRegistration_Local()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "Okta:Domain", "https://local.okta.com" },
+                { "Okta:ManagementId", "local" },
+                { "Okta:PrivateKeyKid", "local" },
+                { "Okta:PEM", "local" }
+            })
+            .Build();
+
+        var services = _serviceCollection.AddLogging().AddOktaUserDirectory(configuration);
+
+
+        var serviceProvider = services.BuildServiceProvider();
+        var oktaService = serviceProvider.GetService(typeof(IOktaUserDirectory));
+
+        oktaService.Should().BeOfType<OktaLocalUserDirectory>();
+    }
+
+    [Fact(DisplayName = "Registers an unimplemented Okta store if Okta config is missing")]
+    public void OktaRegistration_Unimplemented()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var services = _serviceCollection.AddLogging().AddOktaUserDirectory(configuration);
+
+
+        var serviceProvider = services.BuildServiceProvider();
+        var oktaService = serviceProvider.GetService(typeof(IOktaUserDirectory));
+
+        oktaService.Should().BeOfType<OktaUnimplementedUserDirectory>();
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
@@ -67,6 +67,26 @@ public class OktaServiceTests
     }
 
     [Fact]
+    public async Task CreateIfNotExists_UserDeactivated()
+    {
+        var oktaUserResponse = new OktaUserResponse
+        {
+            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero),
+            Status = OktaUserStatus.Deactivated
+        };
+        _oktaUserDirectory.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(oktaUserResponse);
+        _oktaUserDirectory.Setup(x => x.CreateUserAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
+
+        var result = await _sut.CreateIfNotExists(userEmail, firstName, lastName);
+
+        Assert.Multiple(
+            () => result.Success.Should().BeTrue(),
+            () => result.FailureReason.Should().BeNullOrEmpty()
+        );
+    }
+
+    [Fact]
     public async Task CreateIfNotExists_ReactivateUser()
     {
         _timeProvider.Setup(x => x.GetUtcNow()).Returns(new DateTime(2025, 3, 20, 20, 0, 59));

--- a/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
@@ -54,8 +54,7 @@ public class OktaServiceTests
     public async Task CreateIfNotExists_UserExists()
     {
         var oktaUserResponse = new OktaUserResponse { 
-            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero), 
-            IsActive = true 
+            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero), Status = OktaUserStatus.Active
         };
         _oktaUserDirectory.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(oktaUserResponse);
 
@@ -74,8 +73,7 @@ public class OktaServiceTests
 
         var oktaUserResponse = new OktaUserResponse
         {
-            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero),
-            IsProvisioned = true
+            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero), Status = OktaUserStatus.Provisioned
         };
         _oktaUserDirectory.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(oktaUserResponse);
         _oktaUserDirectory.Setup(x => x.ReactivateUserAsync(It.IsAny<string>())).ReturnsAsync(true);
@@ -98,9 +96,7 @@ public class OktaServiceTests
 
         var oktaUserResponse = new OktaUserResponse
         {
-            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero),
-            IsProvisioned = true,
-            IsActive = false
+            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero), Status = OktaUserStatus.Provisioned
         };
 
         _oktaUserDirectory.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(oktaUserResponse);


### PR DESCRIPTION
Solves one Okta bug, and temporarily patches over another. 

Bug 1: High load, Service bus and Timer functions were still registering the Okta API through DI but lacked the config for it. This was triggering exceptions when trying to read the PEM token. There is now an unimplemented Okta store which is registered instead if this config is missing. An added benefit of this is failing fast if Okta functions are ever used in those functions. 

Bug 2: Even when I grant our Okta API service account every single permission in the list, we are still receiving an unauthorised response when trying to reactivate users. This is causing the service to fail when it encounters a Provisioned user who was provisioned over 24 hours ago (i.e. the email was sent out but the user never configured their password/2FA). I can't explain this yet, but it's a live issue so I've added code to except this exact case for now. I will tackle this issue in the next PR. 