### PR TITLE
Appt 869 - Site list additional data

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesPreviewFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesPreviewFunction.cs
@@ -55,7 +55,7 @@ public class GetSitesPreviewFunction(
 
             foreach (var site in allSites)
             {
-                sitesResult.Add(new SitePreview(site.Id, site.Name, site.OdsCode));
+                sitesResult.Add(new SitePreview(site.Id, site.Name, site.OdsCode, site.IntegratedCareBoard));
             }
         }
         else
@@ -67,7 +67,7 @@ public class GetSitesPreviewFunction(
                 var siteInfo = await siteService.GetSiteByIdAsync(siteId);
                 if (siteInfo != null)
                 {
-                    sitesResult.Add(new SitePreview(siteInfo.Id, siteInfo.Name, siteInfo.OdsCode));
+                    sitesResult.Add(new SitePreview(siteInfo.Id, siteInfo.Name, siteInfo.OdsCode, siteInfo.IntegratedCareBoard));
                 }
             }
 
@@ -77,7 +77,7 @@ public class GetSitesPreviewFunction(
                 foreach (var region in regionPermissions.Select(r => r.Replace("region:", "")))
                 {
                     var sites = await siteService.GetSitesInRegion(region);
-                    sitesResult.AddRange(sites.Select(s => new SitePreview(s.Id, s.Name, s.OdsCode)));
+                    sitesResult.AddRange(sites.Select(s => new SitePreview(s.Id, s.Name, s.OdsCode, s.IntegratedCareBoard)));
                 }
             }
         }

--- a/src/api/Nhs.Appointments.Core/Site.cs
+++ b/src/api/Nhs.Appointments.Core/Site.cs
@@ -53,7 +53,9 @@ public record SitePreview
     [JsonProperty("name")]
     string Name,
     [JsonProperty("odsCode")]
