### PR TITLE
APPT-845 - New notification parameters for new templates

### DIFF
--- a/data/CosmosDbSeeder/items/dev/core_data/clinical_services.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/clinical_services.json
@@ -4,39 +4,57 @@
   "services": [
     {
       "id": "RSV:Adult",
-      "label": "RSV Adult"
+      "label": "RSV Adult",
+      "serviceType": "RSV",
+      "url": "https://www.nhs.uk/book-rsv"
     },
     {
       "id": "COVID:5_11",
-      "label": "COVID 5-11"
+      "label": "COVID 5-11",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:12_17",
-      "label": "COVID 12-17"
+      "label": "COVID 12-17",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:18+",
-      "label": "COVID 18+"
+      "label": "COVID 18+",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "FLU:18_64",
-      "label": "Flu 18-64"
+      "label": "Flu 18-64",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "FLU:65+",
-      "label": "Flu 65+"
+      "label": "Flu 65+",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "COVID_FLU:18_64",
-      "label": "Flu and COVID 18-64"
+      "label": "Flu and COVID 18-64",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "COVID_FLU:65+",
-      "label": "Flu and COVID 65+"
+      "label": "Flu and COVID 65+",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "FLU:2_3",
-      "label": "Flu 2-3"
+      "label": "Flu 2-3",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/dev/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/notification_config.json
@@ -17,79 +17,49 @@
     {
       "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
       "emailTemplate": "013bf1ab-b9af-4358-8f41-83b573c9b121",
-      "smsTemplate": "1203db45-e5fc-479d-a64e-079c5723b1c3",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
       "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
       "emailTemplate": "47a7f432-ec7e-4e23-bbb3-105ac134ac73",
-      "smsTemplate": "8e5bc8cb-a65b-44b8-a6f3-f6c60dc9e54e",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
       "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
       "emailTemplate": "357d32fc-b8d5-4e63-aef3-87dc6ddd9ce8",
-      "smsTemplate": "53e36c57-1188-4744-b48b-2014e0fa4ef3",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["RSV:Adult"],
+      "services": [ "RSV:Adult" ],
       "emailTemplate": "c096719c-5aef-4803-9a05-099c136e1c73",
-      "smsTemplate": "474af7ec-bf1c-4c6b-9dec-a20955c58a33",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
-      "emailTemplate": "a065e0b3-9640-4c55-9789-7c0211b2f143",
-      "smsTemplate": "dfc6f5b0-b965-4cc6-a168-18b88b40573a",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "",
+      "smsTemplate": "4b0fae92-07bf-46ba-ad16-1f86ac122d15",
+      "eventType": "BookingMade"
+    },
+    {
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "36b50be4-fad7-440e-8958-b0dc66efe33a",
+      "smsTemplate": "c452be27-5bae-422d-9691-6bb955dbc51f",
       "eventType": "BookingReminder"
     },
     {
-      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
-      "emailTemplate": "7151e402-ab25-45db-a312-d63a4519427d",
-      "smsTemplate": "49fea2c1-219c-49e5-9493-b528b811b729",
-      "eventType": "BookingReminder"
-    },
-    {
-      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
-      "emailTemplate": "4a6eeee1-bfb4-47d8-9e53-aaddf0fe7248",
-      "smsTemplate": "d2de1ecb-c9ea-4c1b-a4a4-0f3c01f55f42",
-      "eventType": "BookingReminder"
-    },
-    {
-      "services": ["RSV:Adult"],
-      "emailTemplate": "b560d593-34d8-4641-8517-ec563e8122ad",
-      "smsTemplate": "b21afedd-e6a2-417e-a146-6f1b7ae2865c",
-      "eventType": "BookingReminder"
-    },
-    {
-      "services": ["RSV:Adult"],
-      "emailTemplate": "5c35172a-58ff-4258-aba9-b88f659a66d5",
-      "smsTemplate": "62a43b97-9715-43a8-83c5-9932c91d22b3",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "c64a1fc4-fbce-48f1-bfb6-9ee95037d531",
+      "smsTemplate": "1809338e-2c31-4e10-b61a-5f63732fe202",
       "eventType": "BookingCancelled"
     },
     {
-      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
-      "emailTemplate": "8d8ffe21-d995-49d5-89b0-3e3f5a7d8e9a",
-      "smsTemplate": "72d8ba78-e3a7-454a-9540-fc42278a9706",
-      "eventType": "BookingRescheduled"
-    },
-    {
-      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
-      "emailTemplate": "679e3760-6dd2-4076-8ee5-0799517fa9ca",
-      "smsTemplate": "0a4bb160-0ab7-4acc-b66d-57256a9d5973",
-      "eventType": "BookingRescheduled"
-    },
-    {
-      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
-      "emailTemplate": "cab0fdf2-d631-4a2f-a2fb-09cfe7e77080",
-      "smsTemplate": "f89fb975-7491-492e-907d-29caa52e40f5",
-      "eventType": "BookingRescheduled"
-    },
-    {
-      "services": ["RSV:Adult"],
-      "emailTemplate": "ae42294c-ef05-4026-a01a-3020f581f377",
-      "smsTemplate": "24e7e620-8e03-4b6c-abe9-79a911b874b3",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "6c665f03-a7c9-47aa-a087-4fbcd8888f96",
+      "smsTemplate": "18a415e5-0354-4986-b84b-947e3b3fc055",
       "eventType": "BookingRescheduled"
     }
   ]

--- a/data/CosmosDbSeeder/items/int/core_data/clinical_services.json
+++ b/data/CosmosDbSeeder/items/int/core_data/clinical_services.json
@@ -4,39 +4,57 @@
   "services": [
     {
       "id": "RSV:Adult",
-      "label": "RSV Adult"
+      "label": "RSV Adult",
+      "serviceType": "RSV",
+      "url": "https://www.nhs.uk/book-rsv"
     },
     {
       "id": "COVID:5_11",
-      "label": "COVID 5-11"
+      "label": "COVID 5-11",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:12_17",
-      "label": "COVID 12-17"
+      "label": "COVID 12-17",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:18+",
-      "label": "COVID 18+"
+      "label": "COVID 18+",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "FLU:18_64",
-      "label": "Flu 18-64"
+      "label": "Flu 18-64",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "FLU:65+",
-      "label": "Flu 65+"
+      "label": "Flu 65+",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "COVID_FLU:18_64",
-      "label": "Flu and COVID 18-64"
+      "label": "Flu and COVID 18-64",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "COVID_FLU:65+",
-      "label": "Flu and COVID 65+"
+      "label": "Flu and COVID 65+",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "FLU:2_3",
-      "label": "Flu 2-3"
+      "label": "Flu 2-3",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/local/core_data/clinical_services.json
+++ b/data/CosmosDbSeeder/items/local/core_data/clinical_services.json
@@ -4,39 +4,57 @@
   "services": [
     {
       "id": "RSV:Adult",
-      "label": "RSV Adult"
+      "label": "RSV Adult",
+      "serviceType": "RSV",
+      "url": "https://www.nhs.uk/book-rsv"
     },
     {
       "id": "COVID:5_11",
-      "label": "COVID 5-11"
+      "label": "COVID 5-11",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:12_17",
-      "label": "COVID 12-17"
+      "label": "COVID 12-17",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:18+",
-      "label": "COVID 18+"
+      "label": "COVID 18+",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "FLU:18_64",
-      "label": "Flu 18-64"
+      "label": "Flu 18-64",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "FLU:65+",
-      "label": "Flu 65+"
+      "label": "Flu 65+",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "COVID_FLU:18_64",
-      "label": "Flu and COVID 18-64"
+      "label": "Flu and COVID 18-64",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "COVID_FLU:65+",
-      "label": "Flu and COVID 65+"
+      "label": "Flu and COVID 65+",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "FLU:2_3",
-      "label": "Flu 2-3"
+      "label": "Flu 2-3",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/local/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/local/core_data/notification_config.json
@@ -15,58 +15,52 @@
       "eventType": "OktaUserRolesChanged"
     },
     {
-      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+" ],
       "emailTemplate": "5028cb32-6168-41ee-8773-2493d073f369",
-      "smsTemplate": "1203db45-e5fc-479d-a64e-079c5723b1c3",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
+      "services": [ "FLU:2_3", "FLU:18_64", "FLU:65+" ],
       "emailTemplate": "82a5a379-9853-46e7-a720-8403eb899216",
-      "smsTemplate": "8e5bc8cb-a65b-44b8-a6f3-f6c60dc9e54e",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
+      "services": [ "COVID_FLU:18_64", "COVID_FLU:65+" ],
       "emailTemplate": "307b5c89-e602-42c1-bdce-5f8043f3ca64",
-      "smsTemplate": "53e36c57-1188-4744-b48b-2014e0fa4ef3",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["RSV:Adult"],
+      "services": [ "RSV:Adult" ],
       "emailTemplate": "c096719c-5aef-4803-9a05-099c136e1c73",
-      "smsTemplate": "474af7ec-bf1c-4c6b-9dec-a20955c58a33",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
-      "emailTemplate": "a065e0b3-9640-4c55-9789-7c0211b2f143",
-      "smsTemplate": "dfc6f5b0-b965-4cc6-a168-18b88b40573a",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "",
+      "smsTemplate": "4b0fae92-07bf-46ba-ad16-1f86ac122d15",
+      "eventType": "BookingMade"
+    },
+    {
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "36b50be4-fad7-440e-8958-b0dc66efe33a",
+      "smsTemplate": "c452be27-5bae-422d-9691-6bb955dbc51f",
       "eventType": "BookingReminder"
     },
     {
-      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
-      "emailTemplate": "7151e402-ab25-45db-a312-d63a4519427d",
-      "smsTemplate": "49fea2c1-219c-49e5-9493-b528b811b729",
-      "eventType": "BookingReminder"
-    },
-    {
-      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
-      "emailTemplate": "4a6eeee1-bfb4-47d8-9e53-aaddf0fe7248",
-      "smsTemplate": "d2de1ecb-c9ea-4c1b-a4a4-0f3c01f55f42",
-      "eventType": "BookingReminder"
-    },
-    {
-      "services": ["RSV:Adult"],
-      "emailTemplate": "b560d593-34d8-4641-8517-ec563e8122ad",
-      "smsTemplate": "b21afedd-e6a2-417e-a146-6f1b7ae2865c",
-      "eventType": "BookingReminder"
-    },
-    {
-      "services": ["RSV:Adult"],
-      "emailTemplate": "2bb90de1-2d7d-45b9-bc6e-88d0c04f0021",
-      "smsTemplate": "2ef9995c-32b9-4088-a630-97c2546062d0",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "c64a1fc4-fbce-48f1-bfb6-9ee95037d531",
+      "smsTemplate": "1809338e-2c31-4e10-b61a-5f63732fe202",
       "eventType": "BookingCancelled"
+    },
+    {
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "6c665f03-a7c9-47aa-a087-4fbcd8888f96",
+      "smsTemplate": "18a415e5-0354-4986-b84b-947e3b3fc055",
+      "eventType": "BookingRescheduled"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/prod/core_data/clinical_services.json
+++ b/data/CosmosDbSeeder/items/prod/core_data/clinical_services.json
@@ -4,39 +4,57 @@
   "services": [
     {
       "id": "RSV:Adult",
-      "label": "RSV Adult"
+      "label": "RSV Adult",
+      "serviceType": "RSV",
+      "url": "https://www.nhs.uk/book-rsv"
     },
     {
       "id": "COVID:5_11",
-      "label": "COVID 5-11"
+      "label": "COVID 5-11",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:12_17",
-      "label": "COVID 12-17"
+      "label": "COVID 12-17",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:18+",
-      "label": "COVID 18+"
+      "label": "COVID 18+",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "FLU:18_64",
-      "label": "Flu 18-64"
+      "label": "Flu 18-64",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "FLU:65+",
-      "label": "Flu 65+"
+      "label": "Flu 65+",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "COVID_FLU:18_64",
-      "label": "Flu and COVID 18-64"
+      "label": "Flu and COVID 18-64",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "COVID_FLU:65+",
-      "label": "Flu and COVID 65+"
+      "label": "Flu and COVID 65+",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "FLU:2_3",
-      "label": "Flu 2-3"
+      "label": "Flu 2-3",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     }
   ]
 }

--- a/data/CosmosDbSeeder/items/stag/core_data/clinical_services.json
+++ b/data/CosmosDbSeeder/items/stag/core_data/clinical_services.json
@@ -4,39 +4,57 @@
   "services": [
     {
       "id": "RSV:Adult",
-      "label": "RSV Adult"
+      "label": "RSV Adult",
+      "serviceType": "RSV",
+      "url": "https://www.nhs.uk/book-rsv"
     },
     {
       "id": "COVID:5_11",
-      "label": "COVID 5-11"
+      "label": "COVID 5-11",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:12_17",
-      "label": "COVID 12-17"
+      "label": "COVID 12-17",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "COVID:18+",
-      "label": "COVID 18+"
+      "label": "COVID 18+",
+      "serviceType": "COVID-19",
+      "url": "https://www.nhs.uk/bookcovid"
     },
     {
       "id": "FLU:18_64",
-      "label": "Flu 18-64"
+      "label": "Flu 18-64",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "FLU:65+",
-      "label": "Flu 65+"
+      "label": "Flu 65+",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     },
     {
       "id": "COVID_FLU:18_64",
-      "label": "Flu and COVID 18-64"
+      "label": "Flu and COVID 18-64",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "COVID_FLU:65+",
-      "label": "Flu and COVID 65+"
+      "label": "Flu and COVID 65+",
+      "serviceType": "COVID-19 and flu",
+      "url": "https://www.nhs.uk/get-vaccination"
     },
     {
       "id": "FLU:2_3",
-      "label": "Flu 2-3"
+      "label": "Flu 2-3",
+      "serviceType": "flu",
+      "url": "https://www.nhs.uk/bookflu"
     }
   ]
 }

--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -80,7 +80,7 @@ public static class FunctionConfigurationExtensions
             .AddTransient<INotificationConfigurationStore, NotificationConfigurationStore>()
             .AddTransient<IAccessibilityDefinitionsStore, AccessibilityDefinitionsStore>()
             .AddTransient<IWellKnownOdsCodesStore, WellKnownOdsCodesStore>()
-            .AddSingleton<IClinicalServiceStore, ClinicalServiceStore>()
+            .AddTransient<IClinicalServiceStore, ClinicalServiceStore>()
             .AddTransient<IWellKnowOdsCodesService, WellKnownOdsCodesService>()
             .AddCosmosDataStores()
             .AddTransient<IBookingWriteService, BookingWriteService>()

--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -104,7 +104,7 @@ public static class FunctionConfigurationExtensions
             .AddTransient<IDataImportHandlerFactory, DataImportHandlerFactory>()
             .AddSingleton<IHasConsecutiveCapacityFilter, HasConsecutiveCapacityFilter>()
             .AddSingleton(TimeProvider.System)
-            .AddScoped<IClinicalServiceProvider, ClinicalServiceProvider>()
+            .AddTransient<IClinicalServiceProvider, ClinicalServiceProvider>()
             .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
             .AddUserNotifications(configuration)
             .AddAutoMapper(typeof(CosmosAutoMapperProfile));

--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -104,6 +104,7 @@ public static class FunctionConfigurationExtensions
             .AddTransient<IDataImportHandlerFactory, DataImportHandlerFactory>()
             .AddSingleton<IHasConsecutiveCapacityFilter, HasConsecutiveCapacityFilter>()
             .AddSingleton(TimeProvider.System)
+            .AddScoped<IClinicalServiceProvider, ClinicalServiceProvider>()
             .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
             .AddUserNotifications(configuration)
             .AddAutoMapper(typeof(CosmosAutoMapperProfile));

--- a/src/api/Nhs.Appointments.Api/Functions/GetClinicalServicesFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetClinicalServicesFunction.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Extensions.Logging;
-using Nhs.Appointments.Api.Features;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Core.Features;
@@ -20,7 +19,7 @@ namespace Nhs.Appointments.Api.Functions
         IUserContextProvider userContextProvider,
         ILogger<GetClinicalServicesFunction> logger,
         IMetricsRecorder metricsRecorder,
-        IClinicalServiceStore store,
+        IClinicalServiceProvider clinicalServiceProvider,
         IFeatureToggleHelper featureToggleHelper)
         : BaseApiFunction<EmptyRequest, IEnumerable<ClinicalServiceType>>(validator, userContextProvider, logger, metricsRecorder)
     {
@@ -42,7 +41,7 @@ namespace Nhs.Appointments.Api.Functions
 
         protected override async Task<ApiResult<IEnumerable<ClinicalServiceType>>> HandleRequest(EmptyRequest request, ILogger logger)
         {
-            var serviceTypes = await store.Get();
+            var serviceTypes = await clinicalServiceProvider.Get();
             return ApiResult<IEnumerable<ClinicalServiceType>>.Success(serviceTypes);
         }
 

--- a/src/api/Nhs.Appointments.Api/Notifications/BookingNotifier.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/BookingNotifier.cs
@@ -54,6 +54,7 @@ public class BookingNotifier(
             logger.LogWarning($"Unable to send notification for {eventType}:{bookingRef} to {notificationType}:{destination} because the specified site does not exist");
             return;
         }
+        var clinicalService = await clinicalServiceProvider.Get(service);
 
         var templateValues = new Dictionary<string, dynamic>
         {
@@ -64,8 +65,8 @@ public class BookingNotifier(
             {"reference", bookingRef},
             {"address", site.Address },
             {"siteLocation", GetSiteLocation(site.InformationForCitizens) },
-            {"vaccine", await clinicalServiceProvider.GetServiceType(service) },
-            {"serviceURL", await clinicalServiceProvider.GetServiceUrl(service) }
+            {"vaccine", clinicalService.ServiceType },
+            {"serviceURL", clinicalService.Url }
         };
 
         var templateId = GetTemplateId(notificationConfiguration, notificationType);

--- a/src/api/Nhs.Appointments.Api/Notifications/BookingNotifier.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/BookingNotifier.cs
@@ -55,6 +55,12 @@ public class BookingNotifier(
             return;
         }
         var clinicalService = await clinicalServiceProvider.Get(service);
+        
+        if(clinicalService == null)
+        {
+            logger.LogWarning($"Unable to send notification for {eventType}:{bookingRef} to {notificationType}:{destination} because the specified clinical service does not exist");
+            return;
+        }
 
         var templateValues = new Dictionary<string, dynamic>
         {

--- a/src/api/Nhs.Appointments.Api/Notifications/BookingNotifier.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/BookingNotifier.cs
@@ -14,9 +14,20 @@ public class BookingNotifier(
     INotificationConfigurationService notificationConfigurationService,
     ISiteService siteService, 
     IPrivacyUtil privacy,
-    ILogger<BookingNotifier> logger) : IBookingNotifier
+    ILogger<BookingNotifier> logger,
+    IClinicalServiceProvider clinicalServiceProvider) : IBookingNotifier
 {
-    public async Task Notify(string eventType, string service, string bookingRef, string siteId, string firstName, DateOnly date, TimeOnly time, NotificationType notificationType, string destination)
+    public async Task Notify(
+        string eventType, 
+        string service, 
+        string bookingRef, 
+        string siteId, 
+        string firstName, 
+        DateOnly date, 
+        TimeOnly time, 
+        NotificationType notificationType, 
+        string destination
+    )
     {
         if(notificationType == NotificationType.Unknown)
         {
@@ -52,7 +63,9 @@ public class BookingNotifier(
             {"time", time.ToString("HH:mm") },
             {"reference", bookingRef},
             {"address", site.Address },
-            {"siteLocation", GetSiteLocation(site.InformationForCitizens) }
+            {"siteLocation", GetSiteLocation(site.InformationForCitizens) },
+            {"vaccine", await clinicalServiceProvider.GetServiceType(service) },
+            {"serviceURL", await clinicalServiceProvider.GetServiceUrl(service) }
         };
 
         var templateId = GetTemplateId(notificationConfiguration, notificationType);

--- a/src/api/Nhs.Appointments.Api/Notifications/IBookingNotifier.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/IBookingNotifier.cs
@@ -6,5 +6,5 @@ namespace Nhs.Appointments.Api.Notifications;
 
 public interface IBookingNotifier
 {
-    Task Notify(string eventType, string service, string bookingRef, string siteId, string firstName, DateOnly date, TimeOnly time, NotificationType type, string destination);
+    Task Notify(string eventType, string service, string bookingRef, string siteId, string firstName, DateOnly date, TimeOnly time, NotificationType notificationType, string destination);
 }

--- a/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
@@ -1,12 +1,14 @@
-using System;
 using MassTransit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nhs.Appointments.Api.Consumers;
 using Nhs.Appointments.Api.Functions;
+using Nhs.Appointments.Core;
 using Nhs.Appointments.Core.Messaging;
 using Nhs.Appointments.Core.Messaging.Events;
+using Nhs.Appointments.Persistance;
 using Notify.Client;
+using System;
 
 namespace Nhs.Appointments.Api.Notifications;
 
@@ -20,6 +22,8 @@ public static class ServiceRegistration
         services.AddTransient<IUserRolesChangedNotifier, UserRolesChangedNotifier>()
                 .AddTransient<IBookingNotifier, BookingNotifier>()
                 .AddTransient<IPrivacyUtil, PrivacyUtil>()
+                .AddScoped<IClinicalServiceProvider, ClinicalServiceProvider>()
+                .AddScoped<IClinicalServiceStore, ClinicalServiceStore>()
                 .AddScoped<NotifyBookingReminderFunction>();
 
         switch (notificationsConfig.NotificationsProvider)

--- a/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
+++ b/src/api/Nhs.Appointments.Api/Notifications/ServiceRegistration.cs
@@ -22,8 +22,6 @@ public static class ServiceRegistration
         services.AddTransient<IUserRolesChangedNotifier, UserRolesChangedNotifier>()
                 .AddTransient<IBookingNotifier, BookingNotifier>()
                 .AddTransient<IPrivacyUtil, PrivacyUtil>()
-                .AddScoped<IClinicalServiceProvider, ClinicalServiceProvider>()
-                .AddScoped<IClinicalServiceStore, ClinicalServiceStore>()
                 .AddScoped<NotifyBookingReminderFunction>();
 
         switch (notificationsConfig.NotificationsProvider)

--- a/src/api/Nhs.Appointments.Core/ClinicalServiceProvider.cs
+++ b/src/api/Nhs.Appointments.Core/ClinicalServiceProvider.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Nhs.Appointments.Core;
+public class ClinicalServiceProvider(IClinicalServiceStore store, IMemoryCache memoryCache) : IClinicalServiceProvider
+{
+    public async Task<string> GetServiceType(string service)
+    {
+        return await GetClinicalServiceProperty(service, x => x.ServiceType);
+    }
+
+    public async Task<string> GetServiceUrl(string service)
+    {
+        return await GetClinicalServiceProperty(service, x => x.Url);
+    }
+
+    public async Task<IEnumerable<ClinicalServiceType>> Get()
+    {
+        var clinicalServices = await store.Get();
+
+        return clinicalServices;
+    }    
+    
+    public async Task<IEnumerable<ClinicalServiceType>> GetFromCache()
+    {
+        var cacheKey = "clinical-service";
+        var clinicalServices = memoryCache.Get<IEnumerable<ClinicalServiceType>>(cacheKey);
+        if (clinicalServices == null)
+        {
+            clinicalServices = await Get();
+            memoryCache.Set(cacheKey, clinicalServices, DateTimeOffset.UtcNow.AddMinutes(60));
+        }
+
+        return clinicalServices;
+    }
+
+    private async Task<string> GetClinicalServiceProperty(string service, Func<ClinicalServiceType, string> selector)
+    {
+        var clinicalServices = await Get();
+
+        var matchedService = clinicalServices.FirstOrDefault(x => x.Value == service);
+        return matchedService != null ? selector(matchedService) : null;
+    }
+}

--- a/src/api/Nhs.Appointments.Core/ClinicalServiceProvider.cs
+++ b/src/api/Nhs.Appointments.Core/ClinicalServiceProvider.cs
@@ -3,23 +3,20 @@ using Microsoft.Extensions.Caching.Memory;
 namespace Nhs.Appointments.Core;
 public class ClinicalServiceProvider(IClinicalServiceStore store, IMemoryCache memoryCache) : IClinicalServiceProvider
 {
-    public async Task<string> GetServiceType(string service)
-    {
-        return await GetClinicalServiceProperty(service, x => x.ServiceType);
-    }
-
-    public async Task<string> GetServiceUrl(string service)
-    {
-        return await GetClinicalServiceProperty(service, x => x.Url);
-    }
-
     public async Task<IEnumerable<ClinicalServiceType>> Get()
     {
         var clinicalServices = await store.Get();
 
         return clinicalServices;
-    }    
-    
+    }
+
+    public async Task<ClinicalServiceType> Get(string service)
+    {
+        var clinicalServices = await store.Get();
+
+        return clinicalServices.FirstOrDefault(x => x.Value == service);
+    }
+
     public async Task<IEnumerable<ClinicalServiceType>> GetFromCache()
     {
         var cacheKey = "clinical-service";
@@ -31,13 +28,5 @@ public class ClinicalServiceProvider(IClinicalServiceStore store, IMemoryCache m
         }
 
         return clinicalServices;
-    }
-
-    private async Task<string> GetClinicalServiceProperty(string service, Func<ClinicalServiceType, string> selector)
-    {
-        var clinicalServices = await Get();
-
-        var matchedService = clinicalServices.FirstOrDefault(x => x.Value == service);
-        return matchedService != null ? selector(matchedService) : null;
     }
 }

--- a/src/api/Nhs.Appointments.Core/ClinicalServiceType.cs
+++ b/src/api/Nhs.Appointments.Core/ClinicalServiceType.cs
@@ -4,5 +4,7 @@ namespace Nhs.Appointments.Core
     {
         public string Value { get; set; }
         public string Label { get; set; }
+        public string ServiceType { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/src/api/Nhs.Appointments.Core/IClinicalServiceProvider.cs
+++ b/src/api/Nhs.Appointments.Core/IClinicalServiceProvider.cs
@@ -1,0 +1,8 @@
+namespace Nhs.Appointments.Core;
+public interface IClinicalServiceProvider
+{
+    Task<IEnumerable<ClinicalServiceType>> Get();
+    Task<IEnumerable<ClinicalServiceType>> GetFromCache();
+    Task<string> GetServiceType(string service);
+    Task<string> GetServiceUrl(string service);
+}

--- a/src/api/Nhs.Appointments.Core/IClinicalServiceProvider.cs
+++ b/src/api/Nhs.Appointments.Core/IClinicalServiceProvider.cs
@@ -2,7 +2,6 @@ namespace Nhs.Appointments.Core;
 public interface IClinicalServiceProvider
 {
     Task<IEnumerable<ClinicalServiceType>> Get();
+    Task<ClinicalServiceType> Get(string service);
     Task<IEnumerable<ClinicalServiceType>> GetFromCache();
-    Task<string> GetServiceType(string service);
-    Task<string> GetServiceUrl(string service);
 }

--- a/src/api/Nhs.Appointments.Persistance/Models/ClinicalServiceDocument.cs
+++ b/src/api/Nhs.Appointments.Persistance/Models/ClinicalServiceDocument.cs
@@ -15,5 +15,11 @@ public class ClinicalServiceTypeDocument
     public string Id { get; set; }
 
     [JsonProperty("label")]
-    public string Label { get; set; }
+    public string Label { get; set; }    
+    
+    [JsonProperty("serviceType")]
+    public string ServiceType { get; set; }    
+    
+    [JsonProperty("url")]
+    public string Url { get; set; }
 }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -73,7 +73,6 @@ public abstract partial class BaseFeatureSteps : Feature
         Mapper = new Mapper(mapperConfiguration);
         SetUpRoles().GetAwaiter().GetResult();
         SetUpIntegrationTestUserRoleAssignments().GetAwaiter().GetResult();
-        SetUpNotificationConfiguration().GetAwaiter().GetResult();
     }
 
     protected string NhsNumber { get; private set; } = CreateRandomTenCharacterString();

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunReminders.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunReminders.feature
@@ -3,9 +3,14 @@ Feature: RunReminders
     @ignore
     Scenario: Running reminders sends reminders for upcoming appointments	
         Given the site is configured for MYA
+        And I have Clinical Services
+          | Service     | ServiceType | Url                          |
+          | RSV:Adult   | RSV         | https://www.nhs.uk/book-rsv  |
+          | COVID:12_17 | COVID-19    | https://www.nhs.uk/bookcovid |
+          | FLU:2_3     | flu         | https://www.nhs.uk/bookflu   |
         And the following bookings have been made
             | Date              | Time  | Duration | Service |
-            | 2 days from today | 09:20 | 5        | COVID   |
+            | 2 days from today | 09:20 | 5        | COVID:12_17   |
         When the reminders job runs
         Then the following notifications are sent out
             | Recipient | Notification         |
@@ -14,27 +19,42 @@ Feature: RunReminders
 
      Scenario: Running reminders does not send reminders for recently made appointments	
         Given the site is configured for MYA
+        And I have Clinical Services
+          | Service     | ServiceType | Url                          |
+          | RSV:Adult   | RSV         | https://www.nhs.uk/book-rsv  |
+          | COVID:12_17 | COVID-19    | https://www.nhs.uk/bookcovid |
+          | FLU:2_3     | flu         | https://www.nhs.uk/bookflu   |
         And the following recent bookings have been made
             | Date              | Time  | Duration | Service |
-            | 2 days from today | 09:20 | 5        | COVID   |
+            | 2 days from today | 09:20 | 5        | COVID:12_17   |
         When the reminders job runs
         Then no notifications are sent out            
 
      Scenario: Running reminders targets correct document types
         Given the site is configured for MYA
+        And I have Clinical Services
+          | Service     | ServiceType | Url                          |
+          | RSV:Adult   | RSV         | https://www.nhs.uk/book-rsv  |
+          | COVID:12_17 | COVID-19    | https://www.nhs.uk/bookcovid |
+          | FLU:2_3     | flu         | https://www.nhs.uk/bookflu   |
         And the following bookings have been made
             | Date              | Time  | Duration | Service |
-            | Tomorrow          | 12:00 | 5        | COVID   |
-            | 2 days from today | 17:20 | 5        | COVID   |
+            | Tomorrow          | 12:00 | 5        | COVID:12_17   |
+            | 2 days from today | 17:20 | 5        | COVID:12_17   |
         And there are audit entries in the database
         When the reminders job runs
         Then there are no errors
     
     Scenario: Running reminders does not send reminders for past appointments	
         Given the site is configured for MYA
+        And I have Clinical Services
+          | Service     | ServiceType | Url                          |
+          | RSV:Adult   | RSV         | https://www.nhs.uk/book-rsv  |
+          | COVID:12_17 | COVID-19    | https://www.nhs.uk/bookcovid |
+          | FLU:2_3     | flu         | https://www.nhs.uk/bookflu   |
         And the following bookings have been made
             | Date              | Time  | Duration | Service |
-            | 2 days before today | 09:20 | 5        | COVID   |
+            | 2 days before today | 09:20 | 5        | COVID:12_17   |
         When the reminders job runs
         Then no notifications are sent out
 
@@ -53,9 +73,14 @@ Feature: RunReminders
     
     Scenario: Running reminders does not send reminders when a reminder has already been sent
         Given the site is configured for MYA    
+        And I have Clinical Services
+          | Service     | ServiceType | Url                          |
+          | RSV:Adult   | RSV         | https://www.nhs.uk/book-rsv  |
+          | COVID:12_17 | COVID-19    | https://www.nhs.uk/bookcovid |
+          | FLU:2_3     | flu         | https://www.nhs.uk/bookflu   |
         And the following bookings have been made
             | Date              | Time  | Duration | Service |
-            | 2 days from today | 09:20 | 5        | COVID   |
+            | 2 days from today | 09:20 | 5        | COVID:12_17   |
         And those appointments have already had notifications sent
         When the reminders job runs
         Then no notifications are sent out

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunReminders.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunReminders.feature
@@ -1,4 +1,4 @@
-﻿Feature: RunReminders
+Feature: RunReminders
 
     @ignore
     Scenario: Running reminders sends reminders for upcoming appointments	
@@ -40,9 +40,14 @@
 
     Scenario: Running reminders does not send reminders for future appointments outside the reminder window
         Given the site is configured for MYA
+        And I have Clinical Services
+          | Service     | ServiceType | Url                          |
+          | RSV:Adult   | RSV         | https://www.nhs.uk/book-rsv  |
+          | COVID:12_17 | COVID-19    | https://www.nhs.uk/bookcovid |
+          | FLU:2_3     | flu         | https://www.nhs.uk/bookflu   |
         And the following bookings have been made
             | Date              | Time  | Duration | Service |
-            | 4 days from today | 09:20 | 5        | COVID   |
+            | 4 days from today | 09:20 | 5        | COVID:12_17   |
         When the reminders job runs
         Then no notifications are sent out
     

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunRemindersFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SystemFunctions/RunRemindersFeatureSteps.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -83,6 +83,27 @@ public class RunRemindersFeatureSteps : BaseFeatureSteps
         allNotifications.AddRange(await GetNotificationsForRecipient(GetContactInfo(ContactItemType.Landline)));
 
         allNotifications.Count().Should().Be(0);
+    }
+
+    [And("I have Clinical Services")]
+    public async Task SetUpClinicalServices(DataTable dataTable)
+    {
+        var clinicalServices = dataTable.Rows.Skip(1).Select(x => new ClinicalServiceTypeDocument()
+        {
+            Id = x.Cells.ElementAt(0).Value,
+            Label = x.Cells.ElementAt(0).Value,
+            ServiceType = x.Cells.ElementAt(1).Value,
+            Url = x.Cells.ElementAt(2).Value
+        });
+
+        var clinicalServicesDocument = new ClinicalServiceDocument()
+        {
+            Id = "clinical_services",
+            DocumentType = "system",
+            Services = clinicalServices.ToArray()
+        };
+
+        await Client.GetContainer("appts", "core_data").UpsertItemAsync(clinicalServicesDocument);
     }
 
     private Task<IEnumerable<NotificationData>> GetNotificationsForRecipient(string contactInfo)

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetClinicalServicesFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetClinicalServicesFunctionTests.cs
@@ -21,7 +21,7 @@ public class GetClinicalServicesFunctionTests
     private readonly Mock<IUserContextProvider> _userContextProvider = new();
     private readonly Mock<ILogger<GetClinicalServicesFunction>> _logger = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
-    private readonly Mock<IClinicalServiceStore> _clinicalServiceStore = new();
+    private readonly Mock<IClinicalServiceProvider> _clinicalServiceProvider = new();
     private readonly Mock<IFeatureToggleHelper> _featureToggleHelper = new();
 
     public GetClinicalServicesFunctionTests()
@@ -31,7 +31,7 @@ public class GetClinicalServicesFunctionTests
             _userContextProvider.Object,
             _logger.Object,
             _metricsRecorder.Object,
-            _clinicalServiceStore.Object,
+            _clinicalServiceProvider.Object,
             _featureToggleHelper.Object);
     }
 
@@ -60,7 +60,7 @@ public class GetClinicalServicesFunctionTests
     public async Task RunsAsync_Returns_501_WhenFeatureDisabled() 
     {
         _featureToggleHelper.Setup(x => x.IsFeatureEnabled(It.Is<string>(x => x.Equals(Flags.MultipleServices)))).ReturnsAsync(false);
-        _clinicalServiceStore.Setup(x => x.Get()).ReturnsAsync(MockServices);
+        _clinicalServiceProvider.Setup(x => x.Get()).ReturnsAsync(MockServices);
 
         var request = CreateRequest();
 
@@ -68,14 +68,14 @@ public class GetClinicalServicesFunctionTests
         result?.StatusCode.Should().Be(501);
 
         _featureToggleHelper.Verify(x => x.IsFeatureEnabled(It.Is<string>(x => x.Equals(Flags.MultipleServices))), Times.Once);
-        _clinicalServiceStore.Verify(x => x.Get(), Times.Never);
+        _clinicalServiceProvider.Verify(x => x.Get(), Times.Never);
     }
 
     [Fact]
     public async Task RunsAsync_Returns_Services_WhenFeatureEnabled()
     {
         _featureToggleHelper.Setup(x => x.IsFeatureEnabled(It.Is<string>(x => x.Equals(Flags.MultipleServices)))).ReturnsAsync(true);
-        _clinicalServiceStore.Setup(x => x.Get()).ReturnsAsync(MockServices);
+        _clinicalServiceProvider.Setup(x => x.Get()).ReturnsAsync(MockServices);
 
         var request = CreateRequest();
 
@@ -86,7 +86,7 @@ public class GetClinicalServicesFunctionTests
         Assert.Equivalent(MockServices, response);
 
         _featureToggleHelper.Verify(x => x.IsFeatureEnabled(It.Is<string>(x => x.Equals(Flags.MultipleServices))), Times.Once);
-        _clinicalServiceStore.Verify(x => x.Get(), Times.Once);
+        _clinicalServiceProvider.Verify(x => x.Get(), Times.Once);
     }
 
     private static async Task<TRequest> ReadResponseAsync<TRequest>(string response)

--- a/tests/Nhs.Appointments.Api.UnitTests/Notifications/BookingNotifierTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Notifications/BookingNotifierTests.cs
@@ -35,13 +35,19 @@ public class BookingNotifierTests
     [Fact]
     public async Task PassesValuesToEmailGovNotifyService()
     {
+        var clinicalService = new ClinicalServiceType()
+        {
+            ServiceType = "COVID-19",
+            Url = "https://www.nhs.uk/bookcovid"
+        };
+
         _notificationConfigurationService
             .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
                 new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
             .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
                 "R1", "ICB1", "Information For Citizens 123", null, null)));
-
+        _clinicalServiceProviderMock.Setup(x => x.Get(Service)).ReturnsAsync(clinicalService);
         _notificationClient.Setup(x => x.SendEmailAsync(Email, EmailTemplateId, It.Is<Dictionary<string, dynamic>>(
             dic =>
                 dic.ContainsKey("firstName") &&
@@ -63,8 +69,10 @@ public class BookingNotifierTests
     [Fact]
     public async Task PassesValuesToSmsGovNotifyService()
     {
-        var serviceType = "COVID-19";
-        var serviceUrl = "https://www.nhs.uk/bookcovid";
+        var clinicalService = new ClinicalServiceType() { 
+            ServiceType = "COVID-19" , 
+            Url = "https://www.nhs.uk/bookcovid" 
+        };
 
         _notificationConfigurationService
             .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
@@ -72,8 +80,7 @@ public class BookingNotifierTests
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
             .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
                 "R1", "ICB1", "Information For Citizens 123", null, null)));
-        _clinicalServiceProviderMock.Setup(x => x.GetServiceType(Service)).ReturnsAsync(serviceType);
-        _clinicalServiceProviderMock.Setup(x => x.GetServiceUrl(Service)).ReturnsAsync(serviceUrl);
+        _clinicalServiceProviderMock.Setup(x => x.Get(Service)).ReturnsAsync(clinicalService);
         _notificationClient.Setup(x => x.SendSmsAsync(PhoneNumber, SmsTemplateId, It.Is<Dictionary<string, dynamic>>(
             dic =>
                 dic.ContainsKey("firstName") &&
@@ -95,9 +102,9 @@ public class BookingNotifierTests
             It.IsAny<string>(),
             It.Is<Dictionary<string, dynamic>>(dic =>
                 dic.ContainsKey("vaccine") &&
-                (dic.GetValueOrDefault("vaccine") as string).Contains(serviceType) &&
+                (dic.GetValueOrDefault("vaccine") as string).Contains(clinicalService.ServiceType) &&
                 dic.ContainsKey("serviceURL") &&
-                (dic.GetValueOrDefault("serviceURL") as string).Contains(serviceUrl)
+                (dic.GetValueOrDefault("serviceURL") as string).Contains(clinicalService.Url)
             )
         ), Times.Once);
     }
@@ -108,14 +115,20 @@ public class BookingNotifierTests
     [InlineData(null, false)]
     public async Task SiteLocationIsRenderedCorrectly(string informationForCitizens, bool hasPrefixText)
     {
+        var clinicalService = new ClinicalServiceType()
+        {
+            ServiceType = "COVID-19",
+            Url = "https://www.nhs.uk/bookcovid"
+        };
         var prefixText = "Additional site information:";
+
         _notificationConfigurationService
             .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
                 new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
             .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
                 "R1", "ICB1", informationForCitizens, null, null)));
