### PR TITLE
APPT-873 - Cancellation reason

### DIFF
--- a/data/CosmosDbSeeder/items/local/booking_data/seed_booking_20.json
+++ b/data/CosmosDbSeeder/items/local/booking_data/seed_booking_20.json
@@ -5,6 +5,7 @@
   "service": "RSV:Adult",
   "created": "2025-07-03T12:58:28.701582+00:00",
   "status": "Booked",
+  "availabilityStatus": "Supported",
   "statusUpdated": "0001-01-01T00:00:00+00:00",
   "attendeeDetails": {
     "nhsNumber": "9513125169",

--- a/postman-collection/Appointment Service.postman_collection.json
+++ b/postman-collection/Appointment Service.postman_collection.json
@@ -28,8 +28,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/availability/apply-template",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "availability", "apply-template" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability", "apply-template"]
         }
       },
       "response": []
@@ -56,8 +56,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/availability",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "availability" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability"]
         }
       },
       "response": []
@@ -87,8 +87,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/availability/query",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "availability", "query" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability", "query"]
         }
       },
       "response": []
@@ -118,8 +118,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/availability/query",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "availability", "query" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability", "query"]
         }
       },
       "response": []
@@ -149,8 +149,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/availability/query",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "availability", "query" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "availability", "query"]
         }
       },
       "response": []
@@ -174,7 +174,7 @@
         {
           "listen": "prerequest",
           "script": {
-            "exec": [ "" ],
+            "exec": [""],
             "type": "text/javascript",
             "packages": {}
           }
@@ -203,8 +203,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/booking",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "booking" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking"]
         }
       },
       "response": []
@@ -228,7 +228,7 @@
         {
           "listen": "prerequest",
           "script": {
-            "exec": [ "" ],
+            "exec": [""],
             "type": "text/javascript",
             "packages": {}
           }
@@ -257,8 +257,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/booking",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "booking" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking"]
         }
       },
       "response": []
@@ -269,7 +269,7 @@
         {
           "listen": "test",
           "script": {
-            "exec": [ "" ],
+            "exec": [""],
             "type": "text/javascript",
             "packages": {}
           }
@@ -277,7 +277,7 @@
         {
           "listen": "prerequest",
           "script": {
-            "exec": [ "" ],
+            "exec": [""],
             "type": "text/javascript",
             "packages": {}
           }
@@ -306,8 +306,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/booking/{{bookingReference}}/confirm",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "booking", "{{bookingReference}}", "confirm" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "{{bookingReference}}", "confirm"]
         }
       },
       "response": []
@@ -318,7 +318,7 @@
         {
           "listen": "test",
           "script": {
-            "exec": [ "" ],
+            "exec": [""],
             "type": "text/javascript",
             "packages": {}
           }
@@ -326,7 +326,7 @@
         {
           "listen": "prerequest",
           "script": {
-            "exec": [ "" ],
+            "exec": [""],
             "type": "text/javascript",
             "packages": {}
           }
@@ -355,8 +355,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/booking/{{bookingReference}}/confirm",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "booking", "{{bookingReference}}", "confirm" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "{{bookingReference}}", "confirm"]
         }
       },
       "response": []
@@ -367,7 +367,7 @@
         {
           "listen": "test",
           "script": {
-            "exec": [ "" ],
+            "exec": [""],
             "type": "text/javascript",
             "packages": {}
           }
@@ -396,8 +396,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/booking/query",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "booking", "query" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "query"]
         }
       },
       "response": []
@@ -418,7 +418,7 @@
         ],
         "body": {
           "mode": "raw",
-          "raw": "",
+          "raw": "{\r\n    \"cancellationReason\": \"CancelledBySite\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -427,8 +427,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/booking/{{bookingReference}}/cancel",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "booking", "{{bookingReference}}", "cancel" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "{{bookingReference}}", "cancel"]
         }
       },
       "response": []
@@ -458,8 +458,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/booking/set-status",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "booking", "set-status" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "set-status"]
         }
       },
       "response": []
@@ -489,8 +489,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/sites/{{site}}/accessibilities",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "sites", "{{site}}", "accessibilities" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "sites", "{{site}}", "accessibilities"]
         }
       },
       "response": []
@@ -520,8 +520,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/sites/{{site}}/informationForCitizens",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "sites", "{{site}}", "informationForCitizens" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "sites", "{{site}}", "informationForCitizens"]
         }
       },
       "response": []
@@ -551,8 +551,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/user/roles",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "user", "roles" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "user", "roles"]
         }
       },
       "response": []
@@ -582,8 +582,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/user/remove",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "user", "remove" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "user", "remove"]
         }
       },
       "response": []
@@ -613,8 +613,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/system/run-reminders",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "system", "run-reminders" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "system", "run-reminders"]
         }
       },
       "response": []
@@ -635,8 +635,8 @@
         ],
         "url": {
           "raw": "{{baseUrl}}/api/system/run-provisional-sweep",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "system", "run-provisional-sweep" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "system", "run-provisional-sweep"]
         }
       },
       "response": []
@@ -669,8 +669,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/accessibilityDefinitions",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "accessibilityDefinitions" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "accessibilityDefinitions"]
         }
       },
       "response": []
