### PR TITLE
APPT-986: Fix erroneous notification config

### DIFF
--- a/data/CosmosDbSeeder/items/dev/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/notification_config.json
@@ -15,79 +15,79 @@
       "eventType": "OktaUserRolesChanged"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "5028cb32-6168-41ee-8773-2493d073f369",
       "smsTemplate": "1203db45-e5fc-479d-a64e-079c5723b1c3",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "82a5a379-9853-46e7-a720-8403eb899216",
       "smsTemplate": "8e5bc8cb-a65b-44b8-a6f3-f6c60dc9e54e",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "307b5c89-e602-42c1-bdce-5f8043f3ca64",
       "smsTemplate": "53e36c57-1188-4744-b48b-2014e0fa4ef3",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "c096719c-5aef-4803-9a05-099c136e1c73",
       "smsTemplate": "474af7ec-bf1c-4c6b-9dec-a20955c58a33",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "a065e0b3-9640-4c55-9789-7c0211b2f143",
       "smsTemplate": "dfc6f5b0-b965-4cc6-a168-18b88b40573a",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "7151e402-ab25-45db-a312-d63a4519427d",
       "smsTemplate": "49fea2c1-219c-49e5-9493-b528b811b729",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "4a6eeee1-bfb4-47d8-9e53-aaddf0fe7248",
       "smsTemplate": "d2de1ecb-c9ea-4c1b-a4a4-0f3c01f55f42",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "b560d593-34d8-4641-8517-ec563e8122ad",
       "smsTemplate": "b21afedd-e6a2-417e-a146-6f1b7ae2865c",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "5c35172a-58ff-4258-aba9-b88f659a66d5",
       "smsTemplate": "62a43b97-9715-43a8-83c5-9932c91d22b3",
       "eventType": "BookingCancelled"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "8d8ffe21-d995-49d5-89b0-3e3f5a7d8e9a",
       "smsTemplate": "72d8ba78-e3a7-454a-9540-fc42278a9706",
       "eventType": "BookingRescheduled"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "679e3760-6dd2-4076-8ee5-0799517fa9ca",
       "smsTemplate": "0a4bb160-0ab7-4acc-b66d-57256a9d5973",
       "eventType": "BookingRescheduled"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "cab0fdf2-d631-4a2f-a2fb-09cfe7e77080",
       "smsTemplate": "f89fb975-7491-492e-907d-29caa52e40f5",
       "eventType": "BookingRescheduled"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "ae42294c-ef05-4026-a01a-3020f581f377",
       "smsTemplate": "24e7e620-8e03-4b6c-abe9-79a911b874b3",
       "eventType": "BookingRescheduled"

--- a/data/CosmosDbSeeder/items/int/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/int/core_data/notification_config.json
@@ -15,79 +15,79 @@
       "eventType": "OktaUserRolesChanged"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "5028cb32-6168-41ee-8773-2493d073f369",
       "smsTemplate": "1203db45-e5fc-479d-a64e-079c5723b1c3",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "82a5a379-9853-46e7-a720-8403eb899216",
       "smsTemplate": "8e5bc8cb-a65b-44b8-a6f3-f6c60dc9e54e",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "307b5c89-e602-42c1-bdce-5f8043f3ca64",
       "smsTemplate": "53e36c57-1188-4744-b48b-2014e0fa4ef3",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "f8ea99be-a78d-42a6-bf81-a6233a7987cf",
       "smsTemplate": "474af7ec-bf1c-4c6b-9dec-a20955c58a33",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "a065e0b3-9640-4c55-9789-7c0211b2f143",
       "smsTemplate": "dfc6f5b0-b965-4cc6-a168-18b88b40573a",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "7151e402-ab25-45db-a312-d63a4519427d",
       "smsTemplate": "49fea2c1-219c-49e5-9493-b528b811b729",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "4a6eeee1-bfb4-47d8-9e53-aaddf0fe7248",
       "smsTemplate": "d2de1ecb-c9ea-4c1b-a4a4-0f3c01f55f42",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "92f0ae99-03bb-41b9-9ed9-f68d0ae4b9c0",
       "smsTemplate": "b21afedd-e6a2-417e-a146-6f1b7ae2865c",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "2bb90de1-2d7d-45b9-bc6e-88d0c04f0021",
       "smsTemplate": "2ef9995c-32b9-4088-a630-97c2546062d0",
       "eventType": "BookingCancelled"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "8d8ffe21-d995-49d5-89b0-3e3f5a7d8e9a",
       "smsTemplate": "72d8ba78-e3a7-454a-9540-fc42278a9706",
       "eventType": "BookingRescheduled"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "679e3760-6dd2-4076-8ee5-0799517fa9ca",
       "smsTemplate": "0a4bb160-0ab7-4acc-b66d-57256a9d5973",
       "eventType": "BookingRescheduled"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "cab0fdf2-d631-4a2f-a2fb-09cfe7e77080",
       "smsTemplate": "f89fb975-7491-492e-907d-29caa52e40f5",
       "eventType": "BookingRescheduled"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "2bdba7e7-901e-46a7-b763-1b301cebf060",
       "smsTemplate": "24e7e620-8e03-4b6c-abe9-79a911b874b3",
       "eventType": "BookingRescheduled"