-
+        _clinicalServiceProviderMock.Setup(x => x.Get(Service)).ReturnsAsync(clinicalService);
         _notificationClient.Setup(x => x.SendEmailAsync(Email, EmailTemplateId, It.Is<Dictionary<string, dynamic>>(
             dic =>
                 dic.ContainsKey("firstName") &&
@@ -143,12 +156,18 @@ public class BookingNotifierTests
     [Fact]
     public async Task GetsNameOfSite()
     {
+        var clinicalService = new ClinicalServiceType()
+        {
+            ServiceType = "COVID-19",
+            Url = "https://www.nhs.uk/bookcovid"
+        };
         _notificationConfigurationService
             .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
                 new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
         _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>())).Returns(
             Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N", "R1", "ICB1", "Information For Citizens 123",
                 Array.Empty<Accessibility>(), new Location("point", [0, 0])))).Verifiable();
+        _clinicalServiceProviderMock.Setup(x => x.Get(Service)).ReturnsAsync(clinicalService);
         _notificationClient.Setup(
             x => x.SendEmailAsync(Email, EmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
 
@@ -160,12 +179,19 @@ public class BookingNotifierTests
     [Fact]
     public async Task GetsCorrectNotificationConfiguration()
     {
+        var clinicalService = new ClinicalServiceType()
+        {
+            ServiceType = "COVID-19",
+            Url = "https://www.nhs.uk/bookcovid"
+        };
+
         _notificationConfigurationService
             .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
                 new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
         _siteService.Setup(x => x.GetSiteByIdAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(
             Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N", "R1", "ICB1", "Information For Citizens 123",
                 Array.Empty<Accessibility>(), new Location("point", [0, 0]))));
+        _clinicalServiceProviderMock.Setup(x => x.Get(Service)).ReturnsAsync(clinicalService);
         _notificationClient.Setup(
             x => x.SendEmailAsync(Email, EmailTemplateId, It.IsAny<Dictionary<string, dynamic>>()));
 

--- a/tests/Nhs.Appointments.Api.UnitTests/Notifications/BookingNotifierTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Notifications/BookingNotifierTests.cs
@@ -13,7 +13,7 @@ public class BookingNotifierTests
     private const string Site = "6877d86e-c2df-4def-8508-e1eccf0ea6ba";
     private const string Email = "test@tempuri.org";
     private const string FirstName = "joe";
-    private const string PhoneNumber = "0123456789";
+    private const string PhoneNumber = "07722333444";
     private const string Reference = "booking-ref-1234";
     private const string Service = "some-service";
     private readonly Mock<ILogger<BookingNotifier>> _logger = new();
@@ -21,6 +21,7 @@ public class BookingNotifierTests
     private readonly Mock<ISendNotifications> _notificationClient = new();
     private readonly Mock<INotificationConfigurationService> _notificationConfigurationService = new();
     private readonly Mock<ISiteService> _siteService = new();
+    private readonly Mock<IClinicalServiceProvider> _clinicalServiceProviderMock = new();
     private readonly BookingNotifier _sut;
     private readonly DateOnly date = new(2050, 1, 1);
     private readonly TimeOnly time = new(12, 15);
@@ -28,11 +29,11 @@ public class BookingNotifierTests
     public BookingNotifierTests()
     {
         _sut = new BookingNotifier(_notificationClient.Object, _notificationConfigurationService.Object,
-            _siteService.Object, new PrivacyUtil(), _logger.Object);
+            _siteService.Object, new PrivacyUtil(), _logger.Object, _clinicalServiceProviderMock.Object);
     }
 
     [Fact]
-    public async Task PassesValuesToGovNotifyService()
+    public async Task PassesValuesToEmailGovNotifyService()
     {
         _notificationConfigurationService
             .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
@@ -49,12 +50,56 @@ public class BookingNotifierTests
                 dic.ContainsKey("time") &&
                 dic.ContainsKey("address") &&
                 dic.ContainsKey("reference") &&
-                dic.ContainsKey("siteLocation") 
+                dic.ContainsKey("siteLocation") &&
+                dic.ContainsKey("vaccine") &&
+                dic.ContainsKey("serviceURL") 
         ))).Verifiable();
 
         await _sut.Notify(nameof(BookingMade), Service, Reference, Site, FirstName, date, time, NotificationType.Email,
             Email);
         _notificationClient.Verify();
