### PR TITLE
Appt 987 - Adding the ability to update / remove regional user permissions

### DIFF
--- a/src/api/Nhs.Appointments.Core/IUserService.cs
+++ b/src/api/Nhs.Appointments.Core/IUserService.cs
@@ -10,4 +10,5 @@ public interface IUserService
     Task<OperationResult> RemoveUserAsync(string userId, string site);
     Task SaveUserAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
     Task<UserIdentityStatus> GetUserIdentityStatusAsync(string siteId, string userId);
+    Task<UpdateUserRoleAssignmentsResult> UpdateRegionalUserRoleAssignmentsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
 }

--- a/src/api/Nhs.Appointments.Core/IUserService.cs
+++ b/src/api/Nhs.Appointments.Core/IUserService.cs
@@ -10,5 +10,5 @@ public interface IUserService
     Task<OperationResult> RemoveUserAsync(string userId, string site);
     Task SaveUserAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
     Task<UserIdentityStatus> GetUserIdentityStatusAsync(string siteId, string userId);
-    Task<UpdateUserRoleAssignmentsResult> UpdateRegionalUserRoleAssignmentsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
+    Task UpdateRegionalUserRoleAssignmentsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
 }

--- a/src/api/Nhs.Appointments.Core/IUserStore.cs
+++ b/src/api/Nhs.Appointments.Core/IUserStore.cs
@@ -11,4 +11,5 @@ public interface IUserStore
     Task<OperationResult> RemoveUserAsync(string userId, string siteId);
 
     Task<OperationResult> RecordEulaAgreementAsync(string userId, DateOnly versionDate);
+    Task UpdateUserRegionPermissionsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
 }

--- a/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/UserDataImportHandler.cs
@@ -50,7 +50,7 @@ public class UserDataImportHandler(
         if (regionalUsers.Count > 0)
         {
             await ValidateRegionCodes(regionalUsers, report);
-            CheckForDuplicateRegionPermissions(userImportRows, report);
+            CheckForDuplicateRegionPermissions(regionalUsers, report);
         }
 
         if (report.Any(r => !r.Success))
@@ -75,7 +75,8 @@ public class UserDataImportHandler(
                 var isRegionPermission = !string.IsNullOrEmpty(userAssignmentGroup.Region);
                 if (isRegionPermission)
                 {
-                    await UpdateRegionPermissionsForUser(userAssignmentGroup, report);
+                    var scope = $"region:{userAssignmentGroup.Region}";
+                    await userService.UpdateRegionalUserRoleAssignmentsAsync(userAssignmentGroup.UserId, scope, userAssignmentGroup.RoleAssignments);
                     continue;
                 }
 
@@ -138,11 +139,6 @@ public class UserDataImportHandler(
                 false,
                 $"Users can only be added to one region per upload. User: {usr.Key} has been added multiple times for region scoped permissions.")));
         }
-    }
-
-    private async Task UpdateRegionPermissionsForUser(UserImportRow userAssignmentGroup, List<ReportItem> report)
-    {
-        var scope = $"region:{userAssignmentGroup.Region}";
     }
 
     public class UserImportRow

--- a/src/api/Nhs.Appointments.Core/UserService.cs
+++ b/src/api/Nhs.Appointments.Core/UserService.cs
@@ -56,22 +56,9 @@ public class UserService(
         return new UpdateUserRoleAssignmentsResult(true, string.Empty, []);
     }
 
-    public async Task<UpdateUserRoleAssignmentsResult> UpdateRegionalUserRoleAssignmentsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
+    public async Task UpdateRegionalUserRoleAssignmentsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
     {
-        var userRoles = await GetUserRoleAssignments(userId);
-        if (!userRoles.Any() || !userRoles.Any(r => r.Role == "system:regional-user"))
-        {
-            return await UpdateUserRoleAssignmentsAsync(userId, scope, roleAssignments);
-        }
-
-        if (userRoles.Any(r => r.Scope == scope))
-        {
-            // Remove permission and return
-        }
-
-        // Remove existing region permissions and replace with the new one
-
-        return new UpdateUserRoleAssignmentsResult(true, string.Empty, []);
+        await userStore.UpdateUserRegionPermissionsAsync(userId, scope, roleAssignments);
     }
 
     private async Task NotifyRoleAssignmentChanged(string userId, string site, IEnumerable<RoleAssignment> oldAssignments, IEnumerable<RoleAssignment> newAssignments) 

