### PR TITLE
APPT-863: Fix lat validation and add Expander component

### DIFF
--- a/src/client/src/app/lib/components/nhsuk-frontend/expander.test.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/expander.test.tsx
@@ -1,0 +1,122 @@
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+import Expander from './expander';
+
+describe('Expander', () => {
+  it('renders', () => {
+    render(
+      <Expander summary={'How to find your NHS number'}>
+        <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
+        <p>
+          You can find your NHS number by logging in to a GP online service or
+          on any document the NHS has sent you, such as your:
+        </p>
+        <ul>
+          <li>prescriptions</li>
+          <li>test results</li>
+          <li>hospital referral letters</li>
+          <li>appointment letters</li>
+        </ul>
+        <p>Ask your GP surgery for help if you can't find your NHS number.</p>
+      </Expander>,
+    );
+
+    expect(screen.getByText('How to find your NHS number')).toBeInTheDocument();
+  });
+
+  it('renders in a collapsed state by default', () => {
+    render(
+      <Expander summary={'How to find your NHS number'}>
+        <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
+        <p>
+          You can find your NHS number by logging in to a GP online service or
+          on any document the NHS has sent you, such as your:
+        </p>
+        <ul>
+          <li>prescriptions</li>
+          <li>test results</li>
+          <li>hospital referral letters</li>
+          <li>appointment letters</li>
+        </ul>
+        <p>Ask your GP surgery for help if you can't find your NHS number.</p>
+      </Expander>,
+    );
+
+    expect(
+      screen.getByText(
+        'An NHS number is a 10 digit number, like 485 777 3456.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'An NHS number is a 10 digit number, like 485 777 3456.',
+      ),
+    ).not.toBeVisible();
+  });
+
+  it('expands when clicked', async () => {
+    const { user } = render(
+      <Expander summary={'How to find your NHS number'}>
+        <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
+        <p>
+          You can find your NHS number by logging in to a GP online service or
+          on any document the NHS has sent you, such as your:
+        </p>
+        <ul>
+          <li>prescriptions</li>
+          <li>test results</li>
+          <li>hospital referral letters</li>
+          <li>appointment letters</li>
+        </ul>
+        <p>Ask your GP surgery for help if you can't find your NHS number.</p>
+      </Expander>,
+    );
+
+    expect(
+      screen.getByText(
+        'An NHS number is a 10 digit number, like 485 777 3456.',
+      ),
+    ).not.toBeVisible();
+
+    await user.click(screen.getByText('How to find your NHS number'));
+
+    expect(
+      screen.getByText(
+        'An NHS number is a 10 digit number, like 485 777 3456.',
+      ),
+    ).toBeVisible();
+  });
+
+  it('expands when clicked then collapses when clicked again', async () => {
+    const { user } = render(
+      <Expander summary={'How to find your NHS number'}>
+        <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
+        <p>
+          You can find your NHS number by logging in to a GP online service or
+          on any document the NHS has sent you, such as your:
+        </p>
+        <ul>
+          <li>prescriptions</li>
+          <li>test results</li>
+          <li>hospital referral letters</li>
+          <li>appointment letters</li>
+        </ul>
+        <p>Ask your GP surgery for help if you can't find your NHS number.</p>
+      </Expander>,
+    );
+
+    await user.click(screen.getByText('How to find your NHS number'));
+    expect(
+      screen.getByText(
+        'An NHS number is a 10 digit number, like 485 777 3456.',
+      ),
+    ).toBeVisible();
+
+    await user.click(screen.getByText('How to find your NHS number'));
+    expect(
+      screen.getByText(
+        'An NHS number is a 10 digit number, like 485 777 3456.',
+      ),
+    ).not.toBeVisible();
+  });
+});

--- a/src/client/src/app/lib/components/nhsuk-frontend/expander.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/expander.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+
+type Props = {
+  summary: string | ReactNode;
+  children: ReactNode;
+};
+
+/**
+ * An Expander component adhering to the NHS UK Frontend design system.
+ * Before making changes to this component, please consult the NHS UK Frontend documentation for it.
+ * @see https://service-manual.nhs.uk/design-system/components/expander
+ */
+const Expander = ({ summary, children }: Props) => {
+  return (
+    <details className="nhsuk-details nhsuk-expander">
+      <summary className="nhsuk-details__summary">
+        <span className="nhsuk-details__summary-text">{summary}</span>
+      </summary>
+      <div className="nhsuk-details__text">{children}</div>
+    </details>
+  );
+};
+
+export default Expander;