+    }
+
+    [Fact]
+    public async Task PassesValuesToSmsGovNotifyService()
+    {
+        var serviceType = "COVID-19";
+        var serviceUrl = "https://www.nhs.uk/bookcovid";
+
+        _notificationConfigurationService
+            .Setup(x => x.GetNotificationConfigurationsAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(
+                new NotificationConfiguration { EmailTemplateId = EmailTemplateId, SmsTemplateId = SmsTemplateId });
+        _siteService.Setup(x => x.GetSiteByIdAsync(It.Is<string>(s => s == Site), It.IsAny<string>()))
+            .Returns(Task.FromResult(new Site(Site, "A Clinical Site", "123 Surgery Street", "0113 1111111", "15N",
+                "R1", "ICB1", "Information For Citizens 123", null, null)));
+        _clinicalServiceProviderMock.Setup(x => x.GetServiceType(Service)).ReturnsAsync(serviceType);
+        _clinicalServiceProviderMock.Setup(x => x.GetServiceUrl(Service)).ReturnsAsync(serviceUrl);
+        _notificationClient.Setup(x => x.SendSmsAsync(PhoneNumber, SmsTemplateId, It.Is<Dictionary<string, dynamic>>(
+            dic =>
+                dic.ContainsKey("firstName") &&
+                dic.ContainsKey("siteName") &&
+                dic.ContainsKey("date") &&
+                dic.ContainsKey("time") &&
+                dic.ContainsKey("address") &&
+                dic.ContainsKey("reference") &&
+                dic.ContainsKey("siteLocation") &&
+                dic.ContainsKey("vaccine") &&
+                dic.ContainsKey("serviceURL")
+        )));
+
+        await _sut.Notify(nameof(BookingMade), Service, Reference, Site, FirstName, date, time, NotificationType.Sms,
+            PhoneNumber);
+
+        _notificationClient.Verify(x => x.SendSmsAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.Is<Dictionary<string, dynamic>>(dic =>
+                dic.ContainsKey("vaccine") &&
+                (dic.GetValueOrDefault("vaccine") as string).Contains(serviceType) &&
+                dic.ContainsKey("serviceURL") &&
+                (dic.GetValueOrDefault("serviceURL") as string).Contains(serviceUrl)
+            )
+        ), Times.Once);
     }
 
     [Theory]

