### PR TITLE
APPT-863: Validate coordinates in frontend. APPT-864: Allow empty phone number

### DIFF
--- a/src/api/Nhs.Appointments.Api/Validators/SetSiteDetailsValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/SetSiteDetailsValidator.cs
@@ -19,8 +19,7 @@ public class SetSiteDetailsValidator : AbstractValidator<SetSiteDetailsRequest>
             .NotEmpty()
             .WithMessage("Provide a valid address");
         RuleFor(x => x.PhoneNumber)
-            .Matches(TelephoneRegex).WithMessage("Phone number must contain numbers and spaces only")
-            .NotEmpty().WithMessage("Provide a valid phone number");
+            .Matches(TelephoneRegex).WithMessage("Phone number must contain numbers and spaces only");
         RuleFor(x => x.Latitude)
             .Must(x => decimal.TryParse(x, out _)).WithMessage("Latitude must be a decimal number")
             .NotEmpty()

--- a/src/client/src/app/lib/components/form-controls/decimal.tsx
+++ b/src/client/src/app/lib/components/form-controls/decimal.tsx
@@ -8,11 +8,7 @@ import {
   FieldPath,
   FieldValues,
   Path,
-  PathValue,
 } from 'react-hook-form';
-
-//the string is a valid decimal number
-const VALID_DECIMAL_REGEX = new RegExp(/^(-?\d+(\.\d+)?)$/);
 
 //the string only contains: numbers, '-', '.'; or is empty
 const INPUT_DECIMAL_REGEX = new RegExp(/^[-\d.]*$/);
@@ -39,26 +35,11 @@ const DecimalFormControl = <TFieldValues extends FieldValues, TContext>({
     }
   };
 
