### PR TITLE
APPT-982: Tie feature toggle pipeline to relevant DevOps environment

### DIFF
--- a/features/scripts/deploy-feature-toggles.yml
+++ b/features/scripts/deploy-feature-toggles.yml
@@ -10,25 +10,19 @@ stages:
     condition: and(succeeded(), eq(${{parameters.isMain}}, true))
     dependsOn: []
     jobs:
-      - job: ApproveFeatureToggles
-        displayName: "Approve Feature Toggles"
-        pool: server
-        steps:
-          - task: ManualValidation@0
-            displayName: "Review Feature Toggles"
-            inputs:
-              notifyUsers: ""
-              instructions: Approve Toggles to ${{parameters.env}}
-      - job: ApplyFeatureToggles
-        dependsOn: ApproveFeatureToggles
+      - deployment: ApplyFeatureToggles
         displayName: "Apply Feature Toggles"
         environment: nbs-mya-${{parameters.env}}
-        steps:
-          - task: AzureCLI@2
-            displayName: "Apply Feature Toggles"
-            inputs:
-              azureSubscription: "nbs-mya-rg-${{parameters.env}}"
-              scriptType: pscore
-              scriptLocation: scriptPath
-              scriptPath: "$(Build.SourcesDirectory)/features/scripts/import-flags.ps1"
-              arguments: "-appConfigName nbs-mya-config-${{parameters.env}}-uks -sourceFile $(Build.SourcesDirectory)/features/${{parameters.env}}.feature.flags.json"
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - task: AzureCLI@2
+                  displayName: "Apply Feature Toggles"
+                  inputs:
+                    azureSubscription: "nbs-mya-rg-${{parameters.env}}"
+                    scriptType: pscore
+                    scriptLocation: scriptPath
+                    scriptPath: "$(Build.SourcesDirectory)/features/scripts/import-flags.ps1"
+                    arguments: "-appConfigName nbs-mya-config-${{parameters.env}}-uks -sourceFile $(Build.SourcesDirectory)/features/${{parameters.env}}.feature.flags.json"

--- a/features/scripts/deploy-feature-toggles.yml
+++ b/features/scripts/deploy-feature-toggles.yml
@@ -22,6 +22,7 @@ stages:
       - job: ApplyFeatureToggles
         dependsOn: ApproveFeatureToggles
         displayName: "Apply Feature Toggles"
+        environment: nbs-mya-${{parameters.env}}
         steps:
           - task: AzureCLI@2
             displayName: "Apply Feature Toggles"


### PR DESCRIPTION
# Description

We've recently introduced Approvals and Checks to the Stag and Prod environment (namely the isMain check and the need for >= 2 approvers). These checks are functioning when deploying the main app, but aren't triggering for the feature toggle pipeline. 

This is because the feature toggle pipeline is not tied to one of our [DevOps environments](https://dev.azure.com/nhsuk/covid19.vaccine-booking/_environments). To link them, we need to use a [deployment job](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/deployment-jobs?view=azure-devops) and set the environment property. 

I've also removed the manual approval check since:

- For stag and prod, this check is now replicated outside of the pipeline
- For dev and int, we've been toggling them manually in the Azure Portal anyway and the check is mostly redundant

Fixes # ([APPT-982](https://nhsd-jira.digital.nhs.uk/browse/APPT-982))

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