--- a/tests/Nhs.Appointments.Api.UnitTests/NotificationsServiceProviderExtensionsTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/NotificationsServiceProviderExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nhs.Appointments.Api.Notifications;
@@ -47,6 +47,7 @@ public class NotificationsServiceProviderExtensionsTests
         var serviceProvider = _serviceCollection
             .AddDependenciesNotUnderTest()
             .AddUserNotifications(configuration)
+            .AddCosmosDataStores()
             .BuildServiceProvider();
 
         var messageBus = serviceProvider.GetService(typeof(IMessageBus));

--- a/tests/Nhs.Appointments.Api.UnitTests/NotificationsServiceProviderExtensionsTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/NotificationsServiceProviderExtensionsTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Nhs.Appointments.Api.Notifications;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Core.Messaging;
+using Nhs.Appointments.Persistance;
 
 namespace Nhs.Appointments.Api.Tests;
 
@@ -49,6 +50,7 @@ public class NotificationsServiceProviderExtensionsTests
             .AddDependenciesNotUnderTest()
             .AddUserNotifications(configuration)
             .AddCosmosDataStores()
+            .AddSingleton<IClinicalServiceStore, ClinicalServiceStore>()
             .AddTransient<IClinicalServiceProvider, ClinicalServiceProvider>()
             .BuildServiceProvider();
 

