### PR TITLE
APPT-953 - Adding prod as an environment option for the old bulk import

### DIFF
--- a/azure-pipelines-bulk-data.yml
+++ b/azure-pipelines-bulk-data.yml
@@ -8,7 +8,7 @@ parameters:
     displayName: "Environment to import data into"
     type: string
     default: ""
-    values: ["dev", "int", "stag"]
+    values: ["dev", "int", "stag", "prod"]
   - name: csvFileName
     displayName: "Filename of the CSV file to import"
     type: string
@@ -88,4 +88,3 @@ stages:
           - pwsh: |
               Write-Host "##vso[task.uploadsummary]$(Build.SourcesDirectory)/data_import_summary.md"
             displayName: "Attach data import summary report"
-            


### PR DESCRIPTION
This is only a temporary change so we can apply the sites & users to production. APPT-954 has been created to revert this change once the import has been done and signed off.