### PR TITLE
APPT-1021 Orphaned total is double counted bug fix

### DIFF
--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_35.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_35.json
@@ -3,7 +3,7 @@
   "from": "2025-08-20T11:25:00",
   "duration": 5,
   "service": "COVID_FLU:18_64",
-  "created": "2025-10-21T06:23:46.654321+00:00",
+  "created": "2025-07-21T06:23:46.654321+00:00",
   "status": "Booked",
   "availabilityStatus": "Orphaned",
   "statusUpdated": "0001-01-01T00:00:00+00:00",

--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_35.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_35.json
@@ -1,0 +1,28 @@
+{
+  "reference": "seed-booking-reference-35",
+  "from": "2025-08-20T11:25:00",
+  "duration": 5,
+  "service": "COVID_FLU:18_64",
+  "created": "2025-10-21T06:23:46.654321+00:00",
+  "status": "Booked",
+  "availabilityStatus": "Orphaned",
+  "statusUpdated": "0001-01-01T00:00:00+00:00",
+  "attendeeDetails": {
+    "nhsNumber": "1975486535",
+    "firstName": "Jeremy",
+    "lastName": "Oswald",
+    "dateOfBirth": "1952-11-13"
+  },
+  "contactDetails": [],
+  "additionalData": {
+    "isCallCentreBooking": true,
+    "callCentreHandlerEmail": "test@example.com",
+    "isAppBooking": false,
+    "selfReferralOccupation": "test",
+    "decisionReason": "test"
+  },
+  "reminderSent": false,
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
+  "id": "seed-booking-reference-35",
+  "docType": "booking"
+}

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_35_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_35_index.json
@@ -1,7 +1,7 @@
 {
   "reference": "seed-booking-reference-35",
   "from": "2025-08-20T11:25:00",
-  "created": "2025-10-25T06:23:46.654321+00:00",
+  "created": "2025-07-25T06:23:46.654321+00:00",
   "status": "Booked",
   "nhsNumber": "1975486535",
   "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",

--- a/data/CosmosDbSeeder/items/local/index_data/seed_booking_35_index.json
+++ b/data/CosmosDbSeeder/items/local/index_data/seed_booking_35_index.json
@@ -1,0 +1,10 @@
+{
+  "reference": "seed-booking-reference-35",
+  "from": "2025-08-20T11:25:00",
+  "created": "2025-10-25T06:23:46.654321+00:00",
+  "status": "Booked",
+  "nhsNumber": "1975486535",
+  "site": "6877d86e-c2df-4def-8508-e1eccf0ea6be",
+  "id": "seed-booking-reference-35",
+  "docType": "booking_index"
+}

--- a/src/api/Nhs.Appointments.Core/BookingAvailabilityStateService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingAvailabilityStateService.cs
@@ -162,19 +162,23 @@ public class BookingAvailabilityStateService(
 
             foreach (var booking in bookingsOnDay)
             {
-                if (booking.Status == AppointmentStatus.Booked)
+                switch (booking.Status)
                 {
-                    daySummary.BookedAppointments++;
-                }
+                    case AppointmentStatus.Booked:
+                        switch (booking.AvailabilityStatus)
+                        {
+                            case AvailabilityStatus.Supported:
+                                daySummary.BookedAppointments++;
+                                break;
+                            case AvailabilityStatus.Orphaned:
+                                daySummary.OrphanedAppointments++;
+                                break;
+                        }
 
-                if (booking.Status == AppointmentStatus.Booked && booking.AvailabilityStatus == AvailabilityStatus.Orphaned)
-                {
-                    daySummary.OrphanedAppointments++;
-                }
-
-                if (booking.Status == AppointmentStatus.Cancelled)
-                {
-                    daySummary.CancelledAppointments++;
+                        break;
+                    case AppointmentStatus.Cancelled:
+                        daySummary.CancelledAppointments++;
+                        break;
                 }
             }
         }

--- a/src/client/testing/availability.ts
+++ b/src/client/testing/availability.ts
@@ -17,6 +17,7 @@ export type DayOverview = {
   totalAppointments: number;
   booked: number;
   unbooked: number;
+  orphaned: number;
 };
 
 export type DaySessionOverview = {
@@ -374,6 +375,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Tuesday 21 October',
@@ -381,6 +383,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Wednesday 22 October',
@@ -388,6 +391,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Thursday 23 October',
@@ -395,6 +399,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Friday 24 October',
@@ -402,6 +407,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Saturday 25 October',
@@ -416,6 +422,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 420,
         booked: 2,
         unbooked: 418,
+        orphaned: 0,
       },
       {
         header: 'Sunday 26 October',
@@ -430,6 +437,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 420,
         booked: 2,
         unbooked: 418,
+        orphaned: 0,
       },
     ],
   },