@@ -691,8 +691,8 @@
         ],
         "url": {
           "raw": "{{baseUrl}}/api/booking/{{bookingReference}}",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "booking", "{{bookingReference}}" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking", "{{bookingReference}}"]
         }
       },
       "response": []
@@ -713,8 +713,8 @@
         ],
         "url": {
           "raw": "{{baseUrl}}/api/booking?nhsNumber={{nhsNumber}}",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "booking" ],
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "booking"],
           "query": [
             {
               "key": "nhsNumber",
@@ -753,8 +753,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/sites/{{site}}/meta",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "sites", "{{site}}", "meta" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "sites", "{{site}}", "meta"]
         }
       },
       "response": []
@@ -787,8 +787,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/sites/{{site}}",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "sites", "{{site}}" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "sites", "{{site}}"]
         }
       },
       "response": []
@@ -821,8 +821,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/sites?long=-1.663038&lat=53.796638&searchRadius=100000&maxRecords=50",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "sites" ],
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "sites"],
           "query": [
             {
               "key": "long",
@@ -879,8 +879,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/roles?tag=canned",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "roles" ],
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "roles"],
           "query": [
             {
               "key": "tag",
@@ -919,8 +919,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/users?site={{site}}",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "users" ],
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "users"],
           "query": [
             {
               "key": "site",
@@ -959,8 +959,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/user/permissions?site={{site}}",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "user", "permissions" ],
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "user", "permissions"],
           "query": [
             {
               "key": "site",
@@ -984,8 +984,8 @@
         ],
         "url": {
           "raw": "{{baseUrl}}/api/daily-availability?site=6877d86e-c2df-4def-8508-e1eccf0ea6be&from=2024-12-03&until=2024-12-08",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "daily-availability" ],
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "daily-availability"],
           "query": [
             {
               "key": "site",
@@ -1032,8 +1032,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/wellKnownOdsCodeEntries",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "wellKnownOdsCodeEntries" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "wellKnownOdsCodeEntries"]
         }
       },
       "response": []
@@ -1063,8 +1063,8 @@
         },
         "url": {
           "raw": "{{baseUrl}}/api/session/cancel",
-          "host": [ "{{baseUrl}}" ],
-          "path": [ "api", "session", "cancel" ]
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "session", "cancel"]
         }
       },
       "response": []

--- a/src/api/Nhs.Appointments.Api/Functions/CancelBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelBookingFunction.cs
@@ -14,6 +14,7 @@ using Nhs.Appointments.Core;
 using Nhs.Appointments.Core.Inspectors;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -79,8 +80,13 @@ public class CancelBookingFunction(
         {
             var (errors, payload) = await JsonRequestReader.ReadRequestAsync<CancelBookingRequest>(req.Body, true);
 
-            if (payload?.cancellationReason != null) 
-            { 
+            if (errors.Any(x => x.Property == "cancellationReason"))
+            {
+                return (errors, null);
+            }
+
+            if (payload?.cancellationReason != null)
+            {
                 cancellationReason = (CancellationReason)payload.cancellationReason;
             }
         }

--- a/src/api/Nhs.Appointments.Api/Functions/CancelBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelBookingFunction.cs
@@ -76,17 +76,15 @@ public class CancelBookingFunction(
 
         var cancellationReason = CancellationReason.CancelledByCitizen;
 
-        if (!string.IsNullOrWhiteSpace(queryCancellationReason))
+        if (!string.IsNullOrWhiteSpace(queryCancellationReason) &&
+            !Enum.TryParse<CancellationReason>(queryCancellationReason, ignoreCase: true, out cancellationReason))
         {
-            if (!Enum.TryParse<CancellationReason>(queryCancellationReason, ignoreCase: true, out cancellationReason))
+            var error = new ErrorMessageResponseItem
             {
-                var error = new ErrorMessageResponseItem
-                {
-                    Property = "cancellationReason",
-                    Message = $"Invalid cancellation reason '{queryCancellationReason}'."
-                };
-                return (new[] { error }, null);
-            }
+                Property = "cancellationReason",
+                Message = $"Invalid cancellation reason '{queryCancellationReason}'."
+            };
+            return (new[] { error }, null);
         }
 
         var requestModel = new CancelBookingRequest(bookingReference, site, cancellationReason);

--- a/src/api/Nhs.Appointments.Api/Functions/CancelSessionFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelSessionFunction.cs
@@ -52,7 +52,8 @@ public class CancelSessionFunction(
             request.Until,
             request.Services,
             request.SlotLength,
-            request.Capacity);
+            request.Capacity
+        );
 
         return Success(new EmptyResponse());
     }

--- a/src/api/Nhs.Appointments.Api/Json/JsonDeserializationContext.cs
+++ b/src/api/Nhs.Appointments.Api/Json/JsonDeserializationContext.cs
@@ -1,0 +1,26 @@
+using Nhs.Appointments.Api.Models;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Nhs.Appointments.Api.Json;
+public static class JsonDeserializationContext
+{
+    private static AsyncLocal<List<ErrorMessageResponseItem>> _errors = new();
+
+    public static void AddError(string property, string message)
+    {
+        if (_errors.Value == null)
+            _errors.Value = new List<ErrorMessageResponseItem>();
+
+        _errors.Value.Add(new ErrorMessageResponseItem
+        {
+            Property = property,
+            Message = message
+        });
+    }
+
+    public static IReadOnlyCollection<ErrorMessageResponseItem> GetErrors()
+        => _errors.Value ?? new List<ErrorMessageResponseItem>();
+
+    public static void Clear() => _errors.Value = null;
+}