--- a/src/api/Nhs.Appointments.Core/UserService.cs
+++ b/src/api/Nhs.Appointments.Core/UserService.cs
@@ -56,6 +56,24 @@ public class UserService(
         return new UpdateUserRoleAssignmentsResult(true, string.Empty, []);
     }
 
+    public async Task<UpdateUserRoleAssignmentsResult> UpdateRegionalUserRoleAssignmentsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments)
+    {
+        var userRoles = await GetUserRoleAssignments(userId);
+        if (!userRoles.Any() || !userRoles.Any(r => r.Role == "system:regional-user"))
+        {
+            return await UpdateUserRoleAssignmentsAsync(userId, scope, roleAssignments);
+        }
+
+        if (userRoles.Any(r => r.Scope == scope))
+        {
+            // Remove permission and return
+        }
+
+        // Remove existing region permissions and replace with the new one
+
+        return new UpdateUserRoleAssignmentsResult(true, string.Empty, []);
+    }
+
     private async Task NotifyRoleAssignmentChanged(string userId, string site, IEnumerable<RoleAssignment> oldAssignments, IEnumerable<RoleAssignment> newAssignments) 
     {
         IEnumerable<RoleAssignment> rolesRemoved = [];

--- a/src/api/Nhs.Appointments.Persistance/UserStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/UserStore.cs
@@ -98,6 +98,7 @@ public class UserStore(ITypedDocumentCosmosStore<UserDocument> cosmosStore, IMap
                 RoleAssignments = roleAssignments.ToArray()
             };
             await InsertAsync(user);
+            return;
         }
 
         const string regionalUserRole = "system:regional-user";

--- a/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
@@ -427,8 +427,11 @@ public class UserDataImportHandlerTests
         report.Count().Should().Be(2);
         report.All(r => r.Success).Should().BeTrue();
 
-        _userServiceMock.Verify(u => u.UpdateUserRoleAssignmentsAsync("test1@nhs.net", "region:R1", It.IsAny<IEnumerable<RoleAssignment>>()), Times.Exactly(1));
-        _userServiceMock.Verify(u => u.UpdateUserRoleAssignmentsAsync("test2@nhs.net", "region:R2", It.IsAny<IEnumerable<RoleAssignment>>()), Times.Exactly(1));
+        _userServiceMock.Verify(u => u.UpdateRegionalUserRoleAssignmentsAsync("test1@nhs.net", "region:R1", It.IsAny<IEnumerable<RoleAssignment>>()), Times.Exactly(1));
+        _userServiceMock.Verify(u => u.UpdateRegionalUserRoleAssignmentsAsync("test2@nhs.net", "region:R2", It.IsAny<IEnumerable<RoleAssignment>>()), Times.Exactly(1));
+
+        _userServiceMock.Verify(u => u.UpdateUserRoleAssignmentsAsync("test1@nhs.net", "region:R1", It.IsAny<IEnumerable<RoleAssignment>>()), Times.Never);
+        _userServiceMock.Verify(u => u.UpdateUserRoleAssignmentsAsync("test2@nhs.net", "region:R2", It.IsAny<IEnumerable<RoleAssignment>>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
Expected behaviour as discussed with Lauren last week:
- If a user has no existing region permissions and the csv file includes region permissions - add them
- If a user has an existing permission to region "R1" and the csv file includes a row with a region permission to "R1" that is classed as an overwrite and the permission will be removed
- If a user has an existing permission to region "R1" and the csv file includes a row with a region permission to "R2", that is classed as an overwrite where permission to "R1" will be removed and it will be replaced by a region permission to "R2"