--- a/data/CosmosDbSeeder/items/local/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/local/core_data/notification_config.json
@@ -15,55 +15,55 @@
       "eventType": "OktaUserRolesChanged"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "5028cb32-6168-41ee-8773-2493d073f369",
       "smsTemplate": "1203db45-e5fc-479d-a64e-079c5723b1c3",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "82a5a379-9853-46e7-a720-8403eb899216",
       "smsTemplate": "8e5bc8cb-a65b-44b8-a6f3-f6c60dc9e54e",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "307b5c89-e602-42c1-bdce-5f8043f3ca64",
       "smsTemplate": "53e36c57-1188-4744-b48b-2014e0fa4ef3",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "c096719c-5aef-4803-9a05-099c136e1c73",
       "smsTemplate": "474af7ec-bf1c-4c6b-9dec-a20955c58a33",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "a065e0b3-9640-4c55-9789-7c0211b2f143",
       "smsTemplate": "dfc6f5b0-b965-4cc6-a168-18b88b40573a",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "7151e402-ab25-45db-a312-d63a4519427d",
       "smsTemplate": "49fea2c1-219c-49e5-9493-b528b811b729",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "4a6eeee1-bfb4-47d8-9e53-aaddf0fe7248",
       "smsTemplate": "d2de1ecb-c9ea-4c1b-a4a4-0f3c01f55f42",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "b560d593-34d8-4641-8517-ec563e8122ad",
       "smsTemplate": "b21afedd-e6a2-417e-a146-6f1b7ae2865c",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "2bb90de1-2d7d-45b9-bc6e-88d0c04f0021",
       "smsTemplate": "2ef9995c-32b9-4088-a630-97c2546062d0",
       "eventType": "BookingCancelled"