--- a/src/api/Nhs.Appointments.Api/Json/NullableStringEnumConverter.cs
+++ b/src/api/Nhs.Appointments.Api/Json/NullableStringEnumConverter.cs
@@ -1,0 +1,33 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Nhs.Appointments.Api.Json;
+public class NullableStringEnumConverter<T> : JsonConverter<T?> where T : struct, Enum
+{
+    public override T? ReadJson(JsonReader reader, Type objectType, T? existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null)
+            return null;
+
+        if (reader.TokenType == JsonToken.String)
+        {
+            var enumText = reader.Value?.ToString();
+            if (Enum.TryParse(enumText, true, out T parsedEnum))
+                return parsedEnum;
+
+            JsonDeserializationContext.AddError(reader.Path, $"Invalid value '{enumText}' for enum '{typeof(T).Name}'");
+            return null;
+        }
+
+        JsonDeserializationContext.AddError(reader.Path, $"Unexpected token {reader.TokenType} for enum '{typeof(T).Name}'");
+        return null;
+    }
+
+    public override void WriteJson(JsonWriter writer, T? value, JsonSerializer serializer)
+    {
+        if (value.HasValue)
+            writer.WriteValue(value.Value.ToString());
+        else
+            writer.WriteNull();
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Models/CancelBookingRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/CancelBookingRequest.cs
@@ -1,5 +1,11 @@
 using Nhs.Appointments.Core;
+using System.Text.Json.Serialization;
 
 namespace Nhs.Appointments.Api.Models;
 
-public record CancelBookingRequest(string bookingReference, string site, CancellationReason cancellationReason);
+public record CancelBookingRequest(
+    string bookingReference, 
+    string site,
+    [property: JsonPropertyName("cancellationReason")]
+    CancellationReason? cancellationReason
+);

--- a/src/api/Nhs.Appointments.Api/Models/CancelBookingRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/CancelBookingRequest.cs
@@ -1,3 +1,5 @@
+using Nhs.Appointments.Core;
+
 namespace Nhs.Appointments.Api.Models;
 
-public record CancelBookingRequest(string bookingReference, string site);
+public record CancelBookingRequest(string bookingReference, string site, CancellationReason cancellationReason);

--- a/src/api/Nhs.Appointments.Core/Booking.cs
+++ b/src/api/Nhs.Appointments.Core/Booking.cs
@@ -41,6 +41,10 @@ public class Booking
 
     [JsonProperty("additionalData")]
     public object AdditionalData { get; set; }
+
+
+    [JsonProperty("cancellationReason")]
+    public CancellationReason CancellationReason { get; set; }
 }
 
 public class AttendeeDetails
@@ -85,4 +89,10 @@ public enum AvailabilityStatus
     Unknown,
     Supported,
     Orphaned
+}
+
+public enum CancellationReason
+{
+    CancelledByCitizen,
+    CancelledBySite
 }

--- a/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
@@ -9,7 +9,7 @@ public interface IBookingsDocumentStore
     Task<IEnumerable<Booking>> GetCrossSiteAsync(DateTime from, DateTime to, params AppointmentStatus[] statuses);
     Task<Booking> GetByReferenceOrDefaultAsync(string bookingReference);
     Task<IEnumerable<Booking>> GetByNhsNumberAsync(string nhsNumber);
-    Task<bool> UpdateStatus(string bookingReference, AppointmentStatus status, AvailabilityStatus availabilityStatus);
+    Task<bool> UpdateStatus(string bookingReference, AppointmentStatus status, AvailabilityStatus availabilityStatus, CancellationReason? cancellationReason = null);
     IDocumentUpdate<Booking> BeginUpdate(string site, string reference);
     Task SetReminderSent(string bookingReference, string site);
     Task<BookingConfirmationResult> ConfirmProvisionals(string[] bookingReferences, IEnumerable<ContactItem> contactDetails);
@@ -51,4 +51,10 @@ public enum BookingCancellationResult
 {
     Success,
     NotFound
+}
+
+public enum BookingCancellationReason
+{
+    Citizen,
+    Site
 }

--- a/src/api/Nhs.Appointments.Persistance/Models/BookingDocument.cs
+++ b/src/api/Nhs.Appointments.Persistance/Models/BookingDocument.cs
@@ -40,4 +40,7 @@ public class BookingDocument : BookingDataCosmosDocument
 
     [JsonProperty("reminderSent")]
     public Boolean ReminderSent { get; set; }
+
+    [JsonProperty("cancellationReason")]
+    public CancellationReason? CancellationReason { get; set; }
 }