--- a/tests/Nhs.Appointments.Api.UnitTests/NotificationsServiceProviderExtensionsTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/NotificationsServiceProviderExtensionsTests.cs
@@ -1,7 +1,8 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nhs.Appointments.Api.Notifications;
+using Nhs.Appointments.Core;
 using Nhs.Appointments.Core.Messaging;
 
 namespace Nhs.Appointments.Api.Tests;
@@ -48,6 +49,7 @@ public class NotificationsServiceProviderExtensionsTests
             .AddDependenciesNotUnderTest()
             .AddUserNotifications(configuration)
             .AddCosmosDataStores()
+            .AddTransient<IClinicalServiceProvider, ClinicalServiceProvider>()
             .BuildServiceProvider();
 
         var messageBus = serviceProvider.GetService(typeof(IMessageBus));

--- a/tests/Nhs.Appointments.Core.UnitTests/ClinicalServiceProviderTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/ClinicalServiceProviderTests.cs
@@ -42,6 +42,26 @@ public class ClinicalServiceProviderTests
         Assert.Equal(_sampleServices[1].Url, resultArray[1].Url);
     }
 
+    [Fact]
+    public async Task Get_ReturnsClinicalServiceType()
+    {
+        // Arrange
+        var service = "COVID:5_11";
+
+        _storeMock.Setup(x => x.Get()).ReturnsAsync(_sampleServices);
+
+        // Act
+        var result = await _sut.Get(service);
+
+        // Assert
+        Assert.Multiple(
+            () => Assert.NotNull(result),
+            () => Assert.Equal(_sampleServices[0].Value, result.Value),
+            () => Assert.Equal(_sampleServices[0].ServiceType, result.ServiceType),
+            () => Assert.Equal(_sampleServices[0].Url, result.Url)
+        );
+    }
+
 
     [Fact]
     public async Task GetFromCache_ReturnsFromCache_WhenPresent()
