### PR TITLE
APPT-855: Set feature toggles during deployment

### DIFF
--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -258,9 +258,26 @@ stages:
             env:
               COSMOS_ENDPOINT: $(COSMOS_ENDPOINT)
               COSMOS_TOKEN: $(COSMOS_TOKEN)
+      
+      -job: ImportFeatureFlags
+        displayName: "Import Feature Flags"
+        dependsOn: UploadCosmosDocuments
+        variables:
+          environment: ${{parameters.env}}
+        steps:
+          - checkout: self
+          - task: AzureCLI@2
+              displayName: "Apply Feature Toggles"
+              inputs:
+                azureSubscription: ${{parameters.serviceConnectionName}}
+                scriptType: pscore
+                scriptLocation: scriptPath
+                scriptPath: "$(Build.SourcesDirectory)/features/scripts/import-flags.ps1"
+                arguments: "-appConfigName nbs-mya-config-${{parameters.env}}-uks -sourceFile $(Build.SourcesDirectory)/features/${{parameters.env}}.feature.flags.json"
+                
       - job: WaitForSlotApproval
         dependsOn:
-          - UploadCosmosDocuments
+          - ImportFeatureFlags
         condition: and(succeeded(), ${{ in(parameters.env, 'stag', 'prod') }})
         displayName: "Wait for approval to swap slots"
         pool: server


### PR DESCRIPTION
We currently have to create/update feature toggles as a manual step after each deployment. This poses risks because:

- There is a time gap between deploying and setting feature toggles, during which toggles could be incorrect
- There is the chance of us forgetting to run the pipeline and never setting toggles at all (this occurred the last time we deployed)

This PR replicas the manual step but brings it into the main deployment pipeline. It runs it straight after uploading documents to Cosmos so it happens in sync with other critical data changes.