-  const validateInput = (
-    value: PathValue<TFieldValues, Path<TFieldValues>>,
-  ) => {
-    if (value.trim().length === 0) {
-      return 'Enter a value';
-    }
-
-    if (!VALID_DECIMAL_REGEX.test(value)) {
-      return 'Enter a valid decimal';
-    }
-  };
-
   return (
     <FormGroup error={(errors[formField]?.message as string) ?? ''}>
       <Controller
         name={formField}
         control={control}
-        rules={{
-          validate: value => validateInput(value),
-        }}
         render={({ field }) => (
           <TextInput
             {...field}

--- a/src/client/src/app/lib/components/form-controls/phoneNumber.tsx
+++ b/src/client/src/app/lib/components/form-controls/phoneNumber.tsx
@@ -8,7 +8,6 @@ import {
   FieldPath,
   FieldValues,
   Path,
-  PathValue,
 } from 'react-hook-form';
 
 const PHONE_NUMBER_REGEX = new RegExp(/^[0-9 ]*$/);
@@ -38,26 +37,11 @@ const PhoneNumberFormControl = <TFieldValues extends FieldValues, TContext>({
     }
   };
 
-  const validateInput = (
-    value: PathValue<TFieldValues, Path<TFieldValues>>,
-  ) => {
-    if (value.trim().length === 0) {
-      return 'Enter a value';
-    }
-
-    if (!PHONE_NUMBER_REGEX.test(value)) {
-      return 'Enter a valid phone number';
-    }
-  };
-
   return (
     <FormGroup error={(errors[formField]?.message as string) ?? ''}>
       <Controller
         name={formField}
         control={control}
-        rules={{
-          validate: value => validateInput(value),
-        }}
         render={({ field }) => (
           <TextInput
             {...field}

--- a/src/client/src/app/lib/types/index.tsx
+++ b/src/client/src/app/lib/types/index.tsx
@@ -41,7 +41,7 @@ type SetInformationForCitizensRequest = {
 type SetSiteDetailsRequest = {
   name: string;
   address: string;
-  phoneNumber: string;
+  phoneNumber?: string;
   latitude: string;
   longitude: string;
 };

--- a/src/client/src/app/site/[site]/details/edit-details/edit-details-form.tsx
+++ b/src/client/src/app/site/[site]/details/edit-details/edit-details-form.tsx
@@ -48,7 +48,7 @@ const EditDetailsForm = ({ site }: { site: Site }) => {
       name: form.name.trim(),
       //remove the line breaks and save back
       address: form.address.replace(/\n/g, ' ').trim(),
-      phoneNumber: form.phoneNumber.trim(),
+      phoneNumber: form.phoneNumber?.trim(),
       latitude: `${form.latitude}`,
       longitude: `${form.longitude}`,
     };

--- a/src/client/src/app/site/[site]/details/edit-details/edit-details-form.tsx
+++ b/src/client/src/app/site/[site]/details/edit-details/edit-details-form.tsx
@@ -11,18 +11,15 @@ import {
 } from '@nhsuk-frontend-components';
 import { useRouter } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
 import { SetSiteDetailsRequest, Site } from '@types';
 import { saveSiteDetails } from '@services/appointmentsService';
 import DecimalFormControl from '@components/form-controls/decimal';
 import PhoneNumberFormControl from '@components/form-controls/phoneNumber';
-
-type FormFields = {
-  name: string;
-  address: string;
-  phoneNumber: string;
-  latitude: string;
-  longitude: string;
-};
+import {
+  editSiteDetailsFormSchema,
+  EditSiteDetailsFormValues,
+} from './edit-site-details-form-schema';
 
 const EditDetailsForm = ({ site }: { site: Site }) => {
   const {
@@ -30,27 +27,30 @@ const EditDetailsForm = ({ site }: { site: Site }) => {
     control,
     handleSubmit,
     formState: { errors, isSubmitting, isSubmitSuccessful },
-  } = useForm<FormFields>({
+  } = useForm<EditSiteDetailsFormValues>({
     defaultValues: {
       name: site.name,
       //add in line breaks at each comma
       address: site.address.replace(/, /g, ',\n'),
       phoneNumber: site.phoneNumber,
-      latitude: site.location.coordinates[1].toString(),
-      longitude: site.location.coordinates[0].toString(),
+      latitude: site.location.coordinates[1],
+      longitude: site.location.coordinates[0],
     },
+    resolver: yupResolver(editSiteDetailsFormSchema),
   });
 
   const { replace } = useRouter();
 
-  const submitForm: SubmitHandler<FormFields> = async (form: FormFields) => {
+  const submitForm: SubmitHandler<EditSiteDetailsFormValues> = async (
+    form: EditSiteDetailsFormValues,
+  ) => {
     const payload: SetSiteDetailsRequest = {
       name: form.name.trim(),
       //remove the line breaks and save back
       address: form.address.replace(/\n/g, ' ').trim(),
       phoneNumber: form.phoneNumber.trim(),
-      latitude: form.latitude.trim(),
-      longitude: form.longitude.trim(),
+      latitude: `${form.latitude}`,
+      longitude: `${form.longitude}`,
     };
     await saveSiteDetails(site.id, payload);
 
@@ -63,12 +63,7 @@ const EditDetailsForm = ({ site }: { site: Site }) => {
         <TextInput
           id="name"
           label="Site name"
-          {...register('name', {
-            required: {
-              value: true,
-              message: 'Enter a name',
-            },
-          })}
+          {...register('name')}
         ></TextInput>
       </FormGroup>
 
@@ -76,12 +71,7 @@ const EditDetailsForm = ({ site }: { site: Site }) => {
         <TextArea
           id="address"
           label="Site address"
-          {...register('address', {
-            required: {
-              value: true,
-              message: 'Enter an address',
-            },
-          })}
+          {...register('address')}
         ></TextArea>
       </FormGroup>
 

--- a/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.test.ts
+++ b/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.test.ts
@@ -1,0 +1,144 @@
+import { ValidationError } from 'yup';
+import {
+  editSiteDetailsFormSchema,
+  EditSiteDetailsFormValues,
+} from './edit-site-details-form-schema';
+
+const validFormValues: EditSiteDetailsFormValues = {
+  name: 'Alderney Road Community Pharmacy',
+  address: '67 Alderney Road, New Pudsey, LS28 7QH',
+  phoneNumber: '01234 567890',
+  latitude: 53.789,
+  longitude: -1.234,
+};
+
+const getValidationErrorMessageOrTrue = async (
+  formValues: EditSiteDetailsFormValues,
+): Promise<string | true> => {
+  try {
+    await editSiteDetailsFormSchema.validate(formValues);
+    return true;
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return error.message;
+    } else {
+      throw error;
+    }
+  }
+};
+
+describe('Set User Roles Form', () => {
+  it('validates the schema', () => {
+    expect(editSiteDetailsFormSchema.isValidSync(validFormValues)).toBe(true);
+  });
+
+  it.each([
+    ['', 'Enter a name'],
+    [undefined, 'Enter a name'],
+    ['Alderney Road Community Pharmacy', true],
+    ['A', true],
+    ['     ', 'Enter a name'],
+  ])(
+    'validates the site name',
+    async (name: string | undefined, expectedErrorOrTrue: string | boolean) => {
+      const result = await getValidationErrorMessageOrTrue({
+        ...validFormValues,
+        name,
+      } as EditSiteDetailsFormValues);
+
+      expect(result).toBe(expectedErrorOrTrue);
+    },
+  );
+
+  it.each([
+    ['', 'Enter an address'],
+    [undefined, 'Enter an address'],
+    ['67 Alderney Road, New Pudsey, LS28 7QH', true],
+    ['A', true],
+    ['     ', 'Enter an address'],
+  ])(
+    'validates the site address',
+    async (
+      address: string | undefined,
+      expectedErrorOrTrue: string | boolean,
+    ) => {
+      const result = await getValidationErrorMessageOrTrue({
+        ...validFormValues,
+        address,
+      } as EditSiteDetailsFormValues);
+
+      expect(result).toBe(expectedErrorOrTrue);
+    },
+  );
+
+  it.each([
+    ['', 'Enter a phone number'],
+    [undefined, 'Enter a phone number'],
+    ['01234 567890', true],
+    ['123 456 789 0', true],
+    ['     ', 'Enter a phone number'],
+    ['abc', 'Enter a valid phone number'],
+    ['123v567', 'Enter a valid phone number'],
+    ['e', 'Enter a valid phone number'],
+    ['    1 2 3 4 5 6 7 8 9 0   ', true],
+  ])(
+    'validates the site phone number',
+    async (
+      phoneNumber: string | undefined,
+      expectedErrorOrTrue: string | boolean,
+    ) => {
+      const result = await getValidationErrorMessageOrTrue({
+        ...validFormValues,
+        phoneNumber,
+      } as EditSiteDetailsFormValues);
+
+      expect(result).toBe(expectedErrorOrTrue);
+    },
+  );
+
+  it.each([
+    [undefined, 'Enter a latitude'],
+    [-10, true],
+    [10, true],
+    [-49.8, true],
+    [-49.9, 'Enter a valid latitude'],
+    [60.9, true],
+    [61.0, 'Enter a valid latitude'],
+  ])(
+    'validates the site latitude',
+    async (
+      latitude: number | undefined,
+      expectedErrorOrTrue: string | boolean,
+    ) => {
+      const result = await getValidationErrorMessageOrTrue({
+        ...validFormValues,
+        latitude,
+      } as EditSiteDetailsFormValues);
+
+      expect(result).toBe(expectedErrorOrTrue);
+    },
+  );
+
+  it.each([
+    [undefined, 'Enter a longitude'],
+    [-1, true],
+    [1, true],
+    [-8.1, true],
+    [-8.2, 'Enter a valid longitude'],
+    [1.8, true],
+    [1.9, 'Enter a valid longitude'],
+  ])(
+    'validates the site longitude',
+    async (
+      longitude: number | undefined,
+      expectedErrorOrTrue: string | boolean,
+    ) => {
+      const result = await getValidationErrorMessageOrTrue({
+        ...validFormValues,
+        longitude,
+      } as EditSiteDetailsFormValues);
+
+      expect(result).toBe(expectedErrorOrTrue);
+    },
+  );
+});

--- a/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.test.ts
+++ b/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.test.ts
@@ -72,11 +72,11 @@ describe('Set User Roles Form', () => {
   );
 
   it.each([
-    ['', 'Enter a phone number'],
-    [undefined, 'Enter a phone number'],
+    ['', true],
+    [undefined, true],
     ['01234 567890', true],
     ['123 456 789 0', true],
-    ['     ', 'Enter a phone number'],
+    ['     ', true],
     ['abc', 'Enter a valid phone number'],
     ['123v567', 'Enter a valid phone number'],
     ['e', 'Enter a valid phone number'],

--- a/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.ts
+++ b/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.ts
@@ -1,0 +1,38 @@
+import * as yup from 'yup';
+
+export type EditSiteDetailsFormValues = {
+  name: string;
+  address: string;
+  phoneNumber: string;
+  latitude: number;
+  longitude: number;
+};
+
+const PHONE_NUMBER_REGEX = new RegExp(/^[0-9 ]*$/);
+
+export const editSiteDetailsFormSchema: yup.ObjectSchema<EditSiteDetailsFormValues> =
+  yup
+    .object({
+      name: yup.string().trim().required('Enter a name'),
+      address: yup.string().trim().required('Enter an address'),
+      phoneNumber: yup
+        .string()
+        .trim()
+        .required('Enter a phone number')
+        .test('is-valid-phone-number', 'Enter a valid phone number', value => {
+          return value ? PHONE_NUMBER_REGEX.test(value) : true;
+        }),
+      latitude: yup
+        .number()
+        .transform(value => (isNaN(value) ? undefined : value))
+        .required('Enter a latitude')
+        .min(-49.8, 'Enter a valid latitude')
+        .max(60.9, 'Enter a valid latitude'),
+      longitude: yup
+        .number()
+        .transform(value => (isNaN(value) ? undefined : value))
+        .required('Enter a longitude')
+        .min(-8.1, 'Enter a valid longitude')
+        .max(1.8, 'Enter a valid longitude'),
+    })
+    .required();

--- a/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.ts
+++ b/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.ts
@@ -3,7 +3,7 @@ import * as yup from 'yup';
 export type EditSiteDetailsFormValues = {
   name: string;
   address: string;
-  phoneNumber: string;
+  phoneNumber?: string;
   latitude: number;
   longitude: number;
 };
@@ -17,8 +17,6 @@ export const editSiteDetailsFormSchema: yup.ObjectSchema<EditSiteDetailsFormValu
       address: yup.string().trim().required('Enter an address'),
       phoneNumber: yup
         .string()
-        .trim()
-        .required('Enter a phone number')
         .test('is-valid-phone-number', 'Enter a valid phone number', value => {
           return value ? PHONE_NUMBER_REGEX.test(value) : true;
         }),

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/UpdateSiteDetails.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/UpdateSiteDetails.feature
@@ -2,40 +2,51 @@ Feature: Manage site details
 
   Scenario: Update details of a site
     Given The following sites exist in the system
-      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                            | Longitude | Latitude |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true  | -60       | -60      |
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -60       | -60      |
     When I update the details for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51'
       | Name   | Address     | PhoneNumber  | Longitude | Latitude |
       | Site-B | 2B New Lane | 011322222222 | -50       | 33       |
     Then the correct information for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51' is returned
-      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                            | Longitude | Latitude |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-B | 2B New Lane | 011322222222 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true  | -50       | 33      |
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-B | 2B New Lane | 011322222222 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -50       | 33       |
 
   Scenario: Update details of a site with an valid phone number with spaces
     Given The following sites exist in the system
-      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                            | Longitude | Latitude |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true  | -60       | -60      |
+      | Site                                 | Name   | Address     | PhoneNumber | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane |             | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -60       | -60      |
     When I update the details for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51'
       | Name   | Address     | PhoneNumber  | Longitude | Latitude |
       | Site-B | 2B New Lane | 0113 2222222 | -50       | 33       |
     Then the correct information for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51' is returned
-      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                            | Longitude | Latitude |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-B | 2B New Lane | 0113 2222222 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true  | -50       | 33      |
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-B | 2B New Lane | 0113 2222222 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -50       | 33       |
+
+  Scenario: Update details of a site with an empty phone number
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -60       | -60      |
+    When I update the details for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51'
+      | Name   | Address     | PhoneNumber | Longitude | Latitude |
+      | Site-B | 2B New Lane |             | -50       | 33       |
+    Then the correct information for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51' is returned
+      | Site                                 | Name   | Address     | PhoneNumber | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-B | 2B New Lane |             | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -50       | 33       |
 
   Scenario: Update details of a site with an invalid phone number
     Given The following sites exist in the system
-      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                            | Longitude | Latitude |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true  | -60       | -60      |
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -60       | -60      |
     When I update the details for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51'
-      | Name   | Address     | PhoneNumber  | Longitude | Latitude |
+      | Name   | Address     | PhoneNumber   | Longitude | Latitude |
       | Site-B | 2B New Lane | 0113 1111111f | -50       | 33       |
     Then a bad request response is returned with the following error messages
       | Phone number must contain numbers and spaces only |
 
   Scenario: Update details of a site with an invalid phone number
     Given The following sites exist in the system
-      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                            | Longitude | Latitude |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true  | -60       | -60      |
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -60       | -60      |
     When I update the details for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51'
       | Name   | Address     | PhoneNumber  | Longitude | Latitude |
       | Site-B | 2B New Lane | abcdefg12345 | -50       | 33       |
@@ -44,24 +55,24 @@ Feature: Manage site details
 
   Scenario: Update details of a site with an empty name and an invalid phone number
     Given The following sites exist in the system
-      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                            | Longitude | Latitude |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true  | -60       | -60      |
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -60       | -60      |
     When I update the details for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51'
-      | Name   | Address     | PhoneNumber  | Longitude | Latitude |
-      |        | 2B New Lane | abcdefg12345 | -50       | 33       |
+      | Name | Address     | PhoneNumber  | Longitude | Latitude |
+      |      | 2B New Lane | abcdefg12345 | -50       | 33       |
     Then a bad request response is returned with the following error messages
       | Provide a valid name | Phone number must contain numbers and spaces only |
 
   Scenario: Update details of a site with all info invalid
     Given The following sites exist in the system
-      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                            | Longitude | Latitude |
-      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true  | -60       | -60      |
+      | Site                                 | Name   | Address     | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                                      | Longitude | Latitude |
+      | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A New Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true, def_one/attr_two=false, def_two/attr_one=true | -60       | -60      |
     When I update the details for site 'beeae4e0-dd4a-4e3a-8f4d-738f9418fb51'
-      | Name   | Address     | PhoneNumber  | Longitude | Latitude  |
-      |        |             |              | -50.45.34 | dsfsdfdsf |
+      | Name | Address | PhoneNumber | Longitude | Latitude  |
+      |      |         |             | -50.45.34 | dsfsdfdsf |
     Then a bad request response is returned with the following error messages
-      | Provide a valid name | Provide a valid address | Provide a valid phone number | Latitude must be a decimal number | Longitude must be a decimal number |
-    
+      | Provide a valid name | Provide a valid address | Latitude must be a decimal number | Longitude must be a decimal number |
+
   Scenario: Returns site not found message when site does not exist
     Given The site 'zero' does not exist in the system
     When I update the details for site 'zero'
@@ -71,7 +82,7 @@ Feature: Manage site details
 
   Scenario: Returns site not found message when site update attempted with ODS code
     Given The following sites exist in the system
-      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities            | Longitude | Latitude |
+      | Site                                 | Name   | Address      | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities       | Longitude | Latitude |
       | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-A | 1A Site Lane | 0113 1111111 | 15N     | R1     | ICB1 | Info 1                 | def_one/attr_one=true | -60       | -60      |
     When I update the details for site '15N'
       | Name   | Address     | PhoneNumber  | Longitude | Latitude |


### PR DESCRIPTION
We're not currently validating the Lat/Long co-ordinates when they're edited through MYA itself. 

This is part 1 of 2, which just adds our validation to the frontend. Part 2 will be to add the same validation to the backend API.

Also doubles up as a PR for APPT-864, which is to permit the empty string as a valid entry for the Phone Number field