@@ -75,45 +95,5 @@ public class ClinicalServiceProviderTests
         // Assert
         Assert.Equal(_sampleServices, result);
         _storeMock.Verify(s => s.Get(), Times.Once);
-    }
-
-    [Fact]
-    public async Task GetServiceType_ReturnsCorrectValue()
-    {
-        // Arrange
-        _storeMock.Setup(s => s.Get()).ReturnsAsync(_sampleServices);
-
-        // Act
-        var result = await _sut.GetServiceType("COVID:5_11");
-
-        // Assert
-        Assert.Equal("COVID-19", result);
-    }
-
-    [Fact]
-    public async Task GetServiceUrl_ReturnsCorrectUrl()
-    {
-        // Arrange
-        _storeMock.Setup(s => s.Get()).ReturnsAsync(_sampleServices);
-
-        // Act
-        var result = await _sut.GetServiceUrl("FLU:18_64");
-
-        // Assert
-        Assert.Equal("https://www.nhs.uk/bookflu", result);
-    }
-
-    [Fact]
-    public async Task GetServiceType_ReturnsNull_WhenServiceNotFound()
-    {
-        // Arrange
-        _storeMock.Setup(s => s.Get()).ReturnsAsync(Array.Empty<ClinicalServiceType>);
-
-        // Act
-        var result = await _sut.GetServiceType("nonexistent");
-
-
-        // Assert
-        Assert.Null(result);
     }
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/ClinicalServiceProviderTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/ClinicalServiceProviderTests.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Nhs.Appointments.Core.UnitTests;
+public class ClinicalServiceProviderTests
+{
+    private readonly Mock<IClinicalServiceStore> _storeMock;
+    private readonly Mock<IMemoryCache> _memoryCacheMock;
+    private readonly ClinicalServiceProvider _sut;
+    private readonly List<ClinicalServiceType> _sampleServices = new()
+    {
+        new ClinicalServiceType { Value = "COVID:5_11", ServiceType = "COVID-19", Url = "https://www.nhs.uk/bookcovid" },
+        new ClinicalServiceType { Value = "FLU:18_64", ServiceType = "flu", Url = "https://www.nhs.uk/bookflu" }
+    };
+    private const string _cacheKey = "clinical-service";
+
+    public ClinicalServiceProviderTests()
+    {
+        _storeMock = new Mock<IClinicalServiceStore>();
+        _memoryCacheMock = new Mock<IMemoryCache>();
+        _sut = new ClinicalServiceProvider(_storeMock.Object, _memoryCacheMock.Object);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsClinicalServiceTypes()
+    {
+        // Arrange
+        _storeMock.Setup(x => x.Get()).ReturnsAsync(_sampleServices);
+
+        // Act
+        var result = await _sut.Get();
+
+        // Assert
+        var resultArray = result.ToArray();
+
+        Assert.NotNull(result);
+        Assert.Equal(2, resultArray.Length);
+        Assert.Equal(_sampleServices[0].Value, resultArray[0].Value);
+        Assert.Equal(_sampleServices[0].ServiceType, resultArray[0].ServiceType);
+        Assert.Equal(_sampleServices[0].Url, resultArray[0].Url);
+        Assert.Equal(_sampleServices[1].Value, resultArray[1].Value);
+        Assert.Equal(_sampleServices[1].ServiceType, resultArray[1].ServiceType);
+        Assert.Equal(_sampleServices[1].Url, resultArray[1].Url);
+    }
+
+
+    [Fact]
+    public async Task GetFromCache_ReturnsFromCache_WhenPresent()
+    {
+        // Arrange
+        object cached = _sampleServices;
+        _memoryCacheMock.Setup(mc => mc.TryGetValue(_cacheKey, out cached)).Returns(true);
+
+        // Act
+        var result = await _sut.GetFromCache();
+
+        // Assert
+        Assert.Equal(_sampleServices, result);
+        _storeMock.Verify(s => s.Get(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetFromCache_ReturnsFromStore_WhenCacheIsEmpty()
+    {
+        // Arrange
+        object cached;
+        _memoryCacheMock.Setup(mc => mc.TryGetValue(_cacheKey, out cached)).Returns(false);
+        _storeMock.Setup(s => s.Get()).ReturnsAsync(_sampleServices);
+
+        var cacheEntryMock = new Mock<ICacheEntry>();
+        _memoryCacheMock.Setup(mc => mc.CreateEntry(It.IsAny<object>())).Returns(cacheEntryMock.Object);
+
+        // Act
+        var result = await _sut.GetFromCache();
+
+        // Assert
+        Assert.Equal(_sampleServices, result);
+        _storeMock.Verify(s => s.Get(), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetServiceType_ReturnsCorrectValue()
+    {
+        // Arrange
+        _storeMock.Setup(s => s.Get()).ReturnsAsync(_sampleServices);
+
+        // Act
+        var result = await _sut.GetServiceType("COVID:5_11");
+
+        // Assert
+        Assert.Equal("COVID-19", result);
+    }
+
+    [Fact]
+    public async Task GetServiceUrl_ReturnsCorrectUrl()
+    {
+        // Arrange
+        _storeMock.Setup(s => s.Get()).ReturnsAsync(_sampleServices);
+
+        // Act
+        var result = await _sut.GetServiceUrl("FLU:18_64");
+
+        // Assert
+        Assert.Equal("https://www.nhs.uk/bookflu", result);
+    }
+
+    [Fact]
+    public async Task GetServiceType_ReturnsNull_WhenServiceNotFound()
+    {
+        // Arrange
+        _storeMock.Setup(s => s.Get()).ReturnsAsync(Array.Empty<ClinicalServiceType>);
+
+        // Act
+        var result = await _sut.GetServiceType("nonexistent");
+
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/NotificationConfigurationServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/NotificationConfigurationServiceTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Nhs.Appointments.Core.UnitTests;
+public class NotificationConfigurationServiceTests
+{
+    private readonly Mock<IMemoryCache> _memoryCacheMock = new();
+    private readonly Mock<INotificationConfigurationStore> _storeMock = new();
+    private readonly NotificationConfigurationService _sut;
+    private static readonly string[] Covid5_11Services = { "COVID:5_11" };
+
+    public NotificationConfigurationServiceTests()
+    {
+        _sut = new NotificationConfigurationService(_memoryCacheMock.Object, _storeMock.Object);
+    }
+
+    [Fact]
+    public async Task GetNotificationConfigurationsAsync_WithMatchingEventTypeAndService_ReturnsCombinedConfiguration()
+    {
+        // Arrange
+        var eventType = "AppointmentBooked";
+        var service = "COVID:5_11";
+
+        var configs = new List<NotificationConfiguration>
+        {
+            new NotificationConfiguration
+            {
+                EventType = "AppointmentBooked",
+                Services = Covid5_11Services,
+                EmailTemplateId = "email-template-1",
+                SmsTemplateId = null
+            },
+            new NotificationConfiguration
+            {
+                EventType = "AppointmentBooked",
+                Services = Covid5_11Services,
+                EmailTemplateId = null,
+                SmsTemplateId = "sms-template-2"
+            }
+        };
+
+        SetupMemoryCache(configs);
+
+        // Act
+        var result = await _sut.GetNotificationConfigurationsAsync(eventType, service);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(eventType, result.EventType);
+        Assert.Single(result.Services);
+        Assert.Equal(service, result.Services.First());
+        Assert.Equal("email-template-1", result.EmailTemplateId);
+        Assert.Equal("sms-template-2", result.SmsTemplateId);
+    }
+
+    [Fact]
+    public async Task GetNotificationConfigurationsAsync_NoMatchingService_ReturnsNull()
+    {
+        // Arrange
+        var eventType = "AppointmentBooked";
+        var service = "UnknownService";
+
+        var configs = new List<NotificationConfiguration>
+        {
+            new NotificationConfiguration
+            {
+                EventType = "AppointmentBooked",
+                Services = Covid5_11Services,
+                EmailTemplateId = "email-template-1",
+                SmsTemplateId = "sms-template-1"
+            }
+        };
+
+        SetupMemoryCache(configs);
+
+        // Act
+        var result = await _sut.GetNotificationConfigurationsAsync(eventType, service);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    private void SetupMemoryCache(IEnumerable<NotificationConfiguration> cacheEntry)
+    {
+        _memoryCacheMock
+            .Setup(mc => mc.TryGetValue(It.IsAny<object>(), out It.Ref<object>.IsAny))
+            .Callback(new TryGetValueCallback((object key, out object value) =>
+            {
+                value = cacheEntry;
+            }))
+            .Returns(true);
+    }
+
+    private delegate void TryGetValueCallback(object key, out object value);
+}


### PR DESCRIPTION
# Description

This PR extends the available template parameters for use in GOV.UK Notify, enabling more dynamic and informative appointment notifications for citizens.

Fixes # (issue)
Added "vaccine" and "serviceURL" parameters.

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