-    string OdsCode
+    string OdsCode,
+    [JsonProperty("icb")]
+    string IntegratedCareBoard
 );
 
 public record DetailsRequest(

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -77,7 +77,7 @@ public class SiteService(ISiteStore siteStore, IMemoryCache memoryCache, TimePro
         var sites = memoryCache.Get(CacheKey) as IEnumerable<Site>;
         sites ??= await GetAndCacheSites();
 
-        return sites.Select(s => new SitePreview(s.Id, s.Name, s.OdsCode));
+        return sites.Select(s => new SitePreview(s.Id, s.Name, s.OdsCode, s.IntegratedCareBoard));
     }
 
     public async Task<OperationResult> SaveSiteAsync(string siteId, string odsCode, string name, string address, string phoneNumber, string icb,

--- a/src/client/src/app/lib/components/site-list.test.tsx
+++ b/src/client/src/app/lib/components/site-list.test.tsx
@@ -38,8 +38,8 @@ describe('<SiteList>', () => {
       },
     ];
     render(<SiteList sites={testSites} />);
-    expect(screen.queryByRole('link', { name: 'Site Alpha' })).toBeVisible();
-    expect(screen.queryByRole('link', { name: 'Site Beta' })).toBeVisible();
+    expect(screen.queryByRole('cell', { name: 'Site Alpha' })).toBeVisible();
+    expect(screen.queryByRole('cell', { name: 'Site Beta' })).toBeVisible();
   });
 
   it('renders sites in ascending alphabetical order', async () => {
@@ -106,12 +106,20 @@ describe('<SiteList>', () => {
       },
     ];
     render(<SiteList sites={testSites} />);
-    const siteNames = within(screen.getByRole('list')).getAllByRole('listitem');
-    expect(siteNames).toHaveLength(4);
-    expect(siteNames[0]?.textContent).toEqual('Site Beta');
-    expect(siteNames[1]?.textContent).toEqual('Site Lima');
-    expect(siteNames[2]?.textContent).toEqual('Site November');
-    expect(siteNames[3]?.textContent).toEqual('Site Zulu');
+    const rows = screen.getAllByRole('row');
+    const dataRows = rows.slice(1);
+
+    const firstCell = within(dataRows[0]).getAllByRole('cell')[0];
+    expect(within(firstCell).getByText('Site Beta')).toBeInTheDocument();
+
+    const secondCell = within(dataRows[1]).getAllByRole('cell')[0];
+    expect(within(secondCell).getByText('Site Lima')).toBeInTheDocument();
+
+    const thirdCell = within(dataRows[2]).getAllByRole('cell')[0];
+    expect(within(thirdCell).getByText('Site November')).toBeInTheDocument();
+
+    const fourthCell = within(dataRows[3]).getAllByRole('cell')[0];
+    expect(within(fourthCell).getByText('Site Zulu')).toBeInTheDocument();
   });
 
   it('links to the correct page', async () => {
@@ -133,7 +141,7 @@ describe('<SiteList>', () => {
       },
     ];
     render(<SiteList sites={testSites} />);
-    expect(screen.getByRole('link', { name: 'Site Alpha' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'View' })).toHaveAttribute(
       'href',
       '/site/95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
     );
@@ -204,8 +212,13 @@ describe('<SiteList>', () => {
     ];
     const { user } = render(<SiteList sites={testSites} />);
 
-    const siteNames = within(screen.getByRole('list')).getAllByRole('listitem');
-    expect(siteNames).toHaveLength(4);
+    expect(screen.getAllByRole('row')).toHaveLength(5);
+    expect(screen.getByRole('cell', { name: 'Site Zulu' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Site Lima' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', { name: 'Site November' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Site Beta' })).toBeInTheDocument();
 
     const searchInput = screen.getByRole('textbox', {
       name: 'site-search',
@@ -213,11 +226,13 @@ describe('<SiteList>', () => {
     await user.type(searchInput, 'Beta');
 
     await waitFor(() => {
-      const filteredSites = within(screen.getByRole('list')).getAllByRole(
-        'listitem',
-      );
-      expect(filteredSites).toHaveLength(1);
-      expect(filteredSites[0]?.textContent).toBe('Site Beta');
+      const rows = screen.getAllByRole('row');
+      // Skip header row
+      const dataRows = rows.slice(1);
+      expect(dataRows).toHaveLength(1);
+
+      const firstCell = within(dataRows[0]).getAllByRole('cell')[0];
+      expect(within(firstCell).getByText('Site Beta')).toBeInTheDocument();
     });
   });
 
@@ -286,8 +301,13 @@ describe('<SiteList>', () => {
     ];
     const { user } = render(<SiteList sites={testSites} />);
 
-    const siteNames = within(screen.getByRole('list')).getAllByRole('listitem');
-    expect(siteNames).toHaveLength(4);
+    expect(screen.getAllByRole('row')).toHaveLength(5);
+    expect(screen.getByRole('cell', { name: 'Site Zulu' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Site Lima' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', { name: 'Site November' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Site Beta' })).toBeInTheDocument();
 
     const searchInput = screen.getByRole('textbox', {
       name: 'site-search',
@@ -295,10 +315,10 @@ describe('<SiteList>', () => {
     await user.type(searchInput, 'Be');
 
     await waitFor(() => {
-      const filteredSites = within(screen.getByRole('list')).getAllByRole(
-        'listitem',
-      );
-      expect(filteredSites).toHaveLength(4);
+      const rows = screen.getAllByRole('row');
+      // Skip header row
+      const dataRows = rows.slice(1);
+      expect(dataRows).toHaveLength(4);
     });
   });
 
@@ -367,8 +387,13 @@ describe('<SiteList>', () => {
     ];
     const { user } = render(<SiteList sites={testSites} />);
 
-    const siteNames = within(screen.getByRole('list')).getAllByRole('listitem');
-    expect(siteNames).toHaveLength(4);
+    expect(screen.getAllByRole('row')).toHaveLength(5);
+    expect(screen.getByRole('cell', { name: 'Site Zulu' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Site Lima' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', { name: 'Site November' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Site Beta' })).toBeInTheDocument();
 
     const searchInput = screen.getByRole('textbox', {
       name: 'site-search',
@@ -376,11 +401,13 @@ describe('<SiteList>', () => {
     await user.type(searchInput, '1004');
 
     await waitFor(() => {
-      const filteredSites = within(screen.getByRole('list')).getAllByRole(
-        'listitem',
-      );
-      expect(filteredSites).toHaveLength(1);
-      expect(filteredSites[0]?.textContent).toBe('Site Beta');
+      const rows = screen.getAllByRole('row');
+      // Skip header row
+      const dataRows = rows.slice(1);
+      expect(dataRows).toHaveLength(1);
+
+      const firstCell = within(dataRows[0]).getAllByRole('cell')[0];
+      expect(within(firstCell).getByText('Site Beta')).toBeInTheDocument();
     });
   });
 
@@ -449,8 +476,13 @@ describe('<SiteList>', () => {
     ];
     const { user } = render(<SiteList sites={testSites} />);
 
-    const siteNames = within(screen.getByRole('list')).getAllByRole('listitem');
-    expect(siteNames).toHaveLength(4);
+    expect(screen.getAllByRole('row')).toHaveLength(5);
+    expect(screen.getByRole('cell', { name: 'Site Zulu' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Site Lima' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', { name: 'Site November' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Site Beta' })).toBeInTheDocument();
 
     const searchInput = screen.getByRole('textbox', {
       name: 'site-search',
@@ -458,10 +490,7 @@ describe('<SiteList>', () => {
     await user.type(searchInput, '1005');
 
     await waitFor(() => {
-      const filteredSites = within(screen.getByRole('list')).queryAllByRole(
-        'listitem',
-      );
-      expect(filteredSites).toHaveLength(0);
+      expect(screen.getAllByRole('row')).toHaveLength(1);
     });
   });
 });

--- a/src/client/src/app/lib/components/site-list.tsx
+++ b/src/client/src/app/lib/components/site-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { Site } from '@types';
-import { Card, TextInput } from '@nhsuk-frontend-components';
+import { Table, TextInput } from '@nhsuk-frontend-components';
 import { sortSitesByName } from '@sorting';
 import { ChangeEvent, useState } from 'react';
 import { debounce } from '../utils/debounce';
@@ -32,27 +32,27 @@ const SiteList = ({ sites }: Props) => {
   const debounceSearchHandler = debounce(handleInputChange, 300);
 
   return (
-    <Card title="Choose a site">
+    <>
       <TextInput
         id="site-search"
         aria-label="site-search"
         placeholder="Search"
         onChange={debounceSearchHandler}
       ></TextInput>
-      <ul className="nhsuk-list nhsuk-list--border">
-        {filteredSites.map(s => (
-          <li key={s.id}>
-            <Link
-              aria-label={s.name}
-              className="nhsuk-back-link__link"
-              href={`/site/${s.id}`}
-            >
-              {s.name}
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </Card>
+      <Table
+        headers={['Name', 'ICB', 'ODS', 'Action']}
+        rows={filteredSites.map(site => {
+          return [
+            site.name,
+            site.integratedCareBoard,
+            site.odsCode,
+            <Link key={site.id} href={`/site/${site.id}`}>
+              View
+            </Link>,
+          ];
+        })}
+      />
+    </>
   );
 };
 

--- a/src/client/src/app/sites/sites-page.test.tsx
+++ b/src/client/src/app/sites/sites-page.test.tsx
@@ -1,5 +1,5 @@
 import { SitesPage } from './sites-page';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { mockSites } from '@testing/data';
 
 describe('Sites Page', () => {
@@ -7,29 +7,50 @@ describe('Sites Page', () => {
     render(<SitesPage sites={mockSites} />);
 
     expect(
-      screen.getByRole('heading', { name: 'Choose a site' }),
+      screen.getByRole('columnheader', { name: 'Name' }),
     ).toBeInTheDocument();
-
     expect(
-      screen.getByRole('link', { name: 'Site Alpha' }),
+      screen.getByRole('columnheader', { name: 'ICB' }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Site Alpha' })).toHaveAttribute(
-      'href',
-      `/site/34e990af-5dc9-43a6-8895-b9123216d699`,
-    );
-
-    expect(screen.getByRole('link', { name: 'Site Beta' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Site Beta' })).toHaveAttribute(
-      'href',
-      `/site/95e4ca69-da15-45f5-9ec7-6b2ea50f07c8`,
-    );
-
     expect(
-      screen.getByRole('link', { name: 'Site Gamma' }),
+      screen.getByRole('columnheader', { name: 'ODS' }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Site Gamma' })).toHaveAttribute(
-      'href',
-      `/site/d79bec60-8968-4101-b553-67dec04e1019`,
-    );
+
+    const rows = screen.getAllByRole('row');
+    const dataRows = rows.slice(1);
+
+    expect(dataRows).toHaveLength(4);
+
+    const firstRow = dataRows[0];
+    expect(within(firstRow).getByText('Site Alpha')).toBeInTheDocument();
+    expect(within(firstRow).getByText('ICB1')).toBeInTheDocument();
+    expect(within(firstRow).getByText('1001')).toBeInTheDocument();
+    expect(
+      within(firstRow).getByRole('link', { name: 'View' }),
+    ).toHaveAttribute('href', `/site/34e990af-5dc9-43a6-8895-b9123216d699`);
+
+    const secondRow = dataRows[1];
+    expect(within(secondRow).getByText('Site Beta')).toBeInTheDocument();
+    expect(within(secondRow).getByText('ICB2')).toBeInTheDocument();
+    expect(within(secondRow).getByText('1002')).toBeInTheDocument();
+    expect(
+      within(secondRow).getByRole('link', { name: 'View' }),
+    ).toHaveAttribute('href', `/site/95e4ca69-da15-45f5-9ec7-6b2ea50f07c8`);
+
+    const thirdRow = dataRows[2];
+    expect(within(thirdRow).getByText('Site Delta')).toBeInTheDocument();
+    expect(within(thirdRow).getByText('ICB4')).toBeInTheDocument();
+    expect(within(thirdRow).getByText('1004')).toBeInTheDocument();
+    expect(
+      within(thirdRow).getByRole('link', { name: 'View' }),
+    ).toHaveAttribute('href', `/site/90a9c1f2-83d0-4c40-9c7c-080d91c56e79`);
+
+    const fourthRow = dataRows[3];
+    expect(within(fourthRow).getByText('Site Gamma')).toBeInTheDocument();
+    expect(within(fourthRow).getByText('ICB3')).toBeInTheDocument();
+    expect(within(fourthRow).getByText('1003')).toBeInTheDocument();
+    expect(
+      within(fourthRow).getByRole('link', { name: 'View' }),
+    ).toHaveAttribute('href', `/site/d79bec60-8968-4101-b553-67dec04e1019`);
   });
 });

--- a/src/client/testing/page-objects/site-selection.ts
+++ b/src/client/testing/page-objects/site-selection.ts
@@ -4,7 +4,6 @@ import { Site } from '@types';
 
 export default class SiteSelectionPage extends RootPage {
   readonly title: Locator;
-  readonly siteSelectionCardHeading: Locator;
   readonly noSitesMessage: Locator;
 
   constructor(page: Page) {
@@ -12,16 +11,14 @@ export default class SiteSelectionPage extends RootPage {
     this.title = page.getByRole('heading', {
       name: 'Manage your appointments',
     });
-    this.siteSelectionCardHeading = page.getByRole('heading', {
-      name: 'Choose a site',
-    });
     this.noSitesMessage = page.getByText(
       'You have not been assigned to any sites.',
     );
   }
 
   async selectSite(site: Site) {
-    await this.page.getByRole('link', { name: site.name }).click();
+    const row = this.page.getByRole('row', { name: site.name });
+    await row.getByRole('link', { name: 'View' }).click();
     await this.page.waitForURL(`**/site/${site.id}`);
   }
 }

--- a/src/client/testing/tests/home.spec.ts
+++ b/src/client/testing/tests/home.spec.ts
@@ -24,8 +24,8 @@ test('A user loads home page, only sites with same scope are loaded', async ({
 }) => {
   const user6 = getTestUser(6);
   await oAuthPage.signIn(user6);
-  await expect(page.getByRole('link', { name: site2.name })).not.toBeVisible();
-  await expect(page.getByRole('link', { name: site1.name })).toBeVisible();
+  await expect(page.getByRole('cell', { name: site2.name })).not.toBeVisible();
+  await expect(page.getByRole('cell', { name: site1.name })).toBeVisible();
 });
 
 test('An admin user loads home page, all sites are loaded', async ({
@@ -33,8 +33,8 @@ test('An admin user loads home page, all sites are loaded', async ({
   getTestUser,
 }) => {
   await oAuthPage.signIn(getTestUser(7));
-  await expect(page.getByRole('link', { name: site2.name })).toBeVisible();
-  await expect(page.getByRole('link', { name: site1.name })).toBeVisible();
+  await expect(page.getByRole('cell', { name: site2.name })).toBeVisible();
+  await expect(page.getByRole('cell', { name: site1.name })).toBeVisible();
 });
 
 test('A user loads home page and searches for a site, site list is filtered', async ({
@@ -43,10 +43,10 @@ test('A user loads home page and searches for a site, site list is filtered', as
 }) => {
   await oAuthPage.signIn(getTestUser(6));
   await expect(
-    page.getByRole('link', { name: 'Church Lane Pharmacy' }),
+    page.getByRole('cell', { name: 'Church Lane Pharmacy' }),
   ).not.toBeVisible();
   await expect(
-    page.getByRole('link', { name: 'Robin Lane Medical Centre' }),
+    page.getByRole('cell', { name: 'Robin Lane Medical Centre' }),
   ).toBeVisible();
 
   const searchInput = page.getByRole('textbox', {
@@ -54,6 +54,6 @@ test('A user loads home page and searches for a site, site list is filtered', as
   });
   await searchInput.fill('Church');
   await expect(
-    page.getByRole('link', { name: 'Robin Lane Medical Centre' }),
+    page.getByRole('cell', { name: 'Robin Lane Medical Centre' }),
   ).not.toBeVisible();
 });

--- a/src/client/testing/tests/okta-toggle.spec.ts
+++ b/src/client/testing/tests/okta-toggle.spec.ts
@@ -47,7 +47,7 @@ test.describe.configure({ mode: 'serial' });
         await oAuthPage.signIn();
 
         await expect(rootPage.logOutButton).toBeVisible();
-        await expect(siteSelectionPage.siteSelectionCardHeading).toBeVisible();
+        await expect(siteSelectionPage.title).toBeVisible();
       });
 
       test('User visits the site origin, signs in, then signs out again', async ({
@@ -62,7 +62,7 @@ test.describe.configure({ mode: 'serial' });
         await oAuthPage.signIn();
 
         await expect(rootPage.logOutButton).toBeVisible();
-        await expect(siteSelectionPage.siteSelectionCardHeading).toBeVisible();
+        await expect(siteSelectionPage.title).toBeVisible();
 
         await expect(siteSelectionPage.logOutButton).toBeVisible();
         await siteSelectionPage.logOutButton.click();

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesPreviewFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesPreviewFunctionTests.cs
@@ -89,7 +89,7 @@ public class GetSitesPreviewFunctionTests
         {
             new() { Role = "Role1", Scope = "site:1" }, new() { Role = "system:admin-user", Scope = "global" }
         };
-        var sitesPreview = new SitePreview[] { new("1", "Site1", "ODS1"), new("2", "Site2", "ODS2"), };
+        var sitesPreview = new SitePreview[] { new("1", "Site1", "ODS1", "ICB1"), new("2", "Site2", "ODS2", "ICB1"), };
         _userContextProvider.Setup(x => x.UserPrincipal).Returns(testPrincipal);
         _userSiteAssignmentService.Setup(x => x.GetUserAsync("test@test.com")).ReturnsAsync(new User
         {


### PR DESCRIPTION
# Description

- Adding additional data to the site list page - ICB & ODS Codes
- Re-design to a table with an action column and a 'View' link to navigate into the site
- There are future tickets planned to further change this page including adding pagination and re-designing the search bar (APPT-870)

![image](https://github.com/user-attachments/assets/22865676-50c2-4c1b-8960-d4e2e1397165)

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