--- a/src/client/src/app/lib/components/nhsuk-frontend/index.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/index.tsx
@@ -7,6 +7,7 @@ import CheckBox from './checkbox';
 import CheckBoxes, { CheckBoxOrAll } from './checkboxes';
 import DateInput from './date-input';
 import Header, { NavigationLink } from './header';
+import Expander from './expander';
 import Fieldset from './fieldset';
 import Footer from './footer';
 import FormGroup from './form-group';
@@ -47,6 +48,7 @@ export type {
   LinkActionProps,
   OnClickActionProps,
 };
+
 export {
   BackLink,
   Breadcrumbs,
@@ -57,10 +59,11 @@ export {
   CheckBoxes,
   CheckBoxOrAll,
   DateInput,
-  Header,
+  Expander,
   Fieldset,
   Footer,
   FormGroup,
+  Header,
   InsetText,
   NhsLogo,
   Pagination,
@@ -71,7 +74,6 @@ export {
   Spinner,
   SpinnerWithText,
   SmallSpinnerWithText,
-  WhiteSpinnerWithText,
   SummaryList,
   Table,
   Tabs,
@@ -80,4 +82,5 @@ export {
   TextArea,
   TextInput,
   WarningCallout,
+  WhiteSpinnerWithText,
 };

--- a/src/client/src/app/site/[site]/details/edit-details/edit-details-form.tsx
+++ b/src/client/src/app/site/[site]/details/edit-details/edit-details-form.tsx
@@ -8,6 +8,7 @@ import {
   SmallSpinnerWithText,
   TextInput,
   TextArea,
+  Expander,
 } from '@nhsuk-frontend-components';
 import { useRouter } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
@@ -75,6 +76,14 @@ const EditDetailsForm = ({ site }: { site: Site }) => {
         ></TextArea>
       </FormGroup>
 
+      <Expander summary={'View the latitude and longitude ranges'}>
+        <ul>
+          <li>the minimum latitude is 49.8 and the maximum latitude is 60.9</li>
+          <li>
+            the minimum longitude is -8.1 and the maximum longitude is 1.8
+          </li>
+        </ul>
+      </Expander>
       <DecimalFormControl
         formField="latitude"
         label="Latitude"

--- a/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.test.ts
+++ b/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.test.ts
@@ -98,12 +98,15 @@ describe('Set User Roles Form', () => {
 
   it.each([
     [undefined, 'Enter a latitude'],
-    [-10, true],
-    [10, true],
-    [-49.8, true],
-    [-49.9, 'Enter a valid latitude'],
+    [-5, 'Enter a valid latitude'],
+    [10.1, 'Enter a valid latitude'],
+    [49.7, 'Enter a valid latitude'],
+    [49.8, true],
+    [54.1, true],
+    [60, true],
     [60.9, true],
     [61.0, 'Enter a valid latitude'],
+    [65.3, 'Enter a valid latitude'],
   ])(
     'validates the site latitude',
     async (

--- a/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.ts
+++ b/src/client/src/app/site/[site]/details/edit-details/edit-site-details-form-schema.ts
@@ -24,7 +24,7 @@ export const editSiteDetailsFormSchema: yup.ObjectSchema<EditSiteDetailsFormValu
         .number()
         .transform(value => (isNaN(value) ? undefined : value))
         .required('Enter a latitude')
-        .min(-49.8, 'Enter a valid latitude')
+        .min(49.8, 'Enter a valid latitude')
         .max(60.9, 'Enter a valid latitude'),
       longitude: yup
         .number()


### PR DESCRIPTION
I made a very silly error when adding in the Lat/Long validation:

- The backend code is correctly validating that the minimum value for Latitude should be **49.8**
- The frontend code is incorrectly validating it as **-49.8** 🤦 

Also, Product/Design have asked for an expander component to be added (screenshots attached) to explain these ranges. 

<img width="851" alt="2" src="https://github.com/user-attachments/assets/0dfaad9d-4951-41eb-a197-d5264e4c9d5b" />
<img width="866" alt="1" src="https://github.com/user-attachments/assets/1c00bf0e-7fc6-4f5a-9196-f7ce90863e12" />
