### PR TITLE
APPT-938 - Adding bulk import integration tests

### DIFF
--- a/tests/Nhs.Appointments.Api.Integration/BulkImportSerialToggleCollection.cs
+++ b/tests/Nhs.Appointments.Api.Integration/BulkImportSerialToggleCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Nhs.Appointments.Api.Integration;
+
+[CollectionDefinition("BulkImportSerialToggle")]
+public class BulkImportSerialToggleCollection : ICollectionFixture<object>
+{
+}

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -110,7 +110,10 @@ public abstract partial class BaseFeatureSteps : Feature
         {
             Id = _testId.ToString(),
             DocumentType = "site",
-            Location = new Location("point", new[] { 21.41416002128359, -157.77021027939483 })
+            OdsCode = "ODS1",
+            IntegratedCareBoard = "ICB1",
+            Region = "R1",
+            Location = new Location("point", [1.41416002128359, 51.77021027939483])
         };
         return Client.GetContainer("appts", "core_data").CreateItemAsync(site);
     }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -34,7 +34,7 @@ public abstract partial class BaseFeatureSteps : Feature
 
     private const string AppointmentsApiUrl = "http://localhost:7071/api";
 
-    private readonly Guid _testId = Guid.NewGuid();
+    protected readonly Guid _testId = Guid.NewGuid();
     protected readonly CosmosClient Client;
     protected readonly HttpClient Http;
     protected readonly Mapper Mapper;
