### PR TITLE
APPT-813: Multi service checkboxes. APPT-931: Select All services checkbox

### DIFF
--- a/src/client/src/app/site/[site]/create-availability/wizard/select-services-step.test.tsx
+++ b/src/client/src/app/site/[site]/create-availability/wizard/select-services-step.test.tsx
@@ -3,134 +3,288 @@ import { screen } from '@testing-library/react';
 import { CreateAvailabilityFormValues } from './availability-template-wizard';
 import MockForm from '@testing/mockForm';
 import SelectServicesStep from './select-services-step';
-import { clinicalServices } from '@types';
+import { ClinicalService } from '@types';
 
 const mockGoToNextStep = jest.fn();
 const mockGoToPreviousStep = jest.fn();
 const mockGoToLastStep = jest.fn();
 const mockSetCurrentStep = jest.fn();
 
+let mockClinicalServices: ClinicalService[] = [];
+
 describe('Select Services Step', () => {
-  it('renders', async () => {
-    render(
-      <MockForm<CreateAvailabilityFormValues>
-        submitHandler={jest.fn()}
-        defaultValues={{ session: { services: [] } }}
-      >
-        <SelectServicesStep
-          stepNumber={1}
-          currentStep={1}
-          isActive
-          setCurrentStep={mockSetCurrentStep}
-          goToNextStep={mockGoToNextStep}
-          goToLastStep={mockGoToLastStep}
-          goToPreviousStep={mockGoToPreviousStep}
-          clinicalServices={clinicalServices}
-          returnRouteUponCancellation="/"
-        />
-      </MockForm>,
-    );
+  describe('Multiple Services Disabled', () => {
+    beforeAll(() => {
+      mockClinicalServices = [{ label: 'RSV Adult', value: 'RSV:Adult' }];
+    });
 
-    expect(
-      screen.getByRole('heading', {
-        name: 'Create weekly session Add services to your session',
-      }),
-    ).toBeInTheDocument();
+    it('renders', async () => {
+      renderStep(mockClinicalServices);
+
+      expect(
+        screen.getByRole('heading', {
+          name: 'Create weekly session Add services to your session',
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('permits user input', async () => {
+      const { user } = renderStep(mockClinicalServices);
+
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
+
+      await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
+      expect(screen.getByRole('checkbox', { name: 'RSV Adult' })).toBeChecked();
+
+      await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
+    });
+
+    it('shows a validation error if no services are selected', async () => {
+      const { user } = renderStep(mockClinicalServices);
+
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
+
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+      expect(screen.getByText('Select a service')).toBeInTheDocument();
+
+      expect(mockGoToNextStep).not.toHaveBeenCalled();
+    });
+
+    it('continues to the next step if a service is selected', async () => {
+      const { user } = renderStep(mockClinicalServices);
+
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
+      await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+      expect(mockGoToNextStep).toHaveBeenCalled();
+    });
+
+    it('continues to the next step if a service is selected', async () => {
+      const { user } = renderStep(mockClinicalServices);
+
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
+      await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+      expect(mockGoToNextStep).toHaveBeenCalled();
+    });
   });
 
-  it('permits user input', async () => {
-    const { user } = render(
-      <MockForm<CreateAvailabilityFormValues>
-        submitHandler={jest.fn()}
-        defaultValues={{ session: { services: [] } }}
-      >
-        <SelectServicesStep
-          stepNumber={1}
-          currentStep={1}
-          isActive
-          setCurrentStep={mockSetCurrentStep}
-          goToNextStep={mockGoToNextStep}
-          goToLastStep={mockGoToLastStep}
-          goToPreviousStep={mockGoToPreviousStep}
-          clinicalServices={clinicalServices}
-          returnRouteUponCancellation="/"
-        />
-      </MockForm>,
-    );
+  describe('Multiple Services Enabled', () => {
+    beforeAll(() => {
+      mockClinicalServices = [
+        {
+          value: 'RSV:Adult',
+          label: 'RSV Adult',
+        },
+        {
+          value: 'COVID:5_11',
+          label: 'COVID 5-11',
+        },
+        {
+          value: 'COVID:12_17',
+          label: 'COVID 12-17',
+        },
+        {
+          value: 'COVID:18+',
+          label: 'COVID 18+',
+        },
+      ];
+    });
 
-    expect(
-      screen.getByRole('checkbox', { name: 'RSV Adult' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('checkbox', { name: 'RSV Adult' }),
-    ).not.toBeChecked();
+    it('renders', async () => {
+      renderStep(mockClinicalServices);
 
-    await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
-    expect(screen.getByRole('checkbox', { name: 'RSV Adult' })).toBeChecked();
+      expect(
+        screen.getByRole('heading', {
+          name: 'Create weekly session Add services to your session',
+        }),
+      ).toBeInTheDocument();
+    });
 
-    await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
-    expect(
-      screen.getByRole('checkbox', { name: 'RSV Adult' }),
-    ).not.toBeChecked();
-  });
+    it('permits user input', async () => {
+      const { user } = renderStep(mockClinicalServices);
 
-  it('shows a validation error if no services are selected', async () => {
-    const { user } = render(
-      <MockForm<CreateAvailabilityFormValues>
-        submitHandler={jest.fn()}
-        defaultValues={{ session: { services: [] } }}
-      >
-        <SelectServicesStep
-          stepNumber={1}
-          currentStep={1}
-          isActive
-          setCurrentStep={mockSetCurrentStep}
-          goToNextStep={mockGoToNextStep}
-          goToLastStep={mockGoToLastStep}
-          goToPreviousStep={mockGoToPreviousStep}
-          clinicalServices={clinicalServices}
-          returnRouteUponCancellation="/"
-        />
-      </MockForm>,
-    );
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
 
-    expect(
-      screen.getByRole('checkbox', { name: 'RSV Adult' }),
-    ).not.toBeChecked();
+      await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
+      expect(screen.getByRole('checkbox', { name: 'RSV Adult' })).toBeChecked();
 
-    await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
+    });
 
-    expect(screen.getByText('Select a service')).toBeInTheDocument();
+    it('shows a validation error if no services are selected', async () => {
+      const { user } = renderStep(mockClinicalServices);
 
-    expect(mockGoToNextStep).not.toHaveBeenCalled();
-  });
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
 
-  it('continues to the next step if a service is selected', async () => {
-    const { user } = render(
-      <MockForm<CreateAvailabilityFormValues>
-        submitHandler={jest.fn()}
-        defaultValues={{ session: { services: [] } }}
-      >
-        <SelectServicesStep
-          stepNumber={1}
-          currentStep={1}
-          isActive
-          setCurrentStep={mockSetCurrentStep}
-          goToNextStep={mockGoToNextStep}
-          goToLastStep={mockGoToLastStep}
-          goToPreviousStep={mockGoToPreviousStep}
-          clinicalServices={clinicalServices}
-          returnRouteUponCancellation="/"
-        />
-      </MockForm>,
-    );
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
 
-    expect(
-      screen.getByRole('checkbox', { name: 'RSV Adult' }),
-    ).not.toBeChecked();
-    await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
-    await user.click(screen.getByRole('button', { name: 'Continue' }));
+      expect(screen.getByText('Select a service')).toBeInTheDocument();
 
-    expect(mockGoToNextStep).toHaveBeenCalled();
+      expect(mockGoToNextStep).not.toHaveBeenCalled();
+    });
+
+    it('continues to the next step if a service is selected', async () => {
+      const { user } = renderStep(mockClinicalServices);
+
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
+      await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+      expect(mockGoToNextStep).toHaveBeenCalled();
+    });
+
+    it('continues to the next step if a service is selected', async () => {
+      const { user } = renderStep(mockClinicalServices);
+
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
+      await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+      expect(mockGoToNextStep).toHaveBeenCalled();
+    });
+
+    it('selects all services when Select All is checked', async () => {
+      const { user } = renderStep(mockClinicalServices);
+
+      await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+      expect(screen.getByRole('checkbox', { name: 'RSV Adult' })).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'COVID 5-11' }),
+      ).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'COVID 12-17' }),
+      ).toBeChecked();
+      expect(screen.getByRole('checkbox', { name: 'COVID 18+' })).toBeChecked();
+    });
+
+    it('deselects all services when Select All is checked', async () => {
+      const { user } = renderStep(mockClinicalServices, [
+        'RSV:Adult',
+        'COVID:5_11',
+        'COVID:12_17',
+        'COVID:18+',
+      ]);
+      expect(screen.getByRole('checkbox', { name: 'RSV Adult' })).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'COVID 5-11' }),
+      ).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'COVID 12-17' }),
+      ).toBeChecked();
+      expect(screen.getByRole('checkbox', { name: 'COVID 18+' })).toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'Select all' }),
+      ).toBeChecked();
+
+      await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+
+      expect(
+        screen.getByRole('checkbox', { name: 'RSV Adult' }),
+      ).not.toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'COVID 5-11' }),
+      ).not.toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'COVID 12-17' }),
+      ).not.toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'COVID 18+' }),
+      ).not.toBeChecked();
+      expect(
+        screen.getByRole('checkbox', { name: 'Select all' }),
+      ).not.toBeChecked();
+    });
+
+    it('automatically checks Select All when each service is checked individually', async () => {
+      const { user } = renderStep(mockClinicalServices);
+
+      expect(
+        screen.getByRole('checkbox', { name: 'Select all' }),
+      ).not.toBeChecked();
+
+      await user.click(screen.getByRole('checkbox', { name: 'RSV Adult' }));
+      await user.click(screen.getByRole('checkbox', { name: 'COVID 5-11' }));
+      await user.click(screen.getByRole('checkbox', { name: 'COVID 12-17' }));
+      await user.click(screen.getByRole('checkbox', { name: 'COVID 18+' }));
+
+      expect(
+        screen.getByRole('checkbox', { name: 'Select all' }),
+      ).toBeChecked();
+    });
+
+    it('automatically unchecks Select All when a service is unchecked individually', async () => {
+      const { user } = renderStep(mockClinicalServices, [
+        'RSV:Adult',
+        'COVID:5_11',
+        'COVID:12_17',
+        'COVID:18+',
+      ]);
+
+      expect(
+        screen.getByRole('checkbox', { name: 'Select all' }),
+      ).toBeChecked();
+
+      await user.click(screen.getByRole('checkbox', { name: 'COVID 18+' }));
+
+      expect(
+        screen.getByRole('checkbox', { name: 'Select all' }),
+      ).not.toBeChecked();
+    });
   });
 });
