### PR TITLE
APPT-956 & APPT-682 RFC Approval step for Production

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pool:
 parameters:
   - name: environments
     type: object
-    default: ["dev", "int"]
+    default: ["dev", "int", "stag", "prod"]
 
 variables:
   prBuildServiceConnectionName: "nbs-myacicd-rg-int"
@@ -339,5 +339,5 @@ stages:
           cosmosAccountName: nbs-mya-cdb-${{env}}-uks
           resourceGroup: nbs-mya-rg-${{env}}-uks
           serviceConnectionName: nbs-mya-rg-${{env}}
-          isMain: true
+          isMain: ${{eq(variables['Build.SourceBranch'], 'refs/heads/main')}}
           buildNumber: "$(Build.BuildNumber)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pool:
 parameters:
   - name: environments
     type: object
-    default: ["dev", "int", "stag", "prod"]
+    default: ["dev", "int"]
 
 variables:
   prBuildServiceConnectionName: "nbs-myacicd-rg-int"
@@ -339,5 +339,5 @@ stages:
           cosmosAccountName: nbs-mya-cdb-${{env}}-uks
           resourceGroup: nbs-mya-rg-${{env}}-uks
           serviceConnectionName: nbs-mya-rg-${{env}}
-          isMain: ${{eq(variables['Build.SourceBranch'], 'refs/heads/main')}}
+          isMain: true
           buildNumber: "$(Build.BuildNumber)"

--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -36,8 +36,21 @@ stages:
     variables:
       - group: ${{parameters.variable_group}}
     jobs:
+      - job: EnterChangeRequest
+        displayName: "Enter Change Request Number (CFG)"
+        pool: server
+        condition: and(succeeded(), eq('${{parameters.env}}', 'int'))
+        steps:
+          - task: ManualValidation@0
+            displayName: "Enter Change Request Number (CFG)"
+            inputs:
+              notifyUsers: ""
+              instructions: Enter a valid CFG
       - job: RunTerraformPlan
         displayName: "Run Terraform Plan"
+        dependsOn:
+          - ${{ if eq(parameters.env, 'int') }}:
+              - EnterChangeRequest
         steps:
           - checkout: none
           - task: ms-devlabs.custom-terraform-tasks.custom-terraform-installer-task.TerraformInstaller@0

--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -39,7 +39,7 @@ stages:
       - job: EnterChangeRequest
         displayName: "Enter Change Request Number (CFG)"
         pool: server
-        condition: and(succeeded(), eq('${{parameters.env}}', 'int'))
+        condition: and(succeeded(), eq('${{parameters.env}}', 'prod'))
         steps:
           - task: ManualValidation@0
             displayName: "Enter Change Request Number (CFG)"
@@ -49,7 +49,7 @@ stages:
       - job: RunTerraformPlan
         displayName: "Run Terraform Plan"
         dependsOn:
-          - ${{ if eq(parameters.env, 'int') }}:
+          - ${{ if eq(parameters.env, 'prod') }}:
               - EnterChangeRequest
         steps:
           - checkout: none

--- a/src/client/testing/tests/manage-user/edit-user.spec.ts
+++ b/src/client/testing/tests/manage-user/edit-user.spec.ts
@@ -89,7 +89,6 @@ test('Verify all roles cannot be removed from existing account', async ({
   // TODO: Use seed data instead!
   await usersPage.addUserButton.click();
 
-  await usersPage.addUserButton.click();
   await page.waitForURL(`**/site/${getTestSite().id}/users/manage`);
 
   await expect(manageUserPage.emailStep.title).toBeVisible();


### PR DESCRIPTION
**This change is a 2-birds-1-stone change - adding the RFC check in the deploy step at the top will prevent the cases where we are having a production lock state due to a timed out terraform plan step on deployment to staging.**

Add EnterChangeRequest validation step in before any of the deploy actions when the environment is Production.

This stops the terraform plan step from running (and acquiring a Production state lock) when a release is deployed to Staging (since it won't kick off the plan step without this manual validation passing). Once this validation has timed out, the Production stage can be reran (on the day of LIVE deployment) and if the validation passes with an entered CFG, then it will do the plan and acquire the lock and hopefully be successfully deployed and then release the lock.

This is a temporary workaround while we try and fine-tune our process. This comment field can't be validated for valid Regex (or anything for that matter!) and a workaround would have to be added for it.