@@ -452,6 +460,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 420,
         booked: 2,
         unbooked: 418,
+        orphaned: 0,
       },
       {
         header: 'Tuesday 28 October',
@@ -459,6 +468,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Wednesday 29 October',
@@ -466,6 +476,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Thursday 30 October',
@@ -473,6 +484,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Friday 31 October',
@@ -480,6 +492,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Saturday 1 November',
@@ -487,6 +500,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Sunday 2 November',
@@ -494,6 +508,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
     ],
   },
@@ -509,6 +524,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Tuesday 24 March',
@@ -516,6 +532,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Wednesday 25 March',
@@ -523,6 +540,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Thursday 26 March',
@@ -530,6 +548,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Friday 27 March',
@@ -537,6 +556,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Saturday 28 March',
@@ -551,6 +571,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 240,
         booked: 2,
         unbooked: 238,
+        orphaned: 0,
       },
       {
         header: 'Sunday 29 March',
@@ -565,6 +586,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 240,
         booked: 2,
         unbooked: 238,
+        orphaned: 0,
       },
     ],
   },
@@ -587,6 +609,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 240,
         booked: 2,
         unbooked: 238,
+        orphaned: 0,
       },
       {
         header: 'Tuesday 31 March',
@@ -594,6 +617,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Wednesday 1 April',
@@ -601,6 +625,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Thursday 2 April',
@@ -608,6 +633,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Friday 3 April',
@@ -615,6 +641,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Saturday 4 April',
@@ -622,6 +649,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
       {
         header: 'Sunday 5 April',
@@ -629,6 +657,7 @@ export const weekTestCases: WeekViewTestCase[] = [
         totalAppointments: 0,
         booked: 0,
         unbooked: 0,
+        orphaned: 0,
       },
     ],
   },

--- a/src/client/testing/tests/availability/availability.spec.ts
+++ b/src/client/testing/tests/availability/availability.spec.ts
@@ -1170,21 +1170,27 @@ test.describe.configure({ mode: 'serial' });
         });
 
         await weekViewAvailabilityPage.verifySessionDataDisplayedInTheCorrectOrder(
-          'Wednesday 20 August',
-          [
-            {
-              serviceName: 'COVID 5-11RSV AdultFlu 18-64COVID 18+',
-              booked: '0 booked0 booked0 booked0 booked',
-              unbooked: 24,
-              sessionTimeInterval: '11:00 - 12:00',
-            },
-            {
-              serviceName: 'COVID 5-11Flu 18-64RSV Adult',
-              booked: '1 booked1 booked0 booked',
-              unbooked: 12,
-              sessionTimeInterval: '11:15 - 11:50',
-            },
-          ],
+          {
+            header: 'Wednesday 20 August',
+            booked: 3,
+            unbooked: 36,
+            orphaned: 1,
+            totalAppointments: 38,
+            sessions: [
+              {
+                serviceName: 'COVID 5-11RSV AdultFlu 18-64COVID 18+',
+                booked: '0 booked0 booked0 booked0 booked',
+                unbooked: 24,
+                sessionTimeInterval: '11:00 - 12:00',
+              },
+              {
+                serviceName: 'COVID 5-11Flu 18-64RSV Adult',
+                booked: '1 booked1 booked0 booked',
+                unbooked: 12,
+                sessionTimeInterval: '11:15 - 11:50',
+              },
+            ],
+          },
         );
 
         //create some new availability to show shuffling