+
+const renderStep = (
+  services: ClinicalService[],
+  currentFormValues: string[] = [],
+) => {
+  return render(
+    <MockForm<CreateAvailabilityFormValues>
+      submitHandler={jest.fn()}
+      defaultValues={{ session: { services: currentFormValues ?? [] } }}
+    >
+      <SelectServicesStep
+        stepNumber={1}
+        currentStep={1}
+        isActive
+        setCurrentStep={mockSetCurrentStep}
+        goToNextStep={mockGoToNextStep}
+        goToLastStep={mockGoToLastStep}
+        goToPreviousStep={mockGoToPreviousStep}
+        clinicalServices={services}
+        returnRouteUponCancellation="/"
+      />
+    </MockForm>,
+  );
+};

--- a/src/client/src/app/site/[site]/create-availability/wizard/select-services-step.tsx
+++ b/src/client/src/app/site/[site]/create-availability/wizard/select-services-step.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   CheckBox,
   CheckBoxes,
+  CheckBoxOrAll,
   FormGroup,
 } from '@components/nhsuk-frontend';
 import { useFormContext } from 'react-hook-form';
@@ -74,12 +75,12 @@ const SelectServicesStep = ({
 
       <FormGroup error={errors.session?.services?.message}>
         <CheckBoxes>
-          {clinicalServices.map(service => (
+          {clinicalServices.map(clinicalService => (
             <CheckBox
-              id={`checkbox-${service.value.toLowerCase()}`}
-              label={service.label}
-              value={[service.value]}
-              key={`checkbox-${service.value.toLowerCase()}`}
+              id={`checkbox-${clinicalService.value}`}
+              label={clinicalService.label}
+              value={clinicalService.value}
+              key={`checkbox-${clinicalService.value}`}
               {...register('session.services', {
                 validate: value => {
                   if (value === undefined || value.length < 1) {
@@ -88,16 +89,14 @@ const SelectServicesStep = ({
                 },
               })}
               onChange={() => {
-                if ((servicesWatch ?? []).includes(service.value)) {
+                if ((servicesWatch ?? []).includes(clinicalService.value)) {
                   setValue(
                     'session.services',
-                    clinicalServices
-                      .filter(s => s.value !== service.value)
-                      .map(_ => _.value),
+                    servicesWatch.filter(d => d !== clinicalService.value),
                   );
                 } else {
                   setValue('session.services', [
-                    service.value,
+                    clinicalService.value,
                     ...(servicesWatch ?? []),
                   ]);
                 }
@@ -107,6 +106,30 @@ const SelectServicesStep = ({
               }}
             />
           ))}
+          {clinicalServices.length > 1 && (
+            <>
+              <CheckBoxOrAll />
+              <CheckBox
+                label={'Select all'}
+                value={clinicalServices.map(_ => _.value)}
+                id={'allServices'}
+                checked={servicesWatch?.length == clinicalServices.length}
+                onChange={() => {
+                  if (servicesWatch?.length == clinicalServices.length) {
+                    setValue('session.services', []);
+                  } else {
+                    setValue(
+                      'session.services',
+                      clinicalServices.map(_ => _.value),
+                    );
+                  }
+                  if (errors.session?.services) {
+                    trigger('session.services');
+                  }
+                }}
+              />
+            </>
+          )}
         </CheckBoxes>
       </FormGroup>
       <Button

--- a/src/client/testing/tests/availability/availability.spec.ts
+++ b/src/client/testing/tests/availability/availability.spec.ts
@@ -120,6 +120,48 @@ test.describe.configure({ mode: 'serial' });
             ).toBeVisible();
           });
 
+          test('Create single session of RSV and Covid availability', async ({
+            page,
+          }) => {
+            let dayIncrement = 1;
+
+            //avoid collisions
+            if (multipleServicesEnabled) {
+              dayIncrement += 40;
+            }
+
+            const futureDate = getDateInFuture(dayIncrement);
+            await createAvailabilityPage.createAvailabilityButton.click();
+            await page.waitForURL(
+              `**/site/${site.id}/create-availability/wizard`,
+            );
+
+            await expect(createAvailabilityPage.sessionTitle).toBeVisible();
+            await createAvailabilityPage.selectSession('Single date session');
+            await createAvailabilityPage.continueButton.click();
+            await createAvailabilityPage.enterSingleDateSessionDate(
+              futureDate.day,
+              futureDate.month,
+              futureDate.year,
+            );
+            await createAvailabilityPage.continueButton.click();
+            await createAvailabilityPage.enterStartTime('09', '00');
+            await createAvailabilityPage.enterEndTime('10', '00');
+            await createAvailabilityPage.enterNoOfVaccinators('2');
+            await createAvailabilityPage.appointmentLength('6');
+            await createAvailabilityPage.continueButton.click();
+            await createAvailabilityPage.addService('RSV Adult');
+            if (multipleServicesEnabled) {
+              await createAvailabilityPage.addService('COVID 5-11');
+              await createAvailabilityPage.addService('COVID 18+');
+            }
+            await createAvailabilityPage.continueButton.click();
+            await createAvailabilityPage.saveSessionButton.click();
+            await expect(
+              createAvailabilityPage.sessionSuccessMsg,
+            ).toBeVisible();
+          });
+
           test('Create weekly session of RSV availability', async ({
             page,
           }) => {
@@ -128,6 +170,56 @@ test.describe.configure({ mode: 'serial' });
             //avoid collisions
             if (multipleServicesEnabled) {
               dayIncrement += 7;
+            }
+
+            const futureDate = getDateInFuture(dayIncrement);
+            const dayAfterFutureDate = getDateInFuture(dayIncrement + 1);
+            await createAvailabilityPage.createAvailabilityButton.click();
+            await page.waitForURL(
+              `**/site/${site.id}/create-availability/wizard`,
+            );
+
+            await expect(createAvailabilityPage.sessionTitle).toBeVisible();
+            await createAvailabilityPage.selectSession('Weekly sessions');
+            await createAvailabilityPage.continueButton.click();
+            await createAvailabilityPage.enterWeeklySessionStartDate(
+              futureDate.day,
+              futureDate.month,
+              futureDate.year,
+            );
+            await createAvailabilityPage.enterWeeklySessionEndDate(
+              dayAfterFutureDate.day,
+              dayAfterFutureDate.month,
+              dayAfterFutureDate.year,
+            );
+            await createAvailabilityPage.continueButton.click();
+            await createAvailabilityPage.selectDay('Select all days');
+            await createAvailabilityPage.continueButton.click();
+            await createAvailabilityPage.enterStartTime('09', '00');
+            await createAvailabilityPage.enterEndTime('10', '00');
+            await createAvailabilityPage.enterNoOfVaccinators('1');
+            await createAvailabilityPage.appointmentLength('5');
+            await createAvailabilityPage.continueButton.click();
+            await createAvailabilityPage.addService('RSV Adult');
+            if (multipleServicesEnabled) {
+              await createAvailabilityPage.addService('COVID 5-11');
+              await createAvailabilityPage.addService('COVID 18+');
+            }
+            await createAvailabilityPage.continueButton.click();
+            await createAvailabilityPage.saveSessionButton.click();
+            await expect(
+              createAvailabilityPage.sessionSuccessMsg,
+            ).toBeVisible();
+          });
+
+          test('Create weekly session of RSV and Covid availability', async ({
+            page,
+          }) => {
+            let dayIncrement = 1;
+
+            //avoid collisions
+            if (multipleServicesEnabled) {
+              dayIncrement += 40;
             }
 
             const futureDate = getDateInFuture(dayIncrement);


### PR DESCRIPTION
The Select Services step of the Create Availability wizard isn't written to handle multiple services properly. 

This PR fixes the bug with (un)checking services when there are multiple services to choose from.
It also adds in the "Select all" checkbox, which [APPT-931](https://nhsd-jira.digital.nhs.uk/browse/APPT-931) requests. 

<img width="508" alt="Screenshot 2025-06-10 152313" src="https://github.com/user-attachments/assets/d4cca673-0bb1-4664-bec1-67e5e7c07e5b" />
