### PR TITLE
APPT-935: Staging redirect bug

### DIFF
--- a/src/client/src/app/auth/set-cookie/route.ts
+++ b/src/client/src/app/auth/set-cookie/route.ts
@@ -37,5 +37,5 @@ export async function GET(request: NextRequest) {
     redirect(`${process.env.CLIENT_BASE_PATH}/${previousPage.value}`);
   }
 
-  redirect('/sites');
+  redirect(`${process.env.CLIENT_BASE_PATH}/sites`);
 }


### PR DESCRIPTION
Try using the base path in the fallback login redirect in the case where the browser has no previousPath cookie