@@ -1204,27 +1210,33 @@ test.describe.configure({ mode: 'serial' });
         );
 
         await weekViewAvailabilityPage.verifySessionDataDisplayedInTheCorrectOrder(
-          'Wednesday 20 August',
-          [
-            {
-              serviceName: 'COVID 5-11RSV AdultFlu 18-64COVID 18+',
-              booked: '0 booked0 booked0 booked0 booked',
-              unbooked: 24,
-              sessionTimeInterval: '11:00 - 12:00',
-            },
-            {
-              serviceName: 'COVID 5-11Flu 18-64RSV Adult',
-              booked: '1 booked0 booked0 booked',
-              unbooked: 13,
-              sessionTimeInterval: '11:15 - 11:50',
-            },
-            {
-              serviceName: 'Flu 18-64',
-              booked: '1 booked',
-              unbooked: 47,
-              sessionTimeInterval: '10:00 - 12:00',
-            },
-          ],
+          {
+            header: 'Wednesday 20 August',
+            booked: 3,
+            unbooked: 84,
+            orphaned: 1,
+            totalAppointments: 86,
+            sessions: [
+              {
+                serviceName: 'COVID 5-11RSV AdultFlu 18-64COVID 18+',
+                booked: '0 booked0 booked0 booked0 booked',
+                unbooked: 24,
+                sessionTimeInterval: '11:00 - 12:00',
+              },
+              {
+                serviceName: 'COVID 5-11Flu 18-64RSV Adult',
+                booked: '1 booked0 booked0 booked',
+                unbooked: 13,
+                sessionTimeInterval: '11:15 - 11:50',
+              },
+              {
+                serviceName: 'Flu 18-64',
+                booked: '1 booked',
+                unbooked: 47,
+                sessionTimeInterval: '10:00 - 12:00',
+              },
+            ],
+          },
         );
 
         //create some new availability to show shuffling
@@ -1244,33 +1256,39 @@ test.describe.configure({ mode: 'serial' });
         );
 
         await weekViewAvailabilityPage.verifySessionDataDisplayedInTheCorrectOrder(
-          'Wednesday 20 August',
-          [
-            {
-              serviceName: 'COVID 5-11RSV AdultFlu 18-64COVID 18+',
-              booked: '0 booked0 booked0 booked0 booked',
-              unbooked: 24,
-              sessionTimeInterval: '11:00 - 12:00',
-            },
-            {
-              serviceName: 'COVID 5-11Flu 18-64RSV Adult',
-              booked: '0 booked0 booked0 booked',
-              unbooked: 14,
-              sessionTimeInterval: '11:15 - 11:50',
-            },
-            {
-              serviceName: 'Flu 18-64',
-              booked: '1 booked',
-              unbooked: 47,
-              sessionTimeInterval: '10:00 - 12:00',
-            },
-            {
-              serviceName: 'COVID 5-11Flu 18-64',
-              booked: '1 booked0 booked',
-              unbooked: 19,
-              sessionTimeInterval: '11:05 - 11:55',
-            },
-          ],
+          {
+            header: 'Wednesday 20 August',
+            booked: 3,
+            unbooked: 104,
+            orphaned: 1,
+            totalAppointments: 106,
+            sessions: [
+              {
+                serviceName: 'COVID 5-11RSV AdultFlu 18-64COVID 18+',
+                booked: '0 booked0 booked0 booked0 booked',
+                unbooked: 24,
+                sessionTimeInterval: '11:00 - 12:00',
+              },
+              {
+                serviceName: 'COVID 5-11Flu 18-64RSV Adult',
+                booked: '0 booked0 booked0 booked',
+                unbooked: 14,
+                sessionTimeInterval: '11:15 - 11:50',
+              },
+              {
+                serviceName: 'Flu 18-64',
+                booked: '1 booked',
+                unbooked: 47,
+                sessionTimeInterval: '10:00 - 12:00',
+              },
+              {
+                serviceName: 'COVID 5-11Flu 18-64',
+                booked: '1 booked0 booked',
+                unbooked: 19,
+                sessionTimeInterval: '11:05 - 11:55',
+              },
+            ],
+          },
         );
 
         //remove the single Flu session
