### PR TITLE
Appt 923 - Daily appointments page permission

### DIFF
--- a/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
@@ -9,7 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -23,7 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -36,7 +36,7 @@
       "description": "A user can edit site details and accessibility information.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -50,7 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -65,7 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -100,7 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/dev/core_data/global_roles.json
@@ -9,6 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -22,6 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -34,6 +36,7 @@
       "description": "A user can edit site details and accessibility information.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -47,6 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -61,6 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -95,6 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/data/CosmosDbSeeder/items/int/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/int/core_data/global_roles.json
@@ -9,7 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -23,7 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -37,7 +37,7 @@
       "permissions": [
         "availability:query",
         "booking:query",
-        "booking:list-view",
+        "booking:view-detail",
         "site:view",
         "site:view:preview",
         "site:manage",
@@ -50,7 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -65,7 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -100,7 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/data/CosmosDbSeeder/items/int/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/int/core_data/global_roles.json
@@ -9,6 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -22,6 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -35,6 +37,7 @@
       "permissions": [
         "availability:query",
         "booking:query",
+        "booking:list-view",
         "site:view",
         "site:view:preview",
         "site:manage",
@@ -47,6 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -61,6 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -95,6 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/data/CosmosDbSeeder/items/local/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/local/core_data/global_roles.json
@@ -9,6 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -22,6 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -34,6 +36,7 @@
       "description": "A user can edit site details and accessibility information.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -47,6 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -61,6 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -95,6 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:make",
         "booking:query",
         "booking:cancel",
@@ -117,6 +123,7 @@
       "permissions": [
         "site:get-meta-data",
         "availability:query",
+        "booking:list-view",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/data/CosmosDbSeeder/items/local/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/local/core_data/global_roles.json
@@ -9,7 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -23,7 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -36,7 +36,7 @@
       "description": "A user can edit site details and accessibility information.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -50,7 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -65,7 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -100,7 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:make",
         "booking:query",
         "booking:cancel",
@@ -123,7 +123,7 @@
       "permissions": [
         "site:get-meta-data",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
@@ -9,7 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -23,7 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -36,7 +36,7 @@
       "description": "A user can edit site details and accessibility information.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -50,7 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -65,7 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -100,7 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/prod/core_data/global_roles.json
@@ -9,6 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -22,6 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -34,6 +36,7 @@
       "description": "A user can edit site details and accessibility information.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -47,6 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -61,6 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -95,6 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
@@ -9,7 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -23,7 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -36,7 +36,7 @@
       "description": "A user can edit site details and accessibility information.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -50,7 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -65,7 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -100,7 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
-        "booking:list-view",
+        "booking:view-detail",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
+++ b/data/CosmosDbSeeder/items/stag/core_data/global_roles.json
@@ -9,6 +9,7 @@
       "permissions": [
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -22,6 +23,7 @@
       "permissions": [
         "availability:query",
         "booking:cancel",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -34,6 +36,7 @@
       "description": "A user can edit site details and accessibility information.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -47,6 +50,7 @@
       "description": "A user can view and manage user role assignments.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -61,6 +65,7 @@
       "description": "Admin user can view all areas that exist in MYA.",
       "permissions": [
         "availability:query",
+        "booking:list-view",
         "booking:query",
         "site:view",
         "site:view:preview",
@@ -95,6 +100,7 @@
         "site:get-meta-data",
         "availability:setup",
         "availability:query",
+        "booking:list-view",
         "booking:make",
         "booking:query",
         "booking:cancel",

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
@@ -24,7 +24,7 @@ type PageProps = {
 };
 
 const Page = async ({ params, searchParams }: PageProps) => {
-  await assertPermission(params.site, 'availability:query');
+  await assertPermission(params.site, 'booking:list-view');
 
   const fromDate = parseToUkDatetime(searchParams.date);
   const toDate = fromDate.endOf('day');

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/page.tsx
@@ -24,7 +24,7 @@ type PageProps = {
 };
 
 const Page = async ({ params, searchParams }: PageProps) => {
-  await assertPermission(params.site, 'booking:list-view');
+  await assertPermission(params.site, 'booking:view-detail');
 
   const fromDate = parseToUkDatetime(searchParams.date);
   const toDate = fromDate.endOf('day');

--- a/src/client/src/app/site/[site]/view-availability/week/day-card-list.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-card-list.tsx
@@ -61,7 +61,7 @@ export const DayCardList = async ({ site, ukWeekStart, ukWeekEnd }: Props) => {
   }
 
   const canManageAvailability = permissions.includes('availability:setup');
-  const canViewDailyAppointments = permissions.includes('booking:list-view');
+  const canViewDailyAppointments = permissions.includes('booking:view-detail');
 
   return (
     <ol className="card-list">

--- a/src/client/src/app/site/[site]/view-availability/week/day-card-list.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-card-list.tsx
@@ -61,6 +61,7 @@ export const DayCardList = async ({ site, ukWeekStart, ukWeekEnd }: Props) => {
   }
 
   const canManageAvailability = permissions.includes('availability:setup');
+  const canViewDailyAppointments = permissions.includes('booking:list-view');
 
   return (
     <ol className="card-list">
@@ -72,6 +73,7 @@ export const DayCardList = async ({ site, ukWeekStart, ukWeekEnd }: Props) => {
               siteId={site.id}
               canManageAvailability={canManageAvailability}
               clinicalServices={clinicalServices}
+              canViewDailyAppointments={canViewDailyAppointments}
             />
           </li>
         );

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
@@ -37,11 +37,15 @@ describe('Day Summary Card', () => {
         siteId={'mock-site'}
         canManageAvailability={true}
         clinicalServices={clinicalServices}
+        canViewDailyAppointments={true}
       />,
     );
 
     expect(
       screen.getByRole('heading', { name: 'Monday 2 December' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'View daily appointments' }),
     ).toBeInTheDocument();
   });
 
@@ -53,6 +57,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -75,6 +80,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -97,6 +103,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={false}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -121,6 +128,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -138,6 +146,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={false}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -153,6 +162,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -168,6 +178,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -183,6 +194,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -200,6 +212,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -217,6 +230,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -242,6 +256,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -259,6 +274,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -276,6 +292,25 @@ describe('Day Summary Card', () => {
         'daily-appointments?date=2024-12-02&page=1&tab=2',
       );
     });
+
+    it('hides the View Daily Appointments link when the user does not have permission', () => {
+      render(
+        <DaySummaryCard
+          daySummary={mockDaySummaries[0]}
+          siteId={'mock-site'}
+          canManageAvailability={true}
+          clinicalServices={clinicalServices}
+          canViewDailyAppointments={false}
+        />,
+      );
+
+      expect(
+        screen.getByRole('heading', { name: 'Monday 2 December' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: 'View daily appointments' }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('when there is no availability', () => {
@@ -286,6 +321,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -305,6 +341,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -324,6 +361,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -341,6 +379,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={false}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -358,6 +397,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -373,6 +413,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -388,6 +429,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -403,6 +445,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -418,6 +461,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -433,6 +477,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={false}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -451,6 +496,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={false}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -466,6 +512,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -491,6 +538,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -516,6 +564,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 
@@ -533,6 +582,7 @@ describe('Day Summary Card', () => {
           siteId={'mock-site'}
           canManageAvailability={true}
           clinicalServices={clinicalServices}
+          canViewDailyAppointments={true}
         />,
       );
 

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
@@ -13,6 +13,7 @@ type DaySummaryCardProps = {
   siteId: string;
   canManageAvailability: boolean;
   clinicalServices: ClinicalService[];
+  canViewDailyAppointments: boolean;
 };
 
 export const DaySummaryCard = ({
@@ -20,6 +21,7 @@ export const DaySummaryCard = ({
   siteId,
   canManageAvailability,
   clinicalServices,
+  canViewDailyAppointments,
 }: DaySummaryCardProps) => {
   const { ukDate, sessions, cancelledAppointments, orphanedAppointments } =
     daySummary;
@@ -53,7 +55,7 @@ export const DaySummaryCard = ({
   }
 
   const actionLinks: ActionLink[] = [
-    {
+    canViewDailyAppointments && {
       text: 'View daily appointments',
       href: `daily-appointments?date=${ukDate.format(dateFormat)}&page=1`,
     },


### PR DESCRIPTION
# Description

Added a new permission `booking:view-detail` and applied it to availability manager, appointment manager, site details manager, user manager and admin roles. It **has not** been applied to the regional manager role.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
