### PR TITLE
APPT-970 - Removing the data-importer role and adding it as a permission to the admin role

### DIFF
--- a/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
@@ -68,7 +68,8 @@
         "site:manage",
         "site:manage:admin",
         "users:view",
-        "users:manage"
+        "users:manage",
+        "system:data-importer"
       ]
     },
     {
@@ -108,12 +109,6 @@
         "system:run-reminders",
         "system:run-provisional-sweep"
       ]
-    },
-    {
-      "id": "system:data-importer",
-      "name": "Data Importer",
-      "description": "System role used for the bulk importing of users and sites",
-      "permissions": ["system:data-importer"]
     },
     {
       "id": "system:regional-user",

--- a/data/CosmosDbSeeder/items/int/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/int/core_data/global_roles.json
@@ -68,7 +68,8 @@
         "site:manage",
         "site:manage:admin",
         "users:view",
-        "users:manage"
+        "users:manage",
+        "system:data-importer"
       ]
     },
     {
@@ -108,12 +109,6 @@
         "system:run-reminders",
         "system:run-provisional-sweep"
       ]
-    },
-    {
-      "id": "system:data-importer",
-      "name": "Data Importer",
-      "description": "System role used for the bulk importing of users and sites",
-      "permissions": ["system:data-importer"]
     },
     {
       "id": "system:regional-user",

--- a/data/CosmosDbSeeder/items/local/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/local/core_data/global_roles.json
@@ -68,7 +68,8 @@
         "site:manage",
         "site:manage:admin",
         "users:view",
-        "users:manage"
+        "users:manage",
+        "system:data-importer"
       ]
     },
     {
@@ -130,12 +131,6 @@
         "system:run-reminders",
         "system:run-provisional-sweep"
       ]
-    },
-    {
-      "id": "system:data-importer",
-      "name": "Data Importer",
-      "description": "System role used for the bulk importing of users and sites",
-      "permissions": ["system:data-importer"]
     },
     {
       "id": "system:regional-user",

--- a/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
@@ -68,7 +68,8 @@
         "site:manage",
         "site:manage:admin",
         "users:view",
-        "users:manage"
+        "users:manage",
+        "system:data-importer"
       ]
     },
     {
@@ -108,12 +109,6 @@
         "system:run-reminders",
         "system:run-provisional-sweep"
       ]
-    },
-    {
-      "id": "system:data-importer",
-      "name": "Data Importer",
-      "description": "System role used for the bulk importing of users and sites",
-      "permissions": ["system:data-importer"]
     },
     {
       "id": "system:regional-user",

--- a/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
@@ -68,7 +68,8 @@
         "site:manage",
         "site:manage:admin",
         "users:view",
-        "users:manage"
+        "users:manage",
+        "system:data-importer"
       ]
     },
     {
@@ -108,12 +109,6 @@
         "system:run-reminders",
         "system:run-provisional-sweep"
       ]
-    },
-    {
-      "id": "system:data-importer",
-      "name": "Data Importer",
-      "description": "System role used for the bulk importing of users and sites",
-      "permissions": ["system:data-importer"]
     },
     {
       "id": "system:regional-user",


### PR DESCRIPTION
Had a discussion with Lauren and Jack and opted to go down the route of giving existing admin users the permission to import data via the bulk upload rather than it being a specific role so this PR also remove the `system:data-importer` role.

Integration tests for the bulk import are currently in a separate PR - hence why they haven't been amended here.