@@ -1316,27 +1334,33 @@ test.describe.configure({ mode: 'serial' });
         });
 
         await weekViewAvailabilityPage.verifySessionDataDisplayedInTheCorrectOrder(
-          'Wednesday 20 August',
-          [
-            {
-              serviceName: 'COVID 5-11RSV AdultFlu 18-64COVID 18+',
-              booked: '0 booked0 booked0 booked0 booked',
-              unbooked: 24,
-              sessionTimeInterval: '11:00 - 12:00',
-            },
-            {
-              serviceName: 'COVID 5-11Flu 18-64RSV Adult',
-              booked: '0 booked0 booked0 booked',
-              unbooked: 14,
-              sessionTimeInterval: '11:15 - 11:50',
-            },
-            {
-              serviceName: 'COVID 5-11Flu 18-64',
-              booked: '1 booked1 booked',
-              unbooked: 18,
-              sessionTimeInterval: '11:05 - 11:55',
-            },
-          ],
+          {
+            header: 'Wednesday 20 August',
+            booked: 3,
+            unbooked: 56,
+            orphaned: 1,
+            totalAppointments: 58,
+            sessions: [
+              {
+                serviceName: 'COVID 5-11RSV AdultFlu 18-64COVID 18+',
+                booked: '0 booked0 booked0 booked0 booked',
+                unbooked: 24,
+                sessionTimeInterval: '11:00 - 12:00',
+              },
+              {
+                serviceName: 'COVID 5-11Flu 18-64RSV Adult',
+                booked: '0 booked0 booked0 booked',
+                unbooked: 14,
+                sessionTimeInterval: '11:15 - 11:50',
+              },
+              {
+                serviceName: 'COVID 5-11Flu 18-64',
+                booked: '1 booked1 booked',
+                unbooked: 18,
+                sessionTimeInterval: '11:05 - 11:55',
+              },
+            ],
+          },
         );
       });
 

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/WeekSummary_MultipleServices.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/WeekSummary_MultipleServices.feature
@@ -64,16 +64,16 @@
     When I query week summary for the current site on 'Next Monday'
     Then the following week summary metrics are returned
       | Maximum Capacity | Remaining Capacity | Booked Appointments | Orphaned Appointments | Cancelled Appointments |
-      | 168              | 147                | 28                  | 7                     | 0                      |
+      | 168              | 147                | 21                  | 7                     | 0                      |
     And the following day summary metrics are returned
       | Date             | Maximum Capacity | Remaining Capacity | Booked Appointments | Orphaned Appointments | Cancelled Appointments |