--- a/src/client/src/app/lib/services/appointmentsService.test.ts
+++ b/src/client/src/app/lib/services/appointmentsService.test.ts
@@ -26,7 +26,8 @@ describe('Appointments Service', () => {
     await cancelAppointment(reference, site, reason);
 
     expect(appointmentsApi.post).toHaveBeenCalledWith(
-      `booking/${reference}/cancel?site=${site}&cancellationReason=${reason}`,
+      `booking/${reference}/cancel?site=${site}`,
+      JSON.stringify({ cancellationReason: reason }),
     );
   });
 });

--- a/src/client/src/app/lib/services/appointmentsService.test.ts
+++ b/src/client/src/app/lib/services/appointmentsService.test.ts
@@ -1,0 +1,32 @@
+import { cancelAppointment } from './appointmentsService';
+import { appointmentsApi } from '@services/api/appointmentsApi';
+
+jest.mock('@services/api/appointmentsApi', () => ({
+  appointmentsApi: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('@services/api/appointmentsApi', () => ({
+  appointmentsApi: { post: jest.fn() },
+}));
+
+describe('Appointments Service', () => {
+  const reference = 'REF123';
+  const site = 'SITE001';
+  const reason = 'Patient no longer available';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls the correct API endpoint with expected parameters', async () => {
+    (appointmentsApi.post as jest.Mock).mockResolvedValue({ success: true });
+
+    await cancelAppointment(reference, site, reason);
+
+    expect(appointmentsApi.post).toHaveBeenCalledWith(
+      `booking/${reference}/cancel?site=${site}&cancellationReason=${reason}`,
+    );
+  });
+});

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -468,8 +468,13 @@ export const cancelAppointment = async (
   site: string,
   cancellationReason: string,
 ) => {
+  const payload = {
+    cancellationReason,
+  };
+
   const response = await appointmentsApi.post(
-    `booking/${reference}/cancel?site=${site}&cancellationReason=${cancellationReason}`,
+    `booking/${reference}/cancel?site=${site}`,
+    JSON.stringify(payload),
   );
 
   return handleEmptyResponse(response);

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -463,9 +463,13 @@ export const fetchBooking = async (reference: string, site: string) => {
   return handleBodyResponse(response);
 };
 
-export const cancelAppointment = async (reference: string, site: string) => {
+export const cancelAppointment = async (
+  reference: string,
+  site: string,
+  cancellationReason: string,
+) => {
   const response = await appointmentsApi.post(
-    `booking/${reference}/cancel?site=${site}`,
+    `booking/${reference}/cancel?site=${site}&cancellationReason=${cancellationReason}`,
   );
 
   return handleEmptyResponse(response);

--- a/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.test.tsx
+++ b/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.test.tsx
@@ -34,11 +34,11 @@ describe('Cancel Appointment Page', () => {
 
     expect(
       screen.getByRole('radio', {
-        name: 'Yes, I want to cancel this appointment',
+        name: 'Cancelled by the citizen',
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Continue' }),
+      screen.getByRole('button', { name: 'Cancel appointment' }),
     ).toBeInTheDocument();
   });
 
@@ -54,7 +54,7 @@ describe('Cancel Appointment Page', () => {
     verifySummaryListItem('Contact information', 'Not provided');
   });
 
-  it('calls the cancel appointment endpoint when a user selects yes', async () => {
+  it('does not call the cancel endpoint and shows an error when no option is selected', async () => {
     const { user } = render(
       <CancelAppointmentPage
         site="TEST01"
@@ -64,37 +64,32 @@ describe('Cancel Appointment Page', () => {
     );
 
     await user.click(
-      screen.getByRole('radio', {
-        name: 'Yes, I want to cancel this appointment',
-      }),
-    );
-    await user.click(screen.getByRole('button', { name: 'Continue' }));
-
-    expect(mockCancelBooking).toHaveBeenCalled();
-    expect(mockReplace).toHaveBeenCalledWith(
-      '/site/TEST01/view-availability/daily-appointments?date=2024-11-10&tab=1&page=1',
-    );
-  });
-
-  it('does not call the cancel endpoint when a user selects no', async () => {
-    const { user } = render(
-      <CancelAppointmentPage
-        site="TEST01"
-        booking={mockBookings[0]}
-        clinicalServices={clinicalServices}
-      />,
+      screen.getByRole('button', { name: 'Cancel appointment' }),
     );
 
-    await user.click(
-      screen.getByRole('radio', {
-        name: 'No, I do not want to cancel this appointment',
-      }),
-    );
-    await user.click(screen.getByRole('button', { name: 'Continue' }));
-
+    expect(
+      screen.getByText('Select a reason for cancelling the appointment'),
+    ).toBeInTheDocument();
     expect(mockCancelBooking).not.toHaveBeenCalled();
-    expect(mockReplace).toHaveBeenCalledWith(
-      '/site/TEST01/view-availability/daily-appointments?date=2024-11-10&tab=0&page=1',
-    );
   });
+
+  it.each(['Cancelled by the citizen', 'Cancelled by the site'])(
+    'calls the cancel endpoint when an option is selected',
+    async option => {
+      const { user } = render(
+        <CancelAppointmentPage
+          site="TEST01"
+          booking={mockBookings[0]}
+          clinicalServices={clinicalServices}
+        />,
+      );
+
+      await user.click(screen.getByLabelText(option));
+      await user.click(
+        screen.getByRole('button', { name: 'Cancel appointment' }),
+      );
+
+      expect(mockCancelBooking).toHaveBeenCalled();
+    },
+  );
 });

--- a/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.tsx
+++ b/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.tsx
@@ -19,7 +19,7 @@ import { useRouter } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 type CancelFormValue = {
-  cancelAppointment: 'yes' | 'no';
+  cancellationReason: 'CancelledByCitizen' | 'CancelledBySite' | '';
 };
 
 const CancelAppointmentPage = ({
@@ -35,10 +35,10 @@ const CancelAppointmentPage = ({
   const {
     register,
     handleSubmit,
-    formState: { isSubmitting, isSubmitSuccessful },
+    formState: { isSubmitting, isSubmitSuccessful, errors },
   } = useForm<CancelFormValue>({
     defaultValues: {
-      cancelAppointment: 'yes',
+      cancellationReason: '',
     },
   });
   const summaryItems = mapSummaryData(booking, clinicalServices);
@@ -46,9 +46,8 @@ const CancelAppointmentPage = ({
   const submitForm: SubmitHandler<CancelFormValue> = async (
     form: CancelFormValue,
   ) => {
-    if (form.cancelAppointment === 'yes') {
-      await cancelAppointment(booking.reference, site);
-    }
+    if (form.cancellationReason !== '') {
+      await cancelAppointment(booking.reference, site, form.cancellationReason);
 
     const returnDate = parseToUkDatetime(booking.from).format(dateFormat);
     const tabNumber = form.cancelAppointment === 'yes' ? 1 : 0;
@@ -62,19 +61,26 @@ const CancelAppointmentPage = ({
     <>
       {summaryItems && <SummaryList {...summaryItems} />}
       <form onSubmit={handleSubmit(submitForm)}>
-        <FormGroup>
+        <FormGroup error={errors.cancellationReason?.message}>
+          <legend className="nhsuk-fieldset__legend nhsuk-label--m">
+            <h1 className="nhsuk-fieldset__heading">Select a reason</h1>
+          </legend>
           <RadioGroup>
             <Radio
-              label="Yes, I want to cancel this appointment"
-              id="cancelOperation-yes"
-              value="yes"
-              {...register('cancelAppointment')}
+              label="Cancelled by the citizen"
+              id="cancelOperation-citizen"
+              value="CancelledByCitizen"
+              {...register('cancellationReason', {
+                required: 'Select a reason for cancelling the appointment',
+              })}
             />
             <Radio
-              label="No, I do not want to cancel this appointment"
-              id="cancelOperation-no"
-              value="no"
-              {...register('cancelAppointment')}
+              label="Cancelled by the site"
+              id="cancelOperation-site"
+              value="CancelledBySite"
+              {...register('cancellationReason', {
+                required: 'Select a reason for cancelling the appointment',
+              })}
             />
           </RadioGroup>
         </FormGroup>
@@ -82,7 +88,7 @@ const CancelAppointmentPage = ({
         {isSubmitting || isSubmitSuccessful ? (
           <SmallSpinnerWithText text="Working..." />
         ) : (
-          <Button type="submit">Continue</Button>
+          <Button type="submit">Cancel appointment</Button>
         )}
       </form>
     </>

--- a/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.tsx
+++ b/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.tsx
@@ -49,12 +49,12 @@ const CancelAppointmentPage = ({
     if (form.cancellationReason !== '') {
       await cancelAppointment(booking.reference, site, form.cancellationReason);
 
-    const returnDate = parseToUkDatetime(booking.from).format(dateFormat);
-    const tabNumber = form.cancelAppointment === 'yes' ? 1 : 0;
+      const returnDate = parseToUkDatetime(booking.from).format(dateFormat);
 
-    replace(
-      `/site/${site}/view-availability/daily-appointments?date=${returnDate}&tab=${tabNumber}&page=1`,
-    );
+      replace(
+        `/site/${site}/view-availability/daily-appointments?date=${returnDate}&tab=1&page=1`,
+      );
+    }
   };
 
   return (
@@ -121,7 +121,10 @@ const mapSummaryData = (
     title: 'Name',
     value: `${booking.attendeeDetails.firstName} ${booking.attendeeDetails.lastName}`,
   });
-  items.push({ title: 'NHS number', value: booking.attendeeDetails.nhsNumber });
+  items.push({
+    title: 'NHS number',
+    value: booking.attendeeDetails.nhsNumber,
+  });
   items.push({
     title: 'Date of birth',
     value: parseToUkDatetime(booking.attendeeDetails.dateOfBirth).format(

--- a/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.tsx
+++ b/src/client/src/app/site/[site]/appointment/[reference]/cancel/cancel-appointment-page.tsx
@@ -19,7 +19,7 @@ import { useRouter } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 type CancelFormValue = {
-  cancellationReason: 'CancelledByCitizen' | 'CancelledBySite' | '';
+  cancellationReason?: 'CancelledByCitizen' | 'CancelledBySite';
 };
 
 const CancelAppointmentPage = ({
@@ -37,16 +37,14 @@ const CancelAppointmentPage = ({
     handleSubmit,
     formState: { isSubmitting, isSubmitSuccessful, errors },
   } = useForm<CancelFormValue>({
-    defaultValues: {
-      cancellationReason: '',
-    },
+    defaultValues: {},
   });
   const summaryItems = mapSummaryData(booking, clinicalServices);
 
   const submitForm: SubmitHandler<CancelFormValue> = async (
     form: CancelFormValue,
   ) => {
-    if (form.cancellationReason !== '') {
+    if (form.cancellationReason !== undefined) {
       await cancelAppointment(booking.reference, site, form.cancellationReason);
 
       const returnDate = parseToUkDatetime(booking.from).format(dateFormat);

--- a/src/client/testing/page-objects/view-availability-appointment-pages/daily-appointment-details-page.ts
+++ b/src/client/testing/page-objects/view-availability-appointment-pages/daily-appointment-details-page.ts
@@ -12,6 +12,7 @@ type Appointment = {
 export default class DailyAppointmentDetailsPage extends RootPage {
   readonly backToWeekViewButton: Locator;
   readonly continueButton: Locator;
+  readonly cancelAppointmentButton: Locator;
   readonly appointmentsTable: Locator;
 
   constructor(page: Page) {
@@ -21,6 +22,9 @@ export default class DailyAppointmentDetailsPage extends RootPage {
     });
     this.continueButton = page.getByRole('button', {
       name: 'Continue',
+    });
+    this.cancelAppointmentButton = page.getByRole('button', {
+      name: 'Cancel appointment',
     });
     this.appointmentsTable = page.getByRole('table');
   }
@@ -84,20 +88,6 @@ export default class DailyAppointmentDetailsPage extends RootPage {
       .filter({ hasText: `${appointmentDetail}` })
       .getByRole('link', { name: 'Cancel' })
       .click();
-  }
-
-  async confirmAppointmentCancellation(option: 'Yes' | 'No') {
-    if (option == 'Yes') {
-      await this.page
-        .getByLabel('Yes, I want to cancel this appointment')
-        .click();
-    }
-    if (option == 'No') {
-      await this.page
-        .getByLabel(`No, I do not want to cancel this appointment`)
-        .click();
-    }
-    await this.continueButton.click();
   }
 
   async verifyAppointmentNotCancelled(appointmentDetail: string) {

--- a/src/client/testing/tests/availability/availability.spec.ts
+++ b/src/client/testing/tests/availability/availability.spec.ts
@@ -1003,9 +1003,14 @@ test.describe.configure({ mode: 'serial' });
 
             await dailyAppointmentDetailsPage.verifyDailyAppointmentDetailsPageDisplayed();
             await dailyAppointmentDetailsPage.cancelAppointment('5932817282');
-            await dailyAppointmentDetailsPage.confirmAppointmentCancellation(
-              'No',
+            await dailyAppointmentDetailsPage.cancelAppointmentButton.click();
+
+            const errorMessage = page.locator('.nhsuk-error-message');
+            await expect(errorMessage).toBeVisible();
+            await expect(errorMessage).toContainText(
+              'Select a reason for cancelling the appointment',
             );
+
             await dailyAppointmentDetailsPage.verifyAppointmentNotCancelled(
               '5932817282',
             );

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -518,6 +518,14 @@ public abstract partial class BaseFeatureSteps : Feature
         indexDocument.Resource.Status.Should().Be(status);
     }
 
+    public async Task AssertCancellationReasonByReference(string bookingReference, CancellationReason cancellationReason)
+    {
+        var siteId = GetSiteId();
+        var bookingDocument = await Client.GetContainer("appts", "booking_data")
+            .ReadItemAsync<BookingDocument>(bookingReference, new PartitionKey(siteId));
+        bookingDocument.Resource.CancellationReason.Should().Be(cancellationReason);
+    }
+
     protected static DateTime GetCreationDateTime(BookingType type) => type switch
     {
         BookingType.Recent => DateTime.UtcNow.AddHours(-18),

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/BookingBaseFeatureSteps.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit.Gherkin.Quick;
 using AttendeeDetails = Nhs.Appointments.Core.AttendeeDetails;
@@ -34,8 +35,16 @@ public abstract class BookingBaseFeatureSteps(string flag, bool enabled) : Audit
     {
         var bookingReference = BookingReferences.GetBookingReference(0, BookingType.Confirmed);
         var site = GetSiteId();
-        Response = await Http.PostAsync($"http://localhost:7071/api/booking/{bookingReference}/cancel?site={site}&cancellationReason={cancellationReason}",
-            null);
+
+        var payload = new { cancellationReason };
+
+        var jsonContent = new StringContent(
+            JsonConvert.SerializeObject(payload),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        Response = await Http.PostAsync($"http://localhost:7071/api/booking/{bookingReference}/cancel?site={site}", jsonContent);
     }
 
     [When(@"I cancel the appointment with reference '(.+)'")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Cancel_SingleService.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Cancel_SingleService.feature
@@ -1,4 +1,4 @@
-﻿Feature: Appointment cancellation
+Feature: Appointment cancellation
 
   Scenario: Cancel a booking appointment
     Given the following sessions
@@ -27,3 +27,35 @@
     And the booking with reference '85032-19283' has status 'Booked'
     And the booking with reference '85032-19283' has availability status 'Supported'
     And an audit function document was created for user 'api@test' and function 'CancelBookingFunction'
+
+  Scenario: Cancel a booking appointment without cancellation reason
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following bookings have been made
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:20 | 5        | COVID   |
+    When I cancel the appointment
+    Then the booking has been 'Cancelled'
+    And default cancellation reason has been used
+
+  Scenario: Cancel a booking appointment with invalid cancellation reason
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following bookings have been made
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:20 | 5        | COVID   |
+    When I cancel the appointment with cancellation reason 'InvalidStatus'
+    Then the call should fail with 400
+
+  Scenario: Cancel a booking appointment with valid cancellation reason
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following bookings have been made
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:20 | 5        | COVID   |
+    When I cancel the appointment with cancellation reason 'CancelledBySite'
+    Then the booking has been 'Cancelled'
+    And 'CancelledBySite' cancellation reason has been used

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelBookingFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelBookingFunctionTests.cs
@@ -1,4 +1,3 @@
-using System.Web.Http;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
@@ -10,6 +9,7 @@ using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Core.UnitTests;
+using System.Web.Http;
 
 namespace Nhs.Appointments.Api.Tests.Functions;
 
@@ -28,7 +28,7 @@ public class CancelBookingFunctionTests : FeatureToggledTests
             _userContextProvider.Object, _logger.Object, _metricsRecorder.Object);
         _validator.Setup(x => x.ValidateAsync(It.IsAny<CancelBookingRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
-        _bookingWriteService.Setup(x => x.CancelBooking(null, string.Empty))
+        _bookingWriteService.Setup(x => x.CancelBooking(null, string.Empty, CancellationReason.CancelledByCitizen))  
             .Returns(Task.FromResult(BookingCancellationResult.NotFound));
     }
 
@@ -37,7 +37,7 @@ public class CancelBookingFunctionTests : FeatureToggledTests
     {
         var bookingRef = "some-booking";
         var site = "TEST01";
-        _bookingWriteService.Setup(x => x.CancelBooking(bookingRef, site))
+        _bookingWriteService.Setup(x => x.CancelBooking(bookingRef, site, CancellationReason.CancelledByCitizen)) 
             .Returns(Task.FromResult(BookingCancellationResult.Success));
 
         var request = BuildRequest(bookingRef, site);
@@ -48,11 +48,11 @@ public class CancelBookingFunctionTests : FeatureToggledTests
     }
 
     [Fact]
-    public async Task RunAsync_CallsBookingServiceOnce_WhenBookingCancelled()
+    public async Task RunAsync_CallsBookingServiceOnce_WhenCancellationReasonIsNull()
     {
         var bookingRef = "some-booking";
         var site = "TEST01";
-        _bookingWriteService.Setup(x => x.CancelBooking(bookingRef, site))
+        _bookingWriteService.Setup(x => x.CancelBooking(bookingRef, site, CancellationReason.CancelledByCitizen)) 
             .Returns(Task.FromResult(BookingCancellationResult.Success)).Verifiable(Times.Once);
 
         var request = BuildRequest(bookingRef, site);
@@ -67,7 +67,7 @@ public class CancelBookingFunctionTests : FeatureToggledTests
     {
         var bookingRef = "some-booking";
         var site = "TEST01";
-        _bookingWriteService.Setup(x => x.CancelBooking(It.IsAny<string>(), It.IsAny<string>()))
+        _bookingWriteService.Setup(x => x.CancelBooking(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationReason>()))
             .Returns(Task.FromResult(BookingCancellationResult.NotFound));
 
         var request = BuildRequest(bookingRef, site);
@@ -83,7 +83,7 @@ public class CancelBookingFunctionTests : FeatureToggledTests
         var bookingRef = "some-booking";
         var site = "TEST01";
         var invalidResultCode = 99;
-        _bookingWriteService.Setup(x => x.CancelBooking(It.IsAny<string>(), It.IsAny<string>()))
+        _bookingWriteService.Setup(x => x.CancelBooking(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationReason>()))
             .Returns(Task.FromResult((BookingCancellationResult)invalidResultCode));
 
         var request = BuildRequest(bookingRef, site);
@@ -94,12 +94,40 @@ public class CancelBookingFunctionTests : FeatureToggledTests
         Assert.Equal(500, response.StatusCode);
     }
 
-    private static HttpRequest BuildRequest(string reference, string site)
+    [Theory]
+    [InlineData(null, CancellationReason.CancelledByCitizen)]
+    [InlineData("cancelledByCitizen", CancellationReason.CancelledByCitizen)]
+    [InlineData("cancelledBySite", CancellationReason.CancelledBySite)]
+    public async Task RunAsync_PassesCancellationReasonToService(string queryReason, CancellationReason expectedCancellationReason)
+    {
+        var bookingRef = "some-booking";
+        var site = "TEST01";
+        var cancellationReason = "CancelledByCitizen";
+
+        _bookingWriteService.Setup(x => x.CancelBooking(bookingRef, site, expectedCancellationReason))
+            .Returns(Task.FromResult(BookingCancellationResult.Success)).Verifiable();
+
+        var request = BuildRequest(bookingRef, site, queryReason);
+
+        var response = await _sut.RunAsync(request) as ContentResult;
+
+        Assert.Equal(200, response.StatusCode.Value);
+        _bookingWriteService.Verify();
+    }
+
+    private static HttpRequest BuildRequest(string reference, string site, string? cancellationReason = null)
     {
         var context = new DefaultHttpContext();
         var request = context.Request;
         request.RouteValues = new RouteValueDictionary { { "bookingReference", reference } };
-        request.QueryString = new QueryString($"?site={site}");
+
+        var query = $"?site={site}";
+        if (!string.IsNullOrWhiteSpace(cancellationReason))
+        {
+            query += $"&cancellationReason={Uri.EscapeDataString(cancellationReason)}";
+        }
+
+        request.QueryString = new QueryString(query);
         request.Headers.Append("Authorization", "Test 123");
 
         return request;

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelBookingFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelBookingFunctionTests.cs
@@ -102,7 +102,6 @@ public class CancelBookingFunctionTests : FeatureToggledTests
     {
         var bookingRef = "some-booking";
         var site = "TEST01";
-        var cancellationReason = "CancelledByCitizen";
 
         _bookingWriteService.Setup(x => x.CancelBooking(bookingRef, site, expectedCancellationReason))
             .Returns(Task.FromResult(BookingCancellationResult.Success)).Verifiable();

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/CancelBookingRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/CancelBookingRequestValidatorTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Api.Validators;
+using Nhs.Appointments.Core;
 
 namespace Nhs.Appointments.Api.Tests.Validators;
 
@@ -11,7 +12,7 @@ public class CancelBookingRequestValidatorTests
     [Fact]
     public void Validate_ReturnError_WhenBookingReferenceIsBlank()
     {
-        var testRequest = new CancelBookingRequest(string.Empty, string.Empty);
+        var testRequest = new CancelBookingRequest(string.Empty, string.Empty, CancellationReason.CancelledByCitizen);
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -21,7 +22,7 @@ public class CancelBookingRequestValidatorTests
     [Fact]
     public void Validate_ReturnsTrue_WhenRequestIsValid()
     {
-        var testRequest = new CancelBookingRequest("ref", string.Empty);
+        var testRequest = new CancelBookingRequest("ref", string.Empty, CancellationReason.CancelledByCitizen);
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeTrue();
         result.Errors.Should().HaveCount(0);

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
@@ -499,7 +499,7 @@ namespace Nhs.Appointments.Core.UnitTests
             _bookingsDocumentStore.Setup(x => x.GetByReferenceOrDefaultAsync(It.IsAny<string>()))
                 .Returns(Task.FromResult(new Booking { Site = site, ContactDetails = [] }));
             _bookingsDocumentStore
-                .Setup(x => x.UpdateStatus(bookingRef, AppointmentStatus.Cancelled, AvailabilityStatus.Unknown, null))
+                .Setup(x => x.UpdateStatus(bookingRef, AppointmentStatus.Cancelled, AvailabilityStatus.Unknown, CancellationReason.CancelledByCitizen))
                 .ReturnsAsync(true).Verifiable();
 
             await _sut.CancelBooking(bookingRef, site, CancellationReason.CancelledByCitizen);
@@ -916,10 +916,9 @@ namespace Nhs.Appointments.Core.UnitTests
         }
 
         [Theory]
-        [InlineData(null, CancellationReason.CancelledByCitizen)]
-        [InlineData("CancelledByCitizen", CancellationReason.CancelledByCitizen)]
-        [InlineData("CancelledBySite", CancellationReason.CancelledBySite)]
-        public async Task CancelBooking_ValidCancellationReasonIsUsed(string? reason, CancellationReason expectedReason)
+        [InlineData(CancellationReason.CancelledByCitizen, CancellationReason.CancelledByCitizen)]
+        [InlineData(CancellationReason.CancelledBySite, CancellationReason.CancelledBySite)]
+        public async Task CancelBooking_ValidCancellationReasonIsUsed(CancellationReason reason, CancellationReason expectedReason)
         {
             var reference = "BOOK-123";
             var site = "SITE01";
@@ -937,7 +936,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 .ReturnsAsync(true)
                 .Verifiable();
 
-            var result = await _sut.CancelBooking(reference, site, CancellationReason.CancelledByCitizen);
+            var result = await _sut.CancelBooking(reference, site, reason);
 
             result.Should().Be(BookingCancellationResult.Success);
             _bookingsDocumentStore.Verify();


### PR DESCRIPTION
# Description

Added mandatory cancellation reason selection to the appointment cancellation flow. Reason is stored only upon confirmed cancellation.

# Screenshots

<img width="813" height="584" alt="2025-07-21 124306" src="https://github.com/user-attachments/assets/ff7fd05e-d845-4566-8108-dd6ec32e5563" />
<img width="716" height="568" alt="2025-07-21 124331" src="https://github.com/user-attachments/assets/f6b43118-21cc-4375-824e-f9eafc7737d5" />


# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [X] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [X] I have ran npm tsc / lint (in the future these will be ran automatically)
- [X] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