@@ -95,6 +95,20 @@ public abstract partial class BaseFeatureSteps : Feature
         var site = new SiteDocument
         {
             Id = GetSiteId(),
+            DocumentType = "site",
+            Location = new Location("point", new[] { 21.41416002128359, -157.77021027939483 })
+        };
+        return Client.GetContainer("appts", "core_data").CreateItemAsync(site);
+    }
+
+    // TODO: Added for BulkImport tests as it requires a valid Guid
+    // To clean up this method & the one above so all siteId's use only a Guid
+    [Given("a new site is configured for MYA")]
+    public Task SetupNewSite()
+    {
+        var site = new SiteDocument
+        {
+            Id = _testId.ToString(),
             DocumentType = "site",
             Location = new Location("point", new[] { 21.41416002128359, -157.77021027939483 })
         };

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/BaseBulkImportFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/BaseBulkImportFeatureSteps.cs
@@ -17,12 +17,12 @@ public class BaseBulkImportFeatureSteps(string flag, bool enabled) : FeatureTogg
 {
     private HttpResponseMessage Response { get; set; }
 
-    private const string UsersHeader = "User,FirstName,LastName,appointment-manager,availability-manager,site-details-manager,user-manager,Site";
-
     [When("I import the following users")]
     public async Task ImportUsers(DataTable dataTable)
     {
-        var csv = BuildInputCsv(dataTable, UsersHeader);
+        const string usersHeader = "User,FirstName,LastName,appointment-manager,availability-manager,site-details-manager,user-manager,Site";
+
+        var csv = BuildInputCsv(dataTable, usersHeader);
 
         using var content = new MultipartFormDataContent();
         using var fileContent = new ByteArrayContent(csv);
@@ -31,6 +31,23 @@ public class BaseBulkImportFeatureSteps(string flag, bool enabled) : FeatureTogg
         content.Add(fileContent, "file", "user-upload.csv");
 
         Response = await Http.PostAsync("http://localhost:7071/api/user/import", content);
+    }
+
+    [When("I import the following site")]
+    public async Task ImportSite(DataTable dataTable)
+    {
+        const string sitesHeader =
+            "OdsCode,Name,Address,PhoneNumber,Longitude,Latitude,ICB,Region,Site type,accessible_toilet,braille_translation_service,disabled_car_parking,car_parking,induction_loop,sign_language_service,step_free_access,text_relay,wheelchair_access,Id";
+
+        var csv = BuildInputCsv(dataTable, sitesHeader);
+
+        using var content = new MultipartFormDataContent();
+        using var fileContent = new ByteArrayContent(csv);
+
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/csv");
+        content.Add(fileContent, "file", "user-upload.csv");
+
+        Response = await Http.PostAsync("http://localhost:7071/api/site/import", content);
     }
 
     [Then("I receive a report that the import was successful")]
@@ -56,8 +73,6 @@ public class BaseBulkImportFeatureSteps(string flag, bool enabled) : FeatureTogg
         {
             var cells = row.Cells.Select(c => EscapeCsv(c.Value)).ToList();
             cells.Add(EscapeCsv(_testId.ToString()));
-
-            var thing = string.Join(",", cells);
 
             sb.Append($"{string.Join(",", cells)}\r\n");
         }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/BaseBulkImportFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/BaseBulkImportFeatureSteps.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Gherkin.Ast;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Nhs.Appointments.Core;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Gherkin.Quick;
+
+namespace Nhs.Appointments.Api.Integration.Scenarios.BulkImport;
+public class BaseBulkImportFeatureSteps(string flag, bool enabled) : FeatureToggledSteps(flag, enabled)
+{
+    private HttpResponseMessage Response { get; set; }
+
+    private const string UsersHeader = "User,FirstName,LastName,appointment-manager,availability-manager,site-details-manager,user-manager,Site";
+
+    [When("I import the following users")]
+    public async Task ImportUsers(DataTable dataTable)
+    {
+        var csv = BuildInputCsv(dataTable, UsersHeader);
+
+        using var content = new MultipartFormDataContent();
+        using var fileContent = new ByteArrayContent(csv);
+
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/csv");
+        content.Add(fileContent, "file", "user-upload.csv");
+
+        Response = await Http.PostAsync("http://localhost:7071/api/user/import", content);
+    }
+
+    [Then("I receive a report that the import was successful")]
+    public async Task AssertSuccessfulBulkImport()
+    {
+        Response.EnsureSuccessStatusCode();
+
+        var result = JsonConvert.DeserializeObject<IEnumerable<ReportItem>>(await Response.Content.ReadAsStringAsync());
+
+        result.All(r => r.Success).Should().BeTrue();
+    }
+
+    [Then(@"the call should fail with (\d*)")]
+    public void AssertFailureCode(int statusCode) => Response.StatusCode.Should().Be((HttpStatusCode)statusCode);
+
+    private byte[] BuildInputCsv(DataTable dataTable, string headers)
+    {
+        var sb = new StringBuilder(headers);
+
+        sb.Append("\r\n");
+
+        foreach (var row in dataTable.Rows.Skip(1))
+        {
+            var cells = row.Cells.Select(c => EscapeCsv(c.Value)).ToList();
+            cells.Add(EscapeCsv(_testId.ToString()));
+
+            var thing = string.Join(",", cells);
+
+            sb.Append($"{string.Join(",", cells)}\r\n");
+        }
+
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    private static string EscapeCsv(string value)
+    {
+        if (value.Contains(',') || value.Contains('"') || value.Contains('\n'))
+        {
+            value = value.Replace("\"", "\"\"");
+            return $"\"{value}\"";
+        }
+        return value;
+    }
+}

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/SiteBulkImportFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/SiteBulkImportFeatureSteps.cs
@@ -1,0 +1,17 @@
+using Nhs.Appointments.Core.Features;
+using Xunit;
+using Xunit.Gherkin.Quick;
+
+namespace Nhs.Appointments.Api.Integration.Scenarios.BulkImport;
+
+[FeatureFile("./Scenarios/BulkImport/SiteBulkImport_Enabled.feature")]
+public abstract class SiteBulkImportEnabledFeatureSteps(string flag, bool enabled) : BaseBulkImportFeatureSteps(flag, enabled);
+
+[Collection("BulkImportSeriaToggle")]
+public class SiteBulkImport_BulkImportEnabled() : SiteBulkImportEnabledFeatureSteps(Flags.BulkImport, true);
+
+[Collection("BulkImportSeriaToggle")]
+public class SiteBulkImport_BulkImportDisabled() : SiteBulkImportDisabledFeatureSteps(Flags.BulkImport, false);
+
+[FeatureFile("./Scenarios/BulkImport/SiteBulkImport_Disabled.feature")]
+public class SiteBulkImportDisabledFeatureSteps(string flag, bool enabled) : BaseBulkImportFeatureSteps(flag, enabled);

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/SiteBulkImport_Disabled.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/SiteBulkImport_Disabled.feature
@@ -1,0 +1,8 @@
+Feature: Site Bulk Import
+
+  Scenario: Import Sites
+    Given the site is configured for MYA
+    When I import the following site
+      | OdsCode | Name      | Address     | PhoneNumber | Longitude | Latitude  | ICB  | Region | Site type | accessible_toilet | braille_translation_service | disabled_car_parking | car_parking | induction_loop | sign_language_service | step_free_access | text_relay | wheelchair_access |
+      | ODS1    | Test Site | 1 Test Lane | N           | -6.3125   | 55.741702 | ICB1 | R1     | Pharmacy  | TRUE              | FALSE                       | FALSE                | TRUE        | FALSE          | FALSE                 | TRUE             | FALSE      | FALSE             |
+    Then the call should fail with 501

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/SiteBulkImport_Enabled.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/SiteBulkImport_Enabled.feature
@@ -1,0 +1,8 @@
+Feature: Site Bulk Import
+
+  Scenario: Import Sites
+    Given the site is configured for MYA
+    When I import the following site
+      | OdsCode | Name      | Address     | PhoneNumber | Longitude | Latitude  | ICB  | Region | Site type | accessible_toilet | braille_translation_service | disabled_car_parking | car_parking | induction_loop | sign_language_service | step_free_access | text_relay | wheelchair_access |
+      | R1      | Test Site | 1 Test Lane | N           | -6.3125   | 55.741702 | ICB1 | R1     | Pharmacy  | TRUE              | FALSE                       | FALSE                | TRUE        | FALSE          | FALSE                 | TRUE             | FALSE      | FALSE             |
+    Then I receive a report that the import was successful

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/UserBulkImportFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/UserBulkImportFeatureSteps.cs
@@ -1,0 +1,17 @@
+using Nhs.Appointments.Core.Features;
+using Xunit;
+using Xunit.Gherkin.Quick;
+
+namespace Nhs.Appointments.Api.Integration.Scenarios.BulkImport;
+
+[FeatureFile("./Scenarios/BulkImport/UserBulkImport_Disabled.feature")]
+public abstract class UserBulkImportDisabledFeatureSteps(string flag, bool enabled) : BaseBulkImportFeatureSteps(flag, enabled);
+
+[Collection("BulkImportSerialToggle")]
+public class UserBulkImport_BulkImportDisabled() : UserBulkImportDisabledFeatureSteps(Flags.BulkImport, false);
+
+[Collection("BulkImportSerialToggle")]
+public class UserBulkImport_BulkImportEnabled() : UserBulkImportEnabledFeatureSteps(Flags.BulkImport, true);
+
+[FeatureFile("./Scenarios/BulkImport/UserBulkImport_Enabled.feature")]
+public class UserBulkImportEnabledFeatureSteps(string flag, bool enabled) : BaseBulkImportFeatureSteps(flag, enabled);

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/UserBulkImport_Disabled.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/UserBulkImport_Disabled.feature
@@ -1,0 +1,9 @@
+Feature: User Bulk Import
+
+  Scenario: Import Users
+    Given a new site is configured for MYA
+    When I import the following users
+      | User               | FirstName | LastName | appointment-manager | availability-manager | site-details-manager | user-manager  |
+      | john.smith@nhs.net | John      | Smith    | FALSE               | TRUE                | TRUE                  | FALSE         |
+      | jane.smith@nhs.net | Jane      | Smith    | FALSE               | TRUE                | TRUE                  | FALSE         |
+    Then the call should fail with 501

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/UserBulkImport_Enabled.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BulkImport/UserBulkImport_Enabled.feature
@@ -1,0 +1,9 @@
+Feature: User Bulk Import
+
+  Scenario: Import Users
+    Given a new site is configured for MYA
+    When I import the following users
+      | User               | FirstName | LastName | appointment-manager | availability-manager | site-details-manager | user-manager  |
+      | john.smith@nhs.net | John      | Smith    | FALSE               | TRUE                | TRUE                  | TRUE         |
+      | jane.smith@nhs.net | Jane      | Smith    | FALSE               | TRUE                | TRUE                  | TRUE         |
+    Then I receive a report that the import was successful


### PR DESCRIPTION
- Adding user & site bulk import integration tests using the feature toggle pattern introduced by Jonny (hence the target branch).
- The tests cover the on & off states for the BulkImport endpoint for both users and sites.
- These tests don't cover all the validation rules for the user & site endpoints - just making sure these pass for both the on / off states with valid csv files so we have confidence in enabling it
- Added a new base feature step which creates a site with a valid Guid as the BulkImport will reject the file if it is not - have added a TODO to tidy this up later. I was reluctant to make changes to the existing step as it has a lot of uses