-      | Next Monday      | 24               | 21                 | 4                   | 1                     | 0                      |
-      | Next Tuesday     | 24               | 21                 | 4                   | 1                     | 0                      |
-      | Next Wednesday   | 24               | 21                 | 4                   | 1                     | 0                      |
-      | Next Thursday    | 24               | 21                 | 4                   | 1                     | 0                      |
-      | Next Friday      | 24               | 21                 | 4                   | 1                     | 0                      |
-      | Next Saturday    | 24               | 21                 | 4                   | 1                     | 0                      |
-      | Next Sunday      | 24               | 21                 | 4                   | 1                     | 0                      |
+      | Next Monday      | 24               | 21                 | 3                   | 1                     | 0                      |
+      | Next Tuesday     | 24               | 21                 | 3                   | 1                     | 0                      |
+      | Next Wednesday   | 24               | 21                 | 3                   | 1                     | 0                      |
+      | Next Thursday    | 24               | 21                 | 3                   | 1                     | 0                      |
+      | Next Friday      | 24               | 21                 | 3                   | 1                     | 0                      |
+      | Next Saturday    | 24               | 21                 | 3                   | 1                     | 0                      |
+      | Next Sunday      | 24               | 21                 | 3                   | 1                     | 0                      |
     And the following session summaries on day 'Next Monday' are returned
       | StartDate      | Start Time | End Time | Bookings                                          | Capacity | Slot Length | Maximum Capacity |
       | Next Monday    | 09:00      | 10:00    | COVID:0, RSV:0, FLU:0, FLU-C:0, FLU-D:0, FLU-E:0  | 1        | 10          | 6                |

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingAvailabilityState/GetWeekSummaryTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingAvailabilityState/GetWeekSummaryTests.cs
@@ -38,7 +38,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
 
         weekSummary.MaximumCapacity.Should().Be(30);
         weekSummary.RemainingCapacity.Should().Be(25);
-        weekSummary.BookedAppointments.Should().Be(7);
+        weekSummary.BookedAppointments.Should().Be(5);
         weekSummary.OrphanedAppointments.Should().Be(2);
         weekSummary.CancelledAppointments.Should().Be(2);
 
@@ -93,7 +93,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
             {
                 MaximumCapacity = 30,
                 RemainingCapacity = 25,
-                BookedAppointments = 7,
+                BookedAppointments = 5,
                 OrphanedAppointments = 2,
                 CancelledAppointments = 2
             });
@@ -420,7 +420,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
         weekSummary.RemainingCapacity.Should().Be(165);
         
         //lost utilisation shows that 6/12 bookings are orphaned when they could have been allocated
-        weekSummary.BookedAppointments.Should().Be(12);
+        weekSummary.BookedAppointments.Should().Be(6);
         weekSummary.OrphanedAppointments.Should().Be(6);
         
         weekSummary.CancelledAppointments.Should().Be(0);
@@ -474,7 +474,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
             {
                 MaximumCapacity = 35,
                 RemainingCapacity = 32,
-                BookedAppointments = 6,
+                BookedAppointments = 3,
                 OrphanedAppointments = 3,
                 CancelledAppointments = 0
             });
@@ -531,7 +531,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
             {
                 MaximumCapacity = 64,
                 RemainingCapacity = 61,
-                BookedAppointments = 6,
+                BookedAppointments = 3,
                 OrphanedAppointments = 3,
                 CancelledAppointments = 0
             });
@@ -610,7 +610,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
         weekSummary.RemainingCapacity.Should().Be(58);
         
         //only half supported
-        weekSummary.BookedAppointments.Should().Be(12);
+        weekSummary.BookedAppointments.Should().Be(6);
         weekSummary.OrphanedAppointments.Should().Be(6);
         
         weekSummary.CancelledAppointments.Should().Be(0);
@@ -646,7 +646,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
             {
                 MaximumCapacity = 32,
                 RemainingCapacity = 29,
-                BookedAppointments = 6,
+                BookedAppointments = 3,
                 OrphanedAppointments = 3,
                 CancelledAppointments = 0
             });
@@ -688,7 +688,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
             {
                 MaximumCapacity = 32,
                 RemainingCapacity = 29,
-                BookedAppointments = 6,
+                BookedAppointments = 3,
                 OrphanedAppointments = 3,
                 CancelledAppointments = 0
             });


### PR DESCRIPTION
# Description

In the front end, the booked metric is both the supported bookings and the orphaned. I reflected this in my API metric. But the UI adds these two together, so its easier for me to only count supported bookings in the API for consistency and keep allowing the front end to add the two totals together. 

Fixes # (issue)

# Checklist:

- [x] My work is behind a feature toggle (if appropriate)
- [x] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [x] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [x] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
