### PR TITLE
APPT-955 Reduce a sessions services - MVP journey

### DIFF
--- a/src/client/src/app/site/[site]/availability/edit-services/confirmed/edit-services-confirmed.test.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/confirmed/edit-services-confirmed.test.tsx
@@ -8,7 +8,7 @@ describe('Cancellation Confirmed Page', () => {
   it('renders the correct session in the table', () => {
     render(
       <EditServicesConfirmed
-        updatedSession={{
+        removedServicesSession={{
           from: '09:00',
           until: '12:00',
           services: ['RSV:Adult'],
@@ -29,7 +29,7 @@ describe('Cancellation Confirmed Page', () => {
   it('renders a link back to the cancel appointments page', () => {
     render(
       <EditServicesConfirmed
-        updatedSession={{
+        removedServicesSession={{
           from: '09:00',
           until: '12:00',
           services: ['RSV:Adult'],

--- a/src/client/src/app/site/[site]/availability/edit-services/confirmed/edit-services-confirmed.test.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/confirmed/edit-services-confirmed.test.tsx
@@ -1,0 +1,55 @@
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
+import EditServicesConfirmed from './edit-services-confirmed';
+import { mockSite } from '@testing/data';
+import { clinicalServices } from '@types';
+
+describe('Cancellation Confirmed Page', () => {
+  it('renders the correct session in the table', () => {
+    render(
+      <EditServicesConfirmed
+        updatedSession={{
+          from: '09:00',
+          until: '12:00',
+          services: ['RSV:Adult'],
+          capacity: 10,
+          slotLength: 5,
+        }}
+        date="2025-01-15"
+        clinicalServices={clinicalServices}
+        site={mockSite}
+      />,
+    );
+
+    expect(
+      screen.getByRole('row', { name: '09:00 - 12:00 RSV Adult' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a link back to the cancel appointments page', () => {
+    render(
+      <EditServicesConfirmed
+        updatedSession={{
+          from: '09:00',
+          until: '12:00',
+          services: ['RSV:Adult'],
+          capacity: 10,
+          slotLength: 5,
+        }}
+        clinicalServices={clinicalServices}
+        date="2025-01-15"
+        site={mockSite}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Cancel appointments' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Cancel appointments' }),
+    ).toHaveAttribute(
+      'href',
+      '/site/34e990af-5dc9-43a6-8895-b9123216d699/view-availability/daily-appointments?date=2025-01-15&page=1&tab=2',
+    );
+  });
+});

--- a/src/client/src/app/site/[site]/availability/edit-services/confirmed/edit-services-confirmed.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/confirmed/edit-services-confirmed.tsx
@@ -3,14 +3,14 @@ import { AvailabilitySession, ClinicalService, Site } from '@types';
 import Link from 'next/link';
 
 type PageProps = {
-  updatedSession: AvailabilitySession;
+  removedServicesSession: AvailabilitySession;
   clinicalServices: ClinicalService[];
   site: Site;
   date: string;
 };
 
 const EditServicesConfirmed = ({
-  updatedSession,
+  removedServicesSession,
   clinicalServices,
   site,
   date,
@@ -22,10 +22,10 @@ const EditServicesConfirmed = ({
         rows={[
           [
             <strong key={`session-0-start-and-end-time`}>
-              {`${updatedSession.from} - ${updatedSession.until}`}
+              {`${removedServicesSession.from} - ${removedServicesSession.until}`}
             </strong>,
             <>
-              {updatedSession.services.map((service, serviceIndex) => {
+              {removedServicesSession.services.map((service, serviceIndex) => {
                 return (
                   <span key={`service-name-${serviceIndex}`}>
                     {clinicalServices.find(c => c.value === service)?.label ??

--- a/src/client/src/app/site/[site]/availability/edit-services/confirmed/edit-services-confirmed.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/confirmed/edit-services-confirmed.tsx
@@ -1,0 +1,56 @@
+import { Table, InsetText } from '@components/nhsuk-frontend';
+import { AvailabilitySession, ClinicalService, Site } from '@types';
+import Link from 'next/link';
+
+type PageProps = {
+  updatedSession: AvailabilitySession;
+  clinicalServices: ClinicalService[];
+  site: Site;
+  date: string;
+};
+
+const EditServicesConfirmed = ({
+  updatedSession,
+  clinicalServices,
+  site,
+  date,
+}: PageProps) => {
+  return (
+    <>
+      <Table
+        headers={['Time', 'Services']}
+        rows={[
+          [
+            <strong key={`session-0-start-and-end-time`}>
+              {`${updatedSession.from} - ${updatedSession.until}`}
+            </strong>,
+            <>
+              {updatedSession.services.map((service, serviceIndex) => {
+                return (
+                  <span key={`service-name-${serviceIndex}`}>
+                    {clinicalServices.find(c => c.value === service)?.label ??
+                      service}
+                    <br />
+                  </span>
+                );
+              })}
+            </>,
+          ],
+        ]}
+      />
+      <InsetText>
+        <p>
+          Some booked appointments may be affected by this change. If so, you'll
+          need to cancel these appointments manually.
+        </p>
+        <Link
+          href={`/site/${site.id}/view-availability/daily-appointments?date=${date}&page=1&tab=2`}
+        >
+          Cancel appointments
+        </Link>
+      </InsetText>
+    </>
+  );
+};
+
+export default EditServicesConfirmed;

--- a/src/client/src/app/site/[site]/availability/edit-services/confirmed/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/confirmed/page.tsx
@@ -1,0 +1,55 @@
+import {
+  assertPermission,
+  fetchClinicalServices,
+  fetchSite,
+} from '@services/appointmentsService';
+import { AvailabilitySession } from '@types';
+import NhsPage from '@components/nhs-page';
+import { parseToUkDatetime } from '@services/timeService';
+import EditServicesConfirmed from './edit-services-confirmed';
+
+type PageProps = {
+  searchParams: {
+    date: string;
+    updatedSession: string;
+  };
+  params: {
+    site: string;
+  };
+};
+
+const Page = async ({ searchParams, params }: PageProps) => {
+  await assertPermission(params.site, 'availability:setup');
+  const [site, clinicalServices] = await Promise.all([
+    fetchSite(params.site),
+    fetchClinicalServices(),
+  ]);
+
+  const date = parseToUkDatetime(searchParams.date);
+
+  const updatedSession: AvailabilitySession = JSON.parse(
+    atob(searchParams.updatedSession),
+  );
+
+  return (
+    <NhsPage
+      originPage="edit-session"
+      title={`Services for ${date.format('DD MMMM YYYY')}`}
+      caption={site.name}
+      backLink={{
+        href: `/site/${site.id}/view-availability/week/?date=${searchParams.date}`,
+        renderingStrategy: 'server',
+        text: 'Back to week view',
+      }}
+    >
+      <EditServicesConfirmed
+        updatedSession={updatedSession}
+        site={site}
+        date={searchParams.date}
+        clinicalServices={clinicalServices}
+      />
+    </NhsPage>
+  );
+};
+
+export default Page;

--- a/src/client/src/app/site/[site]/availability/edit-services/confirmed/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/confirmed/page.tsx
@@ -11,7 +11,7 @@ import EditServicesConfirmed from './edit-services-confirmed';
 type PageProps = {
   searchParams: {
     date: string;
-    updatedSession: string;
+    removedServicesSession: string;
   };
   params: {
     site: string;
@@ -27,14 +27,14 @@ const Page = async ({ searchParams, params }: PageProps) => {
 
   const date = parseToUkDatetime(searchParams.date);
 
-  const updatedSession: AvailabilitySession = JSON.parse(
-    atob(searchParams.updatedSession),
+  const removedServicesSession: AvailabilitySession = JSON.parse(
+    atob(searchParams.removedServicesSession),
   );
 
   return (
     <NhsPage
       originPage="edit-session"
-      title={`Services for ${date.format('DD MMMM YYYY')}`}
+      title={`Services removed for ${date.format('DD MMMM YYYY')}`}
       caption={site.name}
       backLink={{
         href: `/site/${site.id}/view-availability/week/?date=${searchParams.date}`,
@@ -43,7 +43,7 @@ const Page = async ({ searchParams, params }: PageProps) => {
       }}
     >
       <EditServicesConfirmed
-        updatedSession={updatedSession}
+        removedServicesSession={removedServicesSession}
         site={site}
         date={searchParams.date}
         clinicalServices={clinicalServices}

--- a/src/client/src/app/site/[site]/availability/edit-services/edit-services-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/edit-services-form.tsx
@@ -1,0 +1,158 @@
+'use client';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import {
+  Site,
+  SessionSummary,
+  Session,
+  AvailabilitySession,
+  ClinicalService,
+} from '@types';
+import { useRouter } from 'next/navigation';
+import { editSession } from '@services/appointmentsService';
+import {
+  Button,
+  CheckBox,
+  CheckBoxes,
+  FormGroup,
+  InsetText,
+  SmallSpinnerWithText,
+} from '@components/nhsuk-frontend';
+import {
+  dateTimeFormat,
+  parseToUkDatetime,
+  parseToTimeComponents,
+  toTimeFormat,
+} from '@services/timeService';
+import { Fragment } from 'react';
+
+export type RemoveServicesFormValues = {
+  sessionToEdit: Session;
+  newSession: Session;
+  servicesToRemove: ClinicalService[];
+};
+
+type Props = {
+  date: string;
+  site: Site;
+  existingSession: SessionSummary;
+  clinicalServices: ClinicalService[];
+};
+
+const EditServicesForm = ({
+  site,
+  existingSession,
+  date,
+  clinicalServices,
+}: Props) => {
+  const existingUkStartTime = parseToUkDatetime(
+    existingSession.ukStartDatetime,
+    dateTimeFormat,
+  ).format('HH:mm');
+  const existingUkEndTime = parseToUkDatetime(
+    existingSession.ukEndDatetime,
+    dateTimeFormat,
+  ).format('HH:mm');
+
+  const {
+    handleSubmit,
+    register,
+    formState: { isSubmitting, isSubmitSuccessful, errors },
+  } = useForm<RemoveServicesFormValues>({
+    defaultValues: {
+      sessionToEdit: {
+        startTime: parseToTimeComponents(existingUkStartTime),
+        endTime: parseToTimeComponents(existingUkEndTime),
+        services: Object.keys(existingSession.bookings).map(service => service),
+        slotLength: existingSession.slotLength,
+        capacity: existingSession.capacity,
+      },
+      newSession: {
+        startTime: parseToTimeComponents(existingUkStartTime),
+        endTime: parseToTimeComponents(existingUkEndTime),
+        services: Object.keys(existingSession.bookings).map(service => service),
+        slotLength: existingSession.slotLength,
+        capacity: existingSession.capacity,
+      },
+      servicesToRemove: [],
+    },
+  });
+
+  const router = useRouter();
+
+  const submitForm: SubmitHandler<RemoveServicesFormValues> = async (
+    form: RemoveServicesFormValues,
+  ) => {
+    const remainingServices = form.newSession.services.filter(
+      service =>
+        form.servicesToRemove.findIndex(x => x.value === service) === -1,
+    );
+
+    const updatedSession: AvailabilitySession = {
+      from: toTimeFormat(form.newSession.startTime) ?? '',
+      until: toTimeFormat(form.newSession.endTime) ?? '',
+      slotLength: form.newSession.slotLength,
+      capacity: form.newSession.capacity,
+      services: remainingServices,
+    };
+
+    await editSession({
+      date,
+      site: site.id,
+      mode: 'Edit',
+      sessions: [updatedSession],
+      sessionToEdit: {
+        from: toTimeFormat(form.sessionToEdit.startTime) ?? '',
+        until: toTimeFormat(form.sessionToEdit.endTime) ?? '',
+        slotLength: form.sessionToEdit.slotLength,
+        capacity: form.sessionToEdit.capacity,
+        services: form.sessionToEdit.services,
+      },
+    });
+
+    router.push(
+      `edit/confirmed?updatedSession=${btoa(JSON.stringify(updatedSession))}&date=${date}`,
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submitForm)}>
+      <FormGroup error={errors.newSession?.services?.message}>
+        <CheckBoxes>
+          {clinicalServices.map(clinicalService => {
+            if (
+              Object.keys(existingSession.bookings)
+                .map(service => service)
+                .findIndex(x => x === clinicalService.value) === -1
+            ) {
+              // eslint-disable-next-line react/jsx-key, react/jsx-no-useless-fragment
+              return <Fragment />;
+            }
+            return (
+              <CheckBox
+                id={`checkbox-${clinicalService.value}`}
+                label={clinicalService.label}
+                value={clinicalService.value}
+                key={`checkbox-${clinicalService.value}`}
+                {...register('servicesToRemove', {
+                  validate: value => {
+                    if (value === undefined || value.length < 1) {
+                      return 'Select a service';
+                    }
+                  },
+                })}
+              />
+            );
+          })}
+        </CheckBoxes>
+      </FormGroup>
+
+      {isSubmitting || isSubmitSuccessful ? (
+        <SmallSpinnerWithText text="Working..." />
+      ) : (
+        <Button type="submit">Continue</Button>
+      )}
+    </form>
+  );
+};
+
+export default EditServicesForm;

--- a/src/client/src/app/site/[site]/availability/edit-services/edit-services-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/edit-services-form.tsx
@@ -14,6 +14,7 @@ import {
   CheckBox,
   CheckBoxes,
   FormGroup,
+  InsetText,
   SmallSpinnerWithText,
 } from '@components/nhsuk-frontend';
 import {
@@ -106,8 +107,16 @@ const EditServicesForm = ({
       },
     });
 
+    const servicesRemovedSession: AvailabilitySession = {
+      from: toTimeFormat(form.newSession.startTime) ?? '',
+      until: toTimeFormat(form.newSession.endTime) ?? '',
+      slotLength: form.newSession.slotLength,
+      capacity: form.newSession.capacity,
+      services: form.servicesToRemove,
+    };
+
     router.push(
-      `edit-services/confirmed?updatedSession=${btoa(JSON.stringify(updatedSession))}&date=${date}`,
+      `edit-services/confirmed?removedServicesSession=${btoa(JSON.stringify(servicesRemovedSession))}&date=${date}`,
     );
   };
 
@@ -120,6 +129,9 @@ const EditServicesForm = ({
 
   return (
     <form onSubmit={handleSubmit(submitForm)}>
+      <InsetText>
+        <p>If you need to remove all services, cancel the session instead.</p>
+      </InsetText>
       <FormGroup error={errors.servicesToRemove?.message}>
         <CheckBoxes>
           {clinicalServicesInSession.map(clinicalService => {
@@ -132,10 +144,10 @@ const EditServicesForm = ({
                 {...register('servicesToRemove', {
                   validate: value => {
                     if (value === undefined || value.length < 1) {
-                      return 'Select a service to remove';
+                      return 'Select service(s) to remove';
                     }
                     if (value.length === clinicalServicesInSession.length) {
-                      return 'Cannot remove all services, cancel the session instead';
+                      return 'Cannot select all services';
                     }
                   },
                 })}

--- a/src/client/src/app/site/[site]/availability/edit-services/edit-services-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/edit-services-form.tsx
@@ -144,10 +144,10 @@ const EditServicesForm = ({
                 {...register('servicesToRemove', {
                   validate: value => {
                     if (value === undefined || value.length < 1) {
-                      return 'Select service(s) to remove';
+                      return 'Select a service to remove';
                     }
                     if (value.length === clinicalServicesInSession.length) {
-                      return 'Cannot select all services';
+                      return 'Cancel this session if you need to remove all services';
                     }
                   },
                 })}

--- a/src/client/src/app/site/[site]/availability/edit-services/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/page.tsx
@@ -1,0 +1,53 @@
+import {
+  assertPermission,
+  fetchClinicalServices,
+  fetchSite,
+} from '@services/appointmentsService';
+import { SessionSummary } from '@types';
+import NhsPage from '@components/nhs-page';
+import { parseToUkDatetime } from '@services/timeService';
+import EditServicesForm from './edit-services-form';
+
+type PageProps = {
+  searchParams: {
+    date: string;
+    session: string;
+  };
+  params: {
+    site: string;
+  };
+};
+
+const Page = async ({ searchParams, params }: PageProps) => {
+  await assertPermission(params.site, 'availability:setup');
+
+  const [site, clinicalServices] = await Promise.all([
+    fetchSite(params.site),
+    fetchClinicalServices(),
+  ]);
+
+  const date = parseToUkDatetime(searchParams.date);
+  const sessionSummary: SessionSummary = JSON.parse(atob(searchParams.session));
+
+  return (
+    <NhsPage
+      title={`Remove services for ${date.format('DD MMMM YYYY')}`}
+      caption={'Remove services'}
+      originPage="edit-session"
+      backLink={{
+        href: `/site/${site.id}/view-availability/week/edit-session?session=${searchParams.session}&date=${searchParams.date}`,
+        renderingStrategy: 'server',
+        text: 'Go back',
+      }}
+    >
+      <EditServicesForm
+        date={searchParams.date}
+        site={site}
+        existingSession={sessionSummary}
+        clinicalServices={clinicalServices}
+      ></EditServicesForm>
+    </NhsPage>
+  );
+};
+
+export default Page;

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.test.tsx
@@ -39,10 +39,10 @@ describe('Edit Session Decision Page', () => {
   });
 
   it.each([false, true])(
-    'renders the radio buttons',
+    'renders 3 radio buttons when multiple services',
     (multipleServicesEnabled: boolean) => {
       const session = btoa(
-        JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
+        JSON.stringify(mockWeekAvailability__Summary[1].sessions[0]),
       );
       render(
         <EditSessionDecision
@@ -79,11 +79,41 @@ describe('Edit Session Decision Page', () => {
     },
   );
 
+  it('does not render the reduce services radio button when only one service in the session, despite MultipleServices enabled', () => {
+    const session = btoa(
+      JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
+    );
+    render(
+      <EditSessionDecision
+        sessionSummary={session}
+        date="2025-01-15"
+        site={mockSite}
+        clinicalServices={clinicalServices}
+        multipleServicesEnabled
+      />,
+    );
+
+    expect(
+      screen.getByRole('radio', {
+        name: 'Change the length or capacity of this session',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', { name: 'Cancel this session' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('radio', {
+        name: 'Remove services from this session',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it.each([false, true])(
     'toggles between the radio buttons',
     async (multipleServicesEnabled: boolean) => {
       const session = btoa(
-        JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
+        JSON.stringify(mockWeekAvailability__Summary[1].sessions[0]),
       );
       const { user } = render(
         <EditSessionDecision

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.test.tsx
@@ -27,6 +27,7 @@ describe('Edit Session Decision Page', () => {
         date="2025-01-15"
         site={mockSite}
         clinicalServices={clinicalServices}
+        multipleServicesEnabled={false}
       />,
     );
 
@@ -37,68 +38,131 @@ describe('Edit Session Decision Page', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the radio buttons', () => {
-    const session = btoa(
-      JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
-    );
-    render(
-      <EditSessionDecision
-        sessionSummary={session}
-        date="2025-01-15"
-        site={mockSite}
-        clinicalServices={clinicalServices}
-      />,
-    );
+  it.each([false, true])(
+    'renders the radio buttons',
+    (multipleServicesEnabled: boolean) => {
+      const session = btoa(
+        JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
+      );
+      render(
+        <EditSessionDecision
+          sessionSummary={session}
+          date="2025-01-15"
+          site={mockSite}
+          clinicalServices={clinicalServices}
+          multipleServicesEnabled={multipleServicesEnabled}
+        />,
+      );
 
-    expect(
-      screen.getByRole('radio', {
-        name: 'Change the length or capacity of this session',
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('radio', { name: 'Cancel this session' }),
-    ).toBeInTheDocument();
-  });
+      expect(
+        screen.getByRole('radio', {
+          name: 'Change the length or capacity of this session',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('radio', { name: 'Cancel this session' }),
+      ).toBeInTheDocument();
 
-  it('toggles between edit and cancel', async () => {
-    const session = btoa(
-      JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
-    );
-    const { user } = render(
-      <EditSessionDecision
-        sessionSummary={session}
-        date="2025-01-15"
-        site={mockSite}
-        clinicalServices={clinicalServices}
-      />,
-    );
+      if (multipleServicesEnabled) {
+        expect(
+          screen.queryByRole('radio', {
+            name: 'Remove services from this session',
+          }),
+        ).toBeInTheDocument();
+      } else {
+        expect(
+          screen.queryByRole('radio', {
+            name: 'Remove services from this session',
+          }),
+        ).not.toBeInTheDocument();
+      }
+    },
+  );
 
-    await user.click(
-      screen.getByRole('radio', {
-        name: 'Change the length or capacity of this session',
-      }),
-    );
-    expect(
-      screen.getByRole('radio', {
-        name: 'Change the length or capacity of this session',
-      }),
-    ).toBeChecked();
-    expect(
-      screen.getByRole('radio', { name: 'Cancel this session' }),
-    ).not.toBeChecked();
+  it.each([false, true])(
+    'toggles between the radio buttons',
+    async (multipleServicesEnabled: boolean) => {
+      const session = btoa(
+        JSON.stringify(mockWeekAvailability__Summary[0].sessions[0]),
+      );
+      const { user } = render(
+        <EditSessionDecision
+          sessionSummary={session}
+          date="2025-01-15"
+          site={mockSite}
+          clinicalServices={clinicalServices}
+          multipleServicesEnabled={multipleServicesEnabled}
+        />,
+      );
 
-    await user.click(
-      screen.getByRole('radio', { name: 'Cancel this session' }),
-    );
-    expect(
-      screen.getByRole('radio', {
-        name: 'Change the length or capacity of this session',
-      }),
-    ).not.toBeChecked();
-    expect(
-      screen.getByRole('radio', { name: 'Cancel this session' }),
-    ).toBeChecked();
-  });
+      await user.click(
+        screen.getByRole('radio', {
+          name: 'Change the length or capacity of this session',
+        }),
+      );
+      expect(
+        screen.getByRole('radio', {
+          name: 'Change the length or capacity of this session',
+        }),
+      ).toBeChecked();
+
+      expect(
+        screen.getByRole('radio', { name: 'Cancel this session' }),
+      ).not.toBeChecked();
+
+      if (multipleServicesEnabled) {
+        expect(
+          screen.getByRole('radio', {
+            name: 'Remove services from this session',
+          }),
+        ).not.toBeChecked();
+      }
+
+      await user.click(
+        screen.getByRole('radio', { name: 'Cancel this session' }),
+      );
+
+      expect(
+        screen.getByRole('radio', {
+          name: 'Change the length or capacity of this session',
+        }),
+      ).not.toBeChecked();
+
+      expect(
+        screen.getByRole('radio', { name: 'Cancel this session' }),
+      ).toBeChecked();
+
+      if (multipleServicesEnabled) {
+        expect(
+          screen.getByRole('radio', {
+            name: 'Remove services from this session',
+          }),
+        ).not.toBeChecked();
+
+        await user.click(
+          screen.getByRole('radio', {
+            name: 'Remove services from this session',
+          }),
+        );
+
+        expect(
+          screen.getByRole('radio', {
+            name: 'Remove services from this session',
+          }),
+        ).toBeChecked();
+
+        expect(
+          screen.getByRole('radio', {
+            name: 'Change the length or capacity of this session',
+          }),
+        ).not.toBeChecked();
+
+        expect(
+          screen.getByRole('radio', { name: 'Cancel this session' }),
+        ).not.toBeChecked();
+      }
+    },
+  );
 
   it('displays a validation error if no value is selected', async () => {
     const session = btoa(
@@ -110,6 +174,7 @@ describe('Edit Session Decision Page', () => {
         date="2025-01-15"
         site={mockSite}
         clinicalServices={clinicalServices}
+        multipleServicesEnabled={false}
       />,
     );
 
@@ -142,6 +207,7 @@ describe('Edit Session Decision Page', () => {
         date="2025-01-15"
         site={mockSite}
         clinicalServices={clinicalServices}
+        multipleServicesEnabled={false}
       />,
     );
 

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.tsx
@@ -90,17 +90,18 @@ export const EditSessionDecision = ({
                 required: { value: true, message: 'Select an option' },
               })}
             />
-            {multipleServicesEnabled && (
-              <Radio
-                label="Remove services from this session"
-                hint="Remove booked appointments for individual services"
-                id="edit-services"
-                value="edit-services"
-                {...register('action', {
-                  required: { value: true, message: 'Select an option' },
-                })}
-              />
-            )}
+            {multipleServicesEnabled &&
+              Object.keys(session.bookings).length > 1 && (
+                <Radio
+                  label="Remove services from this session"
+                  hint="Remove booked appointments for individual services"
+                  id="edit-services"
+                  value="edit-services"
+                  {...register('action', {
+                    required: { value: true, message: 'Select an option' },
+                  })}
+                />
+              )}
             <Radio
               label="Cancel this session"
               hint="Cancel all booked appointments, and remove this session"

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/edit-session-decision.tsx
@@ -17,17 +17,19 @@ type EditSessionDecisionProps = {
   site: Site;
   sessionSummary: string;
   date: string;
+  multipleServicesEnabled: boolean;
   clinicalServices: ClinicalService[];
 };
 
 type EditSessionDecisionFormData = {
-  action?: 'edit-session' | 'cancel-session';
+  action?: 'edit-session' | 'edit-services' | 'cancel-session';
 };
 
 export const EditSessionDecision = ({
   site,
   sessionSummary,
   date,
+  multipleServicesEnabled,
   clinicalServices,
 }: EditSessionDecisionProps) => {
   const router = useRouter();
@@ -40,15 +42,23 @@ export const EditSessionDecision = ({
   const submitForm: SubmitHandler<EditSessionDecisionFormData> = async (
     form: EditSessionDecisionFormData,
   ) => {
-    if (form.action === 'edit-session') {
-      router.push(
-        `/site/${site.id}/availability/edit?session=${sessionSummary}&date=${date}`,
-      );
-    } else {
-      router.push(
-        `/site/${site.id}/availability/cancel?session=${sessionSummary}&date=${date}`,
-      );
+    let reroute = `/site/${site.id}/availability/`;
+    switch (form.action) {
+      case 'edit-session':
+        reroute += `edit?session=${sessionSummary}&date=${date}`;
+        break;
+      case 'edit-services':
+        reroute += `edit-services?session=${sessionSummary}&date=${date}`;
+        break;
+      case 'cancel-session':
+        reroute += `cancel?session=${sessionSummary}&date=${date}`;
+        break;
+
+      default:
+        throw new Error('Invalid form action');
     }
+
+    router.push(reroute);
   };
 
   const session: SessionSummary = JSON.parse(atob(sessionSummary));
@@ -80,6 +90,17 @@ export const EditSessionDecision = ({
                 required: { value: true, message: 'Select an option' },
               })}
             />
+            {multipleServicesEnabled && (
+              <Radio
+                label="Remove services from this session"
+                hint="Remove booked appointments for individual services"
+                id="edit-services"
+                value="edit-services"
+                {...register('action', {
+                  required: { value: true, message: 'Select an option' },
+                })}
+              />
+            )}
             <Radio
               label="Cancel this session"
               hint="Cancel all booked appointments, and remove this session"

--- a/src/client/src/app/site/[site]/view-availability/week/edit-session/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/edit-session/page.tsx
@@ -2,6 +2,7 @@ import NhsPage from '@components/nhs-page';
 import {
   assertPermission,
   fetchClinicalServices,
+  fetchFeatureFlag,
   fetchSite,
 } from '@services/appointmentsService';
 import { notFound } from 'next/navigation';
@@ -21,8 +22,9 @@ type PageProps = {
 const Page = async ({ searchParams, params }: PageProps) => {
   await assertPermission(params.site, 'availability:setup');
 
-  const [site, clinicalServices] = await Promise.all([
+  const [site, multipleServicesFlag, clinicalServices] = await Promise.all([
     fetchSite(params.site),
+    fetchFeatureFlag('MultipleServices'),
     fetchClinicalServices(),
   ]);
 
@@ -48,6 +50,7 @@ const Page = async ({ searchParams, params }: PageProps) => {
         site={site}
         sessionSummary={searchParams.session}
         date={searchParams.date}
+        multipleServicesEnabled={multipleServicesFlag.enabled}
         clinicalServices={clinicalServices}
       ></EditSessionDecision>
     </NhsPage>

--- a/src/client/testing/availability.ts
+++ b/src/client/testing/availability.ts
@@ -27,6 +27,12 @@ export type DaySessionOverview = {
   unbooked: number;
 };
 
+export type RemovedServicesOverview = {
+  date: string;
+  sessionTimeInterval: string;
+  serviceNames: string;
+};
+
 type SessionTestCase = {
   week: string;
   day: string;

--- a/src/client/testing/page-objects/view-availability-appointment-pages/change-availability-page.ts
+++ b/src/client/testing/page-objects/view-availability-appointment-pages/change-availability-page.ts
@@ -5,6 +5,7 @@ export default class ChangeAvailabilityPage extends RootPage {
   readonly goBackButton: Locator;
   readonly continueButton: Locator;
   readonly editLengthCapacityRadioOption: Locator;
+  readonly editServicesRadioOption: Locator;
   readonly cancelRadioOption: Locator;
   readonly confirmCancelRadioOption: Locator;
   readonly changeHeader: Locator;
@@ -21,6 +22,9 @@ export default class ChangeAvailabilityPage extends RootPage {
     this.editLengthCapacityRadioOption = page.getByRole('radio', {
       name: 'Change the length or capacity of this session',
     });
+    this.editServicesRadioOption = page.getByRole('radio', {
+      name: 'Remove services from this session',
+    });
     this.cancelRadioOption = page.getByRole('radio', {
       name: 'Cancel this session',
     });
@@ -29,12 +33,17 @@ export default class ChangeAvailabilityPage extends RootPage {
     });
   }
 
-  async selectChangeType(changeType: 'ChangeLengthCapacity' | 'CancelSession') {
+  async selectChangeType(
+    changeType: 'ChangeLengthCapacity' | 'CancelSession' | 'ReduceServices',
+  ) {
     if (changeType == 'ChangeLengthCapacity') {
       await this.editLengthCapacityRadioOption.click();
     }
     if (changeType == 'CancelSession') {
       await this.cancelRadioOption.click();
+    }
+    if (changeType == 'ReduceServices') {
+      await this.editServicesRadioOption.click();
     }
   }
 

--- a/src/client/testing/page-objects/view-availability-appointment-pages/edit-services-confirmed.ts
+++ b/src/client/testing/page-objects/view-availability-appointment-pages/edit-services-confirmed.ts
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test';
+import RootPage from '../root';
+import { RemovedServicesOverview } from '../../availability';
+
+export default class EditServicesConfirmedPage extends RootPage {
+  async verifyServicesRemoved(removedSessions: RemovedServicesOverview) {
+    await expect(this.page.getByRole('main')).toContainText(
+      `Services removed for ${removedSessions.date}`,
+    );
+
+    await expect(
+      this.page.getByText('You have successfully edited the session.'),
+    ).toBeVisible();
+
+    const sessionTable = this.page.getByRole('table');
+
+    //single table
+    await expect(sessionTable).toBeVisible();
+
+    const allTableRows = await sessionTable.getByRole('row').all();
+
+    //start at 1 to ignore table header row
+    const tableRow = allTableRows[1];
+    const allCells = await tableRow.getByRole('cell').all();
+
+    await expect(allCells[0]).toContainText(
+      removedSessions.sessionTimeInterval,
+    );
+    await expect(allCells[1]).toContainText(removedSessions.serviceNames);
+  }
+}

--- a/src/client/testing/page-objects/view-availability-appointment-pages/edit-services-page.ts
+++ b/src/client/testing/page-objects/view-availability-appointment-pages/edit-services-page.ts
@@ -1,0 +1,43 @@
+import { type Locator, type Page, expect } from '@playwright/test';
+import RootPage from '../root';
+
+export default class EditServicesPage extends RootPage {
+  readonly goBackButton: Locator;
+  readonly continueButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.goBackButton = page.getByRole('link', {
+      name: 'Go back',
+    });
+    this.continueButton = page.getByRole('button', {
+      name: 'Continue',
+    });
+  }
+
+  async verifyEditServicesPageDisplayed(
+    date: string,
+    expectedServices: string[],
+  ) {
+    await expect(this.page.getByRole('main')).toContainText(
+      `Remove services for ${date}`,
+    );
+
+    for (let index = 0; index < expectedServices.length; index++) {
+      await expect(this.page.getByLabel(expectedServices[index])).toBeVisible();
+    }
+  }
+
+  async removeService(serviceName: string) {
+    await this.page.getByLabel(serviceName).check();
+    await this.continueButton.click();
+  }
+
+  async removeServices(serviceNames: string[]) {
+    for (let index = 0; index < serviceNames.length; index++) {
+      await this.page.getByLabel(serviceNames[index]).check();
+    }
+
+    await this.continueButton.click();
+  }
+}

--- a/src/client/testing/tests/availability/availability.spec.ts
+++ b/src/client/testing/tests/availability/availability.spec.ts
@@ -33,6 +33,8 @@ import {
 } from '../../utils/date-utility';
 import { parseToUkDatetime } from '@services/timeService';
 import { sessionTestCases, weekTestCases } from '../../availability';
+import EditServicesPage from '../../page-objects/view-availability-appointment-pages/edit-services-page';
+import EditServicesConfirmedPage from '../../page-objects/view-availability-appointment-pages/edit-services-confirmed';
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 test.describe.configure({ mode: 'serial' });
@@ -435,16 +437,18 @@ test.describe.configure({ mode: 'serial' });
       });
     });
 
-    test.describe('Add Session', () => {
+    test.describe('Update Session', () => {
       let rootPage: RootPage;
       let oAuthPage: OAuthLoginPage;
       let monthViewAvailabilityPage: MonthViewAvailabilityPage;
       let weekViewAvailabilityPage: WeekViewAvailabilityPage;
       let addSessionPage: AddSessionPage;
       let addServicesPage: AddServicesPage;
+      let editServicesPage: EditServicesPage;
       let checkSessionDetailsPage: CheckSessionDetailsPage;
       let changeAvailabilityPage: ChangeAvailabilityPage;
       let editAvailabilityConfirmedPage: EditAvailabilityConfirmedPage;
+      let editServicesConfirmedPage: EditServicesConfirmedPage;
       let cancelSessionDetailsPage: CancelSessionDetailsPage;
       let dailyAppointmentDetailsPage: DailyAppointmentDetailsPage;
 
@@ -462,6 +466,7 @@ test.describe.configure({ mode: 'serial' });
             weekViewAvailabilityPage = new WeekViewAvailabilityPage(page);
             addSessionPage = new AddSessionPage(page);
             addServicesPage = new AddServicesPage(page);
+            editServicesPage = new EditServicesPage(page);
             checkSessionDetailsPage = new CheckSessionDetailsPage(page);
             changeAvailabilityPage = new ChangeAvailabilityPage(page);
             cancelSessionDetailsPage = new CancelSessionDetailsPage(page);
@@ -469,6 +474,7 @@ test.describe.configure({ mode: 'serial' });
             editAvailabilityConfirmedPage = new EditAvailabilityConfirmedPage(
               page,
             );
+            editServicesConfirmedPage = new EditServicesConfirmedPage(page);
 
             await rootPage.goto();
             await rootPage.cookieBanner.acceptCookiesButton.click();
@@ -636,6 +642,144 @@ test.describe.configure({ mode: 'serial' });
               '**/site/**/availability/edit/confirmed?updatedSession=**',
             );
             await editAvailabilityConfirmedPage.verifySessionUpdated();
+          });
+
+          test('Verify user is able to reduce services for availability', async ({
+            page,
+          }) => {
+            if (!multipleServicesEnabled) {
+              test.skip();
+            }
+
+            const dayIncrement = 11;
+
+            const day = daysFromToday(dayIncrement);
+            const requiredDate = daysFromToday(dayIncrement, 'dddd D MMMM');
+            const requiredDateFormat = daysFromToday(
+              dayIncrement,
+              'DD MMMM YYYY',
+            );
+            const requiredWeekRange = weekHeaderText(day);
+
+            await page.goto(
+              `/manage-your-appointments/site/${siteId}/view-availability?date=${day}`,
+            );
+            await page.waitForURL(
+              `/manage-your-appointments/site/${siteId}/view-availability?date=${day}`,
+            );
+
+            await monthViewAvailabilityPage.verifyViewMonthDisplayed(
+              requiredWeekRange,
+            );
+            await monthViewAvailabilityPage.openWeekViewHavingDate(
+              requiredWeekRange,
+            );
+
+            await page.waitForURL('**/site/**/view-availability/week?date=**');
+
+            await weekViewAvailabilityPage.verifyDateCardDisplayed(
+              requiredDate,
+            );
+            await weekViewAvailabilityPage.addAvailability(requiredDate);
+
+            await page.waitForURL(
+              '**/site/**/create-availability/wizard?date=**',
+            );
+
+            await addSessionPage.addSession('9', '00', '10', '00', '5', '5');
+            await addServicesPage.addServices([
+              'RSV Adult',
+              'COVID 18+',
+              'Flu 18-64',
+              'Flu and COVID 18-64',
+              'Flu 2-3',
+            ]);
+            await checkSessionDetailsPage.saveSession();
+
+            await page.waitForURL('**/site/**/view-availability/week?date=**');
+
+            await weekViewAvailabilityPage.verifySessionAdded();
+
+            await weekViewAvailabilityPage.verifySessionDataDisplayedInTheCorrectOrder(
+              {
+                header: requiredDate,
+                sessions: [
+                  {
+                    serviceName:
+                      'RSV AdultCOVID 18+Flu 18-64Flu and COVID 18-64Flu 2-3',
+                    booked: '0 booked0 booked0 booked0 booked',
+                    unbooked: 60,
+                    sessionTimeInterval: '09:00 - 10:00',
+                  },
+                ],
+                totalAppointments: 60,
+                orphaned: 0,
+                booked: 0,
+                unbooked: 60,
+              },
+            );
+
+            await weekViewAvailabilityPage.openChangeAvailabilityPage(
+              requiredDate,
+            );
+
+            await page.waitForURL(
+              '**/site/**/view-availability/week/edit-session?date=**',
+            );
+
+            await changeAvailabilityPage.selectChangeType('ReduceServices');
+            await changeAvailabilityPage.saveChanges();
+
+            await page.waitForURL(
+              '**/site/**/availability/edit-services?session=**',
+            );
+
+            await editServicesPage.verifyEditServicesPageDisplayed(
+              requiredDateFormat,
+              [
+                'RSV Adult',
+                'COVID 18+',
+                'Flu 18-64',
+                'Flu and COVID 18-64',
+                'Flu 2-3',
+              ],
+            );
+            await editServicesPage.removeServices(['RSV Adult', 'Flu 2-3']);
+
+            await page.waitForURL(
+              '**/site/**/availability/edit-services/confirmed?removedServicesSession=**',
+            );
+
+            await editServicesConfirmedPage.verifyServicesRemoved({
+              date: requiredDateFormat,
+              serviceNames: 'RSV AdultFlu 2-3',
+              sessionTimeInterval: '09:00 - 10:00',
+            });
+
+            await page.goto(
+              `/manage-your-appointments/site/${siteId}/view-availability/week?date=${day}`,
+            );
+            await page.waitForURL(
+              `/manage-your-appointments/site/${siteId}/view-availability/week?date=${day}`,
+            );
+
+            await weekViewAvailabilityPage.verifySessionDataDisplayedInTheCorrectOrder(
+              {
+                header: requiredDate,
+                sessions: [
+                  {
+                    serviceName: 'COVID 18+Flu 18-64Flu and COVID 18-64',
+                    booked: '0 booked0 booked',
+                    unbooked: 60,
+                    sessionTimeInterval: '09:00 - 10:00',
+                  },
+                ],
+                totalAppointments: 60,
+                orphaned: 0,
+                booked: 0,
+                unbooked: 60,
+              },
+            );
           });
 
           test('Verify user is able to cancel session', async ({ page }) => {

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/SetAvailability_MultipleServices.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/SetAvailability_MultipleServices.feature
@@ -28,6 +28,21 @@
       | SingleDateSession | api@test | Tomorrow |        |               | 12:00    | 15:00     | 10         | 2        | COVID, RSV      |
     And an audit function document was created for user 'api@test' and function 'SetAvailabilityFunction'
 
+  Scenario: Edit existing availability for a single day, remove a service
+    Given the following sessions
+      | Date     | From  | Until | Services        | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 17:00 | COVID, FLU, RSV | 5           | 2        |
+    When I edit the following availability
+      | Date     | Old From | Old Until | Old SlotLength | Old Capacity | Old Services     | New From | New Until | New SlotLength | New Capacity | New Services | Mode |
+      | Tomorrow | 09:00    | 17:00     | 5              | 2            | COVID, FLU, RSV  | 09:00    | 17:00     | 5              | 2            | COVID, RSV   | Edit |
+    Then the request is successful and the following daily availability sessions are created
+      | Date     | From  | Until | Services        | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 17:00 | COVID, RSV      | 5           | 2        |
+    And the following availability created events are created
+      | Type              | By       | FromDate | ToDate | Template_Days | FromTime | UntilTime | SlotLength | Capacity | Services        |
+      | SingleDateSession | api@test | Tomorrow |        |               | 09:00    | 17:00     | 5          | 2        | COVID, RSV      |
+    And an audit function document was created for user 'api@test' and function 'SetAvailabilityFunction'
+    
   Scenario: Overwrite existing availability for a single day, add services
     Given the following sessions
       | Date     | From  | Until | Services        | Slot Length | Capacity |


### PR DESCRIPTION
# Description

An MVP journey for reducing services for existing sessions for MultipleServices. The button is only available if MS enabled and the session being edited has more than one service.

Fixes # (issue)

# Checklist:

- [x] My work is behind a feature toggle (if appropriate)
- [x] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [x] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [x] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
