### PR TITLE
APPT-669 - Adding site name to site details card on manage site page

### DIFF
--- a/src/client/src/app/lib/services/siteService.ts
+++ b/src/client/src/app/lib/services/siteService.ts
@@ -42,6 +42,10 @@ export const mapCoreSiteSummaryData = (site: Site) => {
 
   const items: SummaryListItem[] = [
     {
+      title: 'Name',
+      value: site.name,
+    },
+    {
       title: 'Address',
       value: site.address.match(/[^,]+,|[^,]+$/g) || [], // Match each word followed by a comma, or the last word without a comma
     },

--- a/src/client/src/app/site/[site]/details/site-details-page.test.tsx
+++ b/src/client/src/app/site/[site]/details/site-details-page.test.tsx
@@ -53,6 +53,7 @@ describe('Site Details Page', () => {
       screen.getByRole('heading', { level: 2, name: 'Site details' }),
     ).toBeVisible();
 
+    verifySummaryListItem('Name', mockSite.name);
     verifySummaryListItem('Address', mockSite.address);
     verifySummaryListItem(
       'Latitude',

--- a/src/client/testing/page-objects/change-site-details-pages/site-details.ts
+++ b/src/client/testing/page-objects/change-site-details-pages/site-details.ts
@@ -16,6 +16,7 @@ export default class SiteDetailsPage extends RootPage {
   readonly accessNeedsheaderMsg = 'Access needs';
   readonly informationForCitizensheaderMsg = 'Information for citizens';
 
+  readonly siteNameLabel = 'Name';
   readonly addressLabel = 'Address';
   readonly latitudeLabel = 'Latitude';
   readonly longitudeLabel = 'Longitude';
@@ -108,11 +109,13 @@ export default class SiteDetailsPage extends RootPage {
   }
 
   async verifyCoreDetailsContent(
+    name: string,
     address: string,
     long: string,
     lat: string,
     phoneNumber: string,
   ) {
+    await this.verifySummaryListItemContentValue(this.siteNameLabel, name);
     await this.verifySummaryListItemContentValue(this.addressLabel, address);
     await this.verifySummaryListItemContentValue(this.latitudeLabel, lat);
     await this.verifySummaryListItemContentValue(this.longitudeLabel, long);
@@ -213,6 +216,7 @@ export default class SiteDetailsPage extends RootPage {
     ).toBeVisible();
 
     await this.verifyCoreDetailsContent(
+      this.siteDetails.name,
       this.siteDetails.address,
       this.siteDetails.location.coordinates[0].toString(),
       this.siteDetails.location.coordinates[1].toString(),


### PR DESCRIPTION
# Description

Adding the site name to the 'core' site details card on the manage site page

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
