### PR TITLE
APPT-986: Stub out notifications in Perf

### DIFF
--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -105,7 +105,7 @@ public static class FunctionConfigurationExtensions
             .AddSingleton<IHasConsecutiveCapacityFilter, HasConsecutiveCapacityFilter>()
             .AddSingleton(TimeProvider.System)
             .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
-            .AddUserNotifications()
+            .AddUserNotifications(configuration)
             .AddAutoMapper(typeof(CosmosAutoMapperProfile));
 
         var leaseManagerConnection = Environment.GetEnvironmentVariable("LEASE_MANAGER_CONNECTION");

--- a/src/api/Nhs.Appointments.Api/Notifications/NotificationsConfig.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/NotificationsConfig.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Nhs.Appointments.Api.Notifications;
+
+public class NotificationsConfig
+{
+    [ConfigurationKeyName("Notifications_Provider")]
+    public string NotificationsProvider { get; set; }
+
+    public string GovNotifyBaseUri { get; set; }
+    public string GovNotifyApiKey { get; set; }
+}

--- a/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
@@ -1,25 +1,28 @@
+using System;
 using MassTransit;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nhs.Appointments.Api.Consumers;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Core.Messaging;
 using Nhs.Appointments.Core.Messaging.Events;
-using System;
+using Notify.Client;
 
 namespace Nhs.Appointments.Api.Notifications;
 
 public static class ServiceRegistration
 {
-    public static IServiceCollection AddUserNotifications(this IServiceCollection services)
+    public static IServiceCollection AddUserNotifications(this IServiceCollection services,
+        IConfigurationRoot configuration)
     {
-        var userNotificationsProvider = Environment.GetEnvironmentVariable("Notifications_Provider");
+        var notificationsConfig = configuration.Get<NotificationsConfig>();
 
         services.AddTransient<IUserRolesChangedNotifier, UserRolesChangedNotifier>()
                 .AddTransient<IBookingNotifier, BookingNotifier>()
                 .AddTransient<IPrivacyUtil, PrivacyUtil>()
                 .AddScoped<NotifyBookingReminderFunction>();
 
-        switch (userNotificationsProvider)
+        switch (notificationsConfig.NotificationsProvider)
         {
             case "none":
                 services.AddScoped<IMessageBus, NullMessageBus>();
@@ -35,39 +38,61 @@ public static class ServiceRegistration
                     .AddScoped<IMessageBus, ConsoleLogWithMessageDelivery>()
                     .AddScoped<ISendNotifications, CosmosNotificationClient>();
                 break;
-            case "azure":
-                var notifyBaseUri = Environment.GetEnvironmentVariable("GovNotifyBaseUri");
-                var notifyApiKey = Environment.GetEnvironmentVariable("GovNotifyApiKey");
+            case "azure-throttled":
                 services
-                    .AddScoped(x => new Notify.Client.NotificationClient(notifyBaseUri, notifyApiKey))
+                    .AddScoped<ISendNotifications, FakeNotificationClient>()
+                    .AddNotificationFunctions()
+                    .AddMassTransit();
+                break;
+            case "azure":
+                services
+                    .AddScoped(x =>
+                        new NotificationClient(notificationsConfig.GovNotifyBaseUri,
+                            notificationsConfig.GovNotifyApiKey))
                     .AddScoped<ISendNotifications, GovNotifyClient>()
-                    .AddScoped<IMessageBus, MassTransitBusWrapper>()
-                    .AddScoped<NotifyUserRolesChangedFunction>()
-                    .AddScoped<NotifyBookingMadeFunction>()
-                    .AddScoped<NotifyBookingCancelledFunction>()
-                    .AddScoped<ScheduledBookingRemindersFunction>()
-                    .AddScoped<NotifyBookingRescheduledFunction>()
-                    .AddScoped<NotifyOktaUserRolesChangedFunction>()
-                    .AddMassTransitForAzureFunctions(cfg =>
-                        {
-                            EndpointConvention.Map<UserRolesChanged>(new Uri($"queue:{NotifyUserRolesChangedFunction.QueueName}"));
-                            EndpointConvention.Map<OktaUserRolesChanged>(new Uri($"queue:{NotifyOktaUserRolesChangedFunction.QueueName}"));
-                            EndpointConvention.Map<BookingMade>(new Uri($"queue:{NotifyBookingMadeFunction.QueueName}"));
-                            EndpointConvention.Map<BookingRescheduled>(new Uri($"queue:{NotifyBookingRescheduledFunction.QueueName}"));
-                            EndpointConvention.Map<BookingCancelled>(new Uri($"queue:{NotifyBookingCancelledFunction.QueueName}"));
-                            EndpointConvention.Map<BookingReminder>(new Uri($"queue:{NotifyBookingReminderFunction.QueueName}"));
-                            cfg.AddConsumer<UserRolesChangedConsumer>();
-                            cfg.AddConsumer<OktaUserRolesChangedConsumer>();
-                            cfg.AddConsumer<BookingReminderConsumer>();
-                            cfg.AddConsumer<BookingMadeConsumer>();
-                            cfg.AddConsumer<BookingCancelledConsumer>();
-                            cfg.AddConsumer<BookingRescheduledConsumer>();
-                        },
-                        connectionStringConfigurationKey: "ServiceBusConnectionString");
+                    .AddNotificationFunctions()
+                    .AddMassTransit();
                 break;
             default:
-                throw new NotSupportedException("A null or unsupported notifications provider was specified in the configuration");
+                throw new NotSupportedException(
+                    "A null or unsupported notifications provider was specified in the configuration");
         }
+
+        return services;
+    }
+
+    private static IServiceCollection AddNotificationFunctions(this IServiceCollection services)
+    {
+        services
+            .AddScoped<NotifyUserRolesChangedFunction>()
+            .AddScoped<NotifyBookingMadeFunction>()
+            .AddScoped<NotifyBookingCancelledFunction>()
+            .AddScoped<ScheduledBookingRemindersFunction>()
+            .AddScoped<NotifyBookingRescheduledFunction>()
+            .AddScoped<NotifyOktaUserRolesChangedFunction>();
+        return services;
+    }
+
+    private static IServiceCollection AddMassTransit(this IServiceCollection services)
+    {
+        services.AddMassTransitForAzureFunctions(cfg =>
+            {
+                EndpointConvention.Map<UserRolesChanged>(new Uri($"queue:{NotifyUserRolesChangedFunction.QueueName}"));
+                EndpointConvention.Map<OktaUserRolesChanged>(
+                    new Uri($"queue:{NotifyOktaUserRolesChangedFunction.QueueName}"));
+                EndpointConvention.Map<BookingMade>(new Uri($"queue:{NotifyBookingMadeFunction.QueueName}"));
+                EndpointConvention.Map<BookingRescheduled>(
+                    new Uri($"queue:{NotifyBookingRescheduledFunction.QueueName}"));
+                EndpointConvention.Map<BookingCancelled>(new Uri($"queue:{NotifyBookingCancelledFunction.QueueName}"));
+                EndpointConvention.Map<BookingReminder>(new Uri($"queue:{NotifyBookingReminderFunction.QueueName}"));
+                cfg.AddConsumer<UserRolesChangedConsumer>();
+                cfg.AddConsumer<OktaUserRolesChangedConsumer>();
+                cfg.AddConsumer<BookingReminderConsumer>();
+                cfg.AddConsumer<BookingMadeConsumer>();
+                cfg.AddConsumer<BookingCancelledConsumer>();
+                cfg.AddConsumer<BookingRescheduledConsumer>();
+            },
+            "ServiceBusConnectionString");
         return services;
     }
 }