--- a/data/CosmosDbSeeder/items/stag/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/stag/core_data/notification_config.json
@@ -9,97 +9,97 @@
       "eventType": "UserRolesChanged"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "d34d6234-27ce-4e27-829c-b41d6d2eead4",
       "smsTemplate": "b0d985f8-a068-4bb5-9f26-d2520d3c809e",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "5c95148c-d665-4f47-92a0-4548e4b114ab",
       "smsTemplate": "6bb0d711-ea4e-49a9-9b69-25af30ad4074",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "cdfe56d9-8478-4b06-809e-5e75ace569c1",
       "smsTemplate": "87f81bd0-7860-4424-82f3-6ec8e5e04c37",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "a89c6a69-2c7f-422a-9420-db581517c823",
       "smsTemplate": "3f493a78-0ee9-44f1-aff6-fd484f94d1ff",
       "eventType": "BookingMade"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "0d3126b2-1db2-4f7c-9ea7-f734dc699b42",
       "smsTemplate": "acc62fb6-389f-4786-b685-b8ed126a3ea5",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "61371ce6-59ae-4d53-8c2d-18c0b92cc592",
       "smsTemplate": "1be8b191-3de5-4205-9028-7814864ad887",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "005c6708-e82e-4eb2-b806-3a7fd951164a",
       "smsTemplate": "e6934c4b-9fb5-403b-b4be-efeb1dcedc7d",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "c51af46c-bd1d-448d-8d3e-7abe8f2e6ca8",
       "smsTemplate": "338c19e6-d9c8-4e85-910b-e81b7b6ff8b5",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "bd0e95d1-8adf-4b5e-8abd-d02f11281b18",
       "smsTemplate": "0c08601c-e42d-4b0e-b23e-262b7ca9c793",
       "eventType": "BookingCancelled"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "eb4a32c1-0839-47bf-878a-5b8ae77d6560",
       "smsTemplate": "5320797b-3f5e-4dc0-afe1-d7613c721939",
       "eventType": "BookingCancelled"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "5de858aa-3c15-48a8-845e-57e9f41ddac4",
       "smsTemplate": "1b57a890-2953-4c3a-a13e-dd35da9f406f",
       "eventType": "BookingCancelled"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "c2176f0f-21f9-4094-86d6-c592fb685015",
       "smsTemplate": "5cddbebe-0905-41ab-acc6-1c8011e496c7",
       "eventType": "BookingCancelled"
     },
     {
-      "services": [ "COVID:12_15", "COVID:16_17", "COVID:18_74", "COVID:5_11", "COVID:75" ],
+      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "88aa1820-ffb5-41c5-b997-f2e566f50c6e",
       "smsTemplate": "deeaddb6-3255-46fd-a5a1-3c98af05e6d8",
       "eventType": "BookingRescheduled"
     },
     {
-      "services": [ "FLU:18_64", "FLU:65" ],
+      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "413d1010-095b-4c33-b2bc-c44ea554765e",
       "smsTemplate": "f17ce7a1-84f3-4458-9748-ff68945b750c",
       "eventType": "BookingRescheduled"
     },
     {
-      "services": [ "COVID_FLU:18_64", "COVID_FLU:65_74", "COVID_FLU:75" ],
+      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "3bcd14e5-f9f7-4b3d-901b-5fb4c40fc789",
       "smsTemplate": "8293edf5-6a91-4458-b374-6d9970773b01",
       "eventType": "BookingRescheduled"
     },
     {
-      "services": [ "RSV:Adult" ],
+      "services": ["RSV:Adult"],
       "emailTemplate": "6fc813a9-1c8e-40a1-adab-e207719887dd",
       "smsTemplate": "dd254efe-2d1a-4b1a-84b5-ebd8a56127b0",
       "eventType": "BookingRescheduled"

--- a/tests/CosmosDbSeederTests/BaseCosmosDbSeederTest.cs
+++ b/tests/CosmosDbSeederTests/BaseCosmosDbSeederTest.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+
+namespace CosmosDbSeederTests;
+
+public class BaseCosmosDbSeederTest
+{
+    protected static T ReadDocument<T>(string environment)
+    {
+        var documentName = GetDocumentName<T>();
+
+        var document = JsonConvert.DeserializeObject<T>(File.ReadAllText(Path.Combine(
+            AppDomain.CurrentDomain.BaseDirectory,
+            $"items/{environment}/core_data/{documentName}.json")));
+
+        return document ??
+               throw new Exception($"Could not read {documentName}.json for {environment} environment");
+    }
+
+    private static string GetDocumentName<T>()
+    {
+        var docName = typeof(T).Name;
+        switch (typeof(T).Name)
+        {
+            case nameof(GlobalRolesDocument):
+                return "global_roles";
+            case nameof(ClinicalServicesDocument):
+                return "clinical_services";
+            case nameof(NotificationConfigDocument):
+                return "notification_config";
+            default:
+                throw new Exception($"Could not read {typeof(T).Name} from {typeof(T).Name}");
+        }
+    }
+}

--- a/tests/CosmosDbSeederTests/ClinicalServicesTests.cs
+++ b/tests/CosmosDbSeederTests/ClinicalServicesTests.cs
@@ -1,28 +1,17 @@
 using FluentAssertions;
-using Newtonsoft.Json;
 
 namespace CosmosDbSeederTests;
 
-public class ClinicalServicesTests
+public class ClinicalServicesTests : BaseCosmosDbSeederTest
 {
-    private static ClinicalServicesDocument ReadClinicalServices(string environment)
-    {
-        var ClinicalServices = JsonConvert.DeserializeObject<ClinicalServicesDocument>(File.ReadAllText(Path.Combine(
-            AppDomain.CurrentDomain.BaseDirectory,
-            $"items/{environment}/core_data/clinical_services.json")));
-
-        return ClinicalServices ??
-               throw new Exception($"Could not read clinical_services.json from {environment} environment");
-    }
-
     [Fact]
     public void ClinicalServicesShouldBeTheSameInEachEnvironment()
     {
-        var localClinicalServices = ReadClinicalServices("local");
-        var devClinicalServices = ReadClinicalServices("dev");
-        var intClinicalServices = ReadClinicalServices("int");
-        var stagClinicalServices = ReadClinicalServices("stag");
-        var prodClinicalServices = ReadClinicalServices("prod");
+        var localClinicalServices = ReadDocument<ClinicalServicesDocument>("local");
+        var devClinicalServices = ReadDocument<ClinicalServicesDocument>("dev");
+        var intClinicalServices = ReadDocument<ClinicalServicesDocument>("int");
+        var stagClinicalServices = ReadDocument<ClinicalServicesDocument>("stag");
+        var prodClinicalServices = ReadDocument<ClinicalServicesDocument>("prod");
 
         localClinicalServices.Should().BeEquivalentTo(devClinicalServices);
         devClinicalServices.Should().BeEquivalentTo(intClinicalServices);
@@ -33,7 +22,7 @@ public class ClinicalServicesTests
     [Fact(DisplayName = "APPT-740: Define Autumn/Winter Clinical Services")]
     public void ClinicalRolesShouldBeCorrect()
     {
-        var clinicalServices = ReadClinicalServices("local").Services;
+        var clinicalServices = ReadDocument<ClinicalServicesDocument>("local").Services;
 
         clinicalServices.Should().Contain(service => service.Id == "RSV:Adult" && service.Label == "RSV Adult");
         clinicalServices.Should().Contain(service => service.Id == "COVID:5_11" && service.Label == "COVID 5-11");

--- a/tests/CosmosDbSeederTests/GlobalRolesTests.cs
+++ b/tests/CosmosDbSeederTests/GlobalRolesTests.cs
@@ -1,27 +1,17 @@
 using FluentAssertions;
-using Newtonsoft.Json;
 
 namespace CosmosDbSeederTests;
 
-public class GlobalRolesTests
+public class GlobalRolesTests : BaseCosmosDbSeederTest
 {
-    private static GlobalRolesDocument ReadGlobalRoles(string environment)
-    {
-        var globalRoles = JsonConvert.DeserializeObject<GlobalRolesDocument>(File.ReadAllText(Path.Combine(
-            AppDomain.CurrentDomain.BaseDirectory,
-            $"items/{environment}/core_data/global_roles.json")));
-
-        return globalRoles ?? throw new Exception($"Could not read global_roles.json from {environment} environment");
-    }
-
     [Fact]
     public void GlobalRolesShouldBeTheSameInEachEnvironment()
     {
-        var localGlobalRoles = ReadGlobalRoles("local");
-        var devGlobalRoles = ReadGlobalRoles("dev");
-        var intGlobalRoles = ReadGlobalRoles("int");
-        var stagGlobalRoles = ReadGlobalRoles("stag");
-        var prodGlobalRoles = ReadGlobalRoles("prod");
+        var localGlobalRoles = ReadDocument<GlobalRolesDocument>("local");
+        var devGlobalRoles = ReadDocument<GlobalRolesDocument>("dev");
+        var intGlobalRoles = ReadDocument<GlobalRolesDocument>("int");
+        var stagGlobalRoles = ReadDocument<GlobalRolesDocument>("stag");
+        var prodGlobalRoles = ReadDocument<GlobalRolesDocument>("prod");
 
         devGlobalRoles.Should().BeEquivalentTo(intGlobalRoles);
         intGlobalRoles.Should().BeEquivalentTo(stagGlobalRoles);
@@ -35,7 +25,8 @@ public class GlobalRolesTests
     [Fact(DisplayName = "APPT-802: Admin User roles should include user manager")]
     public void AdminUserRolesShouldIncludeManageUsers()
     {
-        var adminRoles = ReadGlobalRoles("local").Roles.Single(role => role.Id == "system:admin-user");
+        var adminRoles = ReadDocument<GlobalRolesDocument>("local").Roles
+            .Single(role => role.Id == "system:admin-user");
 
         adminRoles.Permissions.Should().Contain("users:manage");
     }

--- a/tests/CosmosDbSeederTests/NotificationConfigDocument.cs
+++ b/tests/CosmosDbSeederTests/NotificationConfigDocument.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json.Serialization;
+
+namespace CosmosDbSeederTests;
+
+public class NotificationConfigDocument
+{
+    [JsonPropertyName("id")] public required string Id { get; set; }
+
+    [JsonPropertyName("docType")] public required string DocType { get; set; }
+
+    [JsonPropertyName("configs")] public required Config[] Configs { get; set; }
+}
+
+public class Config
+{
+    [JsonPropertyName("services")] public required string[] Services { get; set; }
+
+    [JsonPropertyName("emailTemplate")] public required string EmailTemplate { get; set; }
+
+    [JsonPropertyName("smsTemplate")] public required string SmsTemplate { get; set; }
+
+    [JsonPropertyName("eventType")] public required string EventType { get; set; }
+}

--- a/tests/CosmosDbSeederTests/NotificationConfigTests.cs
+++ b/tests/CosmosDbSeederTests/NotificationConfigTests.cs
@@ -8,7 +8,6 @@ public class NotificationConfigTests : BaseCosmosDbSeederTest
     [InlineData("local")]
     [InlineData("dev")]
     [InlineData("int")]
-    [InlineData("perf")]
     [InlineData("stag")]
     [InlineData("prod")]
     public void AllConfigsAreForValidServices(string environment)

--- a/tests/CosmosDbSeederTests/NotificationConfigTests.cs
+++ b/tests/CosmosDbSeederTests/NotificationConfigTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+
+namespace CosmosDbSeederTests;
+
+public class NotificationConfigTests : BaseCosmosDbSeederTest
+{
+    [Theory]
+    [InlineData("local")]
+    [InlineData("dev")]
+    [InlineData("int")]
+    [InlineData("perf")]
+    [InlineData("stag")]
+    [InlineData("prod")]
+    public void AllConfigsAreForValidServices(string environment)
+    {
+        var notificationConfigs = ReadDocument<NotificationConfigDocument>(environment);
+        var clinicalServiceIds =
+            ReadDocument<ClinicalServicesDocument>(environment).Services.Select(s => s.Id).ToArray();
+
+        foreach (var config in notificationConfigs.Configs)
+        {
+            foreach (var serviceId in config.Services)
+            {
+                clinicalServiceIds.Should().Contain(serviceId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
We recently updated all `clinical_services.json` documents with the confirmed services for the Autumn/Winter campaign. 

What we (I) forgot to do, was update the notification config documents with these new IDs. This means that when the NotifyFoo functions are picking up messages from the bus, they are trying to fetch the templateId for services which don't exist. 

This PR fixes the documents and adds some tests to ensure that all Notification Configurations use service Ids which exist in the clinical services document.