--- a/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
@@ -75,7 +75,9 @@ public static class ServiceRegistration
 
     private static IServiceCollection AddMassTransit(this IServiceCollection services)
     {
-        services.AddMassTransitForAzureFunctions(cfg =>
+        services
+            .AddScoped<IMessageBus, MassTransitBusWrapper>()
+            .AddMassTransitForAzureFunctions(cfg =>
             {
                 EndpointConvention.Map<UserRolesChanged>(new Uri($"queue:{NotifyUserRolesChangedFunction.QueueName}"));
                 EndpointConvention.Map<OktaUserRolesChanged>(

--- a/tests/Nhs.Appointments.Api.UnitTests/NotificationsServiceProviderExtensionsTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/NotificationsServiceProviderExtensionsTests.cs
@@ -1,0 +1,104 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nhs.Appointments.Api.Notifications;
+using Nhs.Appointments.Core.Messaging;
+
+namespace Nhs.Appointments.Api.Tests;
+
+public class NotificationsServiceProviderExtensionsTests
+{
+    private readonly IServiceCollection _serviceCollection = new ServiceCollection();
+
+    [Fact(DisplayName = "Registers the null message bus if provider is none")]
+    public void NotificationsRegistration_Null()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "Notifications_Provider", "none" },
+                { "GovNotifyBaseUri", "https://api.notifications.service.gov.uk" },
+                { "GovNotifyApiKey", "some-api-key-123abc" }
+            })
+            .Build();
+
+        var serviceProvider = _serviceCollection
+            .AddLogging()
+            .AddUserNotifications(configuration)
+            .BuildServiceProvider();
+
+        var messageBus = serviceProvider.GetService(typeof(IMessageBus));
+
+        messageBus.Should().BeOfType<NullMessageBus>();
+    }
+
+    [Fact(DisplayName = "Registers the local message bus and cosmos notification client if provider is local")]
+    public void NotificationsRegistration_Local()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "Notifications_Provider", "local" },
+                { "GovNotifyBaseUri", "https://api.notifications.service.gov.uk" },
+                { "GovNotifyApiKey", "some-api-key-123abc" }
+            })
+            .Build();
+
+        var serviceProvider = _serviceCollection
+            .AddDependenciesNotUnderTest()
+            .AddUserNotifications(configuration)
+            .BuildServiceProvider();
+
+        var messageBus = serviceProvider.GetService(typeof(IMessageBus));
+        messageBus.Should().BeOfType<ConsoleLogWithMessageDelivery>();
+
+        var notificationsClient = serviceProvider.GetService(typeof(ISendNotifications));
+        notificationsClient.Should().BeOfType<CosmosNotificationClient>();
+    }
+
+    [Fact(DisplayName = "Registers the fake notification client if provider is azure-throttled")]
+    public void NotificationsRegistration_AzureThrottled()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "Notifications_Provider", "azure-throttled" },
+                { "GovNotifyBaseUri", "https://api.notifications.service.gov.uk" },
+                { "GovNotifyApiKey", "some-api-key-123abc" }
+            })
+            .Build();
+
+        var serviceProvider = _serviceCollection
+            .AddDependenciesNotUnderTest()
+            .AddUserNotifications(configuration)
+            .BuildServiceProvider();
+
+        var notificationsClient = serviceProvider.GetService(typeof(ISendNotifications));
+        notificationsClient.Should().BeOfType<FakeNotificationClient>();
+    }
+
+    [Fact(DisplayName = "Registers the real notification client if provider is azure")]
+    public void NotificationsRegistration_Azure()
+    {
+        // Dummy strings throw a format error when requesting this service, so I've
+        // generated then IMMEDIATELY REVOKED this Api Key on one of our test accounts.
+        var revokedApiKey = "tempkeytorevoke-784fc430-ef03-409f-8989-d1d06954f515-3068f145-0e4b-423f-b2b8-4dce20238f50";
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "Notifications_Provider", "azure" },
+                { "GovNotifyBaseUri", "https://api.notifications.service.gov.uk" },
+                { "GovNotifyApiKey", revokedApiKey }
+            })
+            .Build();
+
+        var serviceProvider = _serviceCollection
+            .AddDependenciesNotUnderTest()
+            .AddUserNotifications(configuration)
+            .BuildServiceProvider();
+
+        var notificationsClient = serviceProvider.GetService(typeof(ISendNotifications));
+        notificationsClient.Should().BeOfType<GovNotifyClient>();
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/NotificationsTestServiceProviderExtensions.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/NotificationsTestServiceProviderExtensions.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Nhs.Appointments.Core;
+using Nhs.Appointments.Persistance;
+using Nhs.Appointments.Persistance.Models;
+
+namespace Nhs.Appointments.Api.Tests;
+
+public static class NotificationsTestServiceProviderExtensions
+{
+    public static IServiceCollection AddDependenciesNotUnderTest(this IServiceCollection services)
+    {
+        var cosmosClient = new CosmosClient(
+            "https://localhost:8081",
+            "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+            new CosmosClientOptions());
+
+        services
+            .AddLogging()
+            .AddSingleton(cosmosClient)
+            .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
+            .AddAutoMapper(typeof(CosmosAutoMapperProfile))
+            .AddTransient<ITypedDocumentCosmosStore<NotificationConfigurationDocument>,
+                TypedDocumentCosmosStore<NotificationConfigurationDocument>>()
+            .AddTransient<ITypedDocumentCosmosStore<RolesDocument>,
+                TypedDocumentCosmosStore<RolesDocument>>()
+            .AddTransient<ITypedDocumentCosmosStore<SiteDocument>,
+                TypedDocumentCosmosStore<SiteDocument>>()
+            .AddSingleton(TimeProvider.System)
+            .AddTransient<ISiteService, SiteService>()
+            .AddTransient<ISiteStore, SiteStore>()
+            .AddTransient<IRolesStore, RolesStore>()
+            .AddTransient<INotificationConfigurationStore, NotificationConfigurationStore>()
+            .AddTransient<INotificationConfigurationService, NotificationConfigurationService>()
+            .AddSingleton<IMemoryCache, MemoryCache>();
+
+        return services;
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/NotificationsTestServiceProviderExtensions.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/NotificationsTestServiceProviderExtensions.cs
@@ -18,22 +18,22 @@ public static class NotificationsTestServiceProviderExtensions
 
         services
             .AddLogging()
-            .AddSingleton(cosmosClient)
-            .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
+            .AddSingleton<IMemoryCache, MemoryCache>()
             .AddAutoMapper(typeof(CosmosAutoMapperProfile))
-            .AddTransient<ITypedDocumentCosmosStore<NotificationConfigurationDocument>,
-                TypedDocumentCosmosStore<NotificationConfigurationDocument>>()
-            .AddTransient<ITypedDocumentCosmosStore<RolesDocument>,
-                TypedDocumentCosmosStore<RolesDocument>>()
-            .AddTransient<ITypedDocumentCosmosStore<SiteDocument>,
-                TypedDocumentCosmosStore<SiteDocument>>()
+            .AddSingleton(cosmosClient)
             .AddSingleton(TimeProvider.System)
-            .AddTransient<ISiteService, SiteService>()
-            .AddTransient<ISiteStore, SiteStore>()
-            .AddTransient<IRolesStore, RolesStore>()
-            .AddTransient<INotificationConfigurationStore, NotificationConfigurationStore>()
-            .AddTransient<INotificationConfigurationService, NotificationConfigurationService>()
-            .AddSingleton<IMemoryCache, MemoryCache>();
+            .AddSingleton<IMetricsRecorder, InMemoryMetricsRecorder>()
+            .AddSingleton<ITypedDocumentCosmosStore<NotificationConfigurationDocument>,
+                TypedDocumentCosmosStore<NotificationConfigurationDocument>>()
+            .AddSingleton<ITypedDocumentCosmosStore<RolesDocument>,
+                TypedDocumentCosmosStore<RolesDocument>>()
+            .AddSingleton<ITypedDocumentCosmosStore<SiteDocument>,
+                TypedDocumentCosmosStore<SiteDocument>>()
+            .AddSingleton<ISiteStore, SiteStore>()
+            .AddSingleton<IRolesStore, RolesStore>()
+            .AddSingleton<INotificationConfigurationStore, NotificationConfigurationStore>()
+            .AddSingleton<ISiteService, SiteService>()
+            .AddSingleton<INotificationConfigurationService, NotificationConfigurationService>();
 
         return services;
     }


### PR DESCRIPTION
We've ran into issues on the PERF environment, both when using the APIM stub and a test profile of Gov.Notify. Because the notification consumers run in a separate process, outside of the main booking/querying journeys, they can be safely ignored without invalidation the performance testing. 

We could therefore just leave them erroring and not care, but the problem then is that the dead-letter queue is growing to a huge size and eventually maxing out. When it maxes out, the main BAU functions which try to add events to that queue start erroring out too. So we need a way to consume items from the queues without throwing any errors. 

We already have a FakeNotificationsClient which isn't currently being used. We also have the concept of a "Notifications Provider" which:

- When "none", will not consume notifications at all
- When "local", will write notifications to the console
- When "azure", will send notifications through to Gov.Notify as required in prod

I have added a fourth, "azure-throttled", which utilises this found FakeNotificationsClient. 

I've also added in some tests to prove the correct service is being registered. 

This value only needs to be set in the PERF env, which isn't currently in main. Therefore this code has been cherry-picked onto the perf branch and the actual usage of this value is in [this commit](https://github.com/NHSDigital/nbs-appointments-management-service/commit/10c9ccd28015fffc41be295a07c5866b2ec2b6e2)
