### PR TITLE
APPT-950 - Removing the cancelled appointment count on week & day view

### DIFF
--- a/src/client/src/app/lib/components/appointment-counts-summary.test.tsx
+++ b/src/client/src/app/lib/components/appointment-counts-summary.test.tsx
@@ -9,7 +9,6 @@ const mockDaySummary: DaySummary = {
   ...mockDaySummaries[0],
   maximumCapacity: 123,
   bookedAppointments: 5,
-  cancelledAppointments: 7,
   orphanedAppointments: 3,
   remainingCapacity: 118,
 };
@@ -29,48 +28,11 @@ describe('Appointment Counts Summary', () => {
       expect(screen.getByText('Booked: 8')).toBeInTheDocument();
     });
 
-    it('renders a warning if there is a cancelled appointments', () => {
-      render(
-        <AppointmentCountsSummary
-          period={{
-            ...mockDaySummary,
-            cancelledAppointments: 1,
-            orphanedAppointments: 0,
-          }}
-        />,
-      );
-
-      expect(screen.getByText(/There is/)).toBeInTheDocument();
-      expect(screen.getByText('1')).toBeInTheDocument();
-      expect(
-        screen.getByText(/cancelled appointment on this day/),
-      ).toBeInTheDocument();
-    });
-
-    it('renders a warning if there are cancelled appointments', () => {
-      render(
-        <AppointmentCountsSummary
-          period={{
-            ...mockDaySummary,
-            cancelledAppointments: 20,
-            orphanedAppointments: 0,
-          }}
-        />,
-      );
-
-      expect(screen.getByText(/There are/)).toBeInTheDocument();
-      expect(screen.getByText('20')).toBeInTheDocument();
-      expect(
-        screen.getByText(/cancelled appointments on this day/),
-      ).toBeInTheDocument();
-    });
-
     it('does not render a warning if there are no cancelled appointments', () => {
       render(
         <AppointmentCountsSummary
           period={{
             ...mockDaySummary,
-            cancelledAppointments: 0,
             orphanedAppointments: 0,
           }}
         />,
@@ -87,7 +49,6 @@ describe('Appointment Counts Summary', () => {
         <AppointmentCountsSummary
           period={{
             ...mockDaySummary,
-            cancelledAppointments: 0,
             orphanedAppointments: 1,
           }}
         />,
@@ -105,7 +66,6 @@ describe('Appointment Counts Summary', () => {
         <AppointmentCountsSummary
           period={{
             ...mockDaySummary,
-            cancelledAppointments: 0,
             orphanedAppointments: 20,
           }}
         />,
@@ -123,7 +83,6 @@ describe('Appointment Counts Summary', () => {
         <AppointmentCountsSummary
           period={{
             ...mockDaySummary,
-            cancelledAppointments: 0,
             orphanedAppointments: 0,
           }}
         />,
@@ -150,65 +109,11 @@ describe('Appointment Counts Summary', () => {
       expect(screen.getByText('Booked: 5')).toBeInTheDocument();
     });
 
-    it('renders a warning if there is a cancelled appointment', () => {
-      render(
-        <AppointmentCountsSummary
-          period={{
-            ...mockWeekSummary,
-            cancelledAppointments: 1,
-            orphanedAppointments: 0,
-          }}
-        />,
-      );
-
-      expect(screen.getByText(/There is/)).toBeInTheDocument();
-      expect(screen.getByText('1')).toBeInTheDocument();
-      expect(
-        screen.getByText(/cancelled appointment in this week/),
-      ).toBeInTheDocument();
-    });
-
-    it('renders a warning if there are cancelled appointments', () => {
-      render(
-        <AppointmentCountsSummary
-          period={{
-            ...mockWeekSummary,
-            cancelledAppointments: 20,
-            orphanedAppointments: 0,
-          }}
-        />,
-      );
-
-      expect(screen.getByText(/There are/)).toBeInTheDocument();
-      expect(screen.getByText('20')).toBeInTheDocument();
-      expect(
-        screen.getByText(/cancelled appointments in this week/),
-      ).toBeInTheDocument();
-    });
-
-    it('does not render a warning if there are no cancelled appointments', () => {
-      render(
-        <AppointmentCountsSummary
-          period={{
-            ...mockWeekSummary,
-            cancelledAppointments: 0,
-            orphanedAppointments: 0,
-          }}
-        />,
-      );
-
-      expect(screen.queryByText(/There are/)).toBeNull();
-      expect(
-        screen.queryByText(/cancelled appointments in this week/),
-      ).toBeNull();
-    });
-
     it('renders a warning if there is an orphaned appointment', () => {
       render(
         <AppointmentCountsSummary
           period={{
             ...mockWeekSummary,
-            cancelledAppointments: 0,
             orphanedAppointments: 1,
           }}
         />,
@@ -226,7 +131,6 @@ describe('Appointment Counts Summary', () => {
         <AppointmentCountsSummary
           period={{
             ...mockWeekSummary,
-            cancelledAppointments: 0,
             orphanedAppointments: 20,
           }}
         />,
@@ -244,7 +148,6 @@ describe('Appointment Counts Summary', () => {
         <AppointmentCountsSummary
           period={{
             ...mockWeekSummary,
-            cancelledAppointments: 0,
             orphanedAppointments: 0,
           }}
         />,

--- a/src/client/src/app/lib/components/appointment-counts-summary.tsx
+++ b/src/client/src/app/lib/components/appointment-counts-summary.tsx
@@ -11,7 +11,6 @@ export const AppointmentCountsSummary = ({
     bookedAppointments,
     orphanedAppointments,
     remainingCapacity,
-    cancelledAppointments,
   },
 }: AppointmentCountsSummaryProps) => {
   const periodLength = 'daySummaries' in period ? 'week' : 'day';
@@ -21,10 +20,6 @@ export const AppointmentCountsSummary = ({
       <div style={{ marginTop: 10, marginBottom: 10 }}>
         <OrphanedAppointmentsMessage
           orphanedAppointments={orphanedAppointments}
-          periodLength={periodLength}
-        />
-        <CancelledAppointmentsMessage
-          cancelledAppointments={cancelledAppointments}
           periodLength={periodLength}
         />
       </div>
@@ -75,49 +70,6 @@ const OrphanedAppointmentsMessage = ({
         <div>
           There are <strong>{orphanedAppointments}</strong> manual cancellations
           on this day.
-        </div>
-      );
-    default:
-      return null;
-  }
-};
-
-const CancelledAppointmentsMessage = ({
-  cancelledAppointments,
-  periodLength,
-}: {
-  cancelledAppointments: number;
-  periodLength: 'week' | 'day';
-}) => {
-  switch (true) {
-    case periodLength === 'week' && cancelledAppointments === 0:
-      return null;
-    case periodLength === 'week' && cancelledAppointments === 1:
-      return (
-        <div>
-          There is <strong>1</strong> cancelled appointment in this week.
-        </div>
-      );
-    case periodLength === 'week' && cancelledAppointments > 1:
-      return (
-        <div>
-          There are <strong>{cancelledAppointments}</strong> cancelled
-          appointments in this week.
-        </div>
-      );
-    case periodLength === 'day' && cancelledAppointments === 0:
-      return null;
-    case periodLength === 'day' && cancelledAppointments === 1:
-      return (
-        <div>
-          There is <strong>1</strong> cancelled appointment on this day.
-        </div>
-      );
-    case periodLength === 'day' && cancelledAppointments > 1:
-      return (
-        <div>
-          There are <strong>{cancelledAppointments}</strong> cancelled
-          appointments on this day.
         </div>
       );
     default:

--- a/src/client/src/app/site/[site]/view-availability/week-summary-card.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week-summary-card.test.tsx
@@ -65,21 +65,6 @@ describe('Week Summary Card', () => {
     expect(screen.getByText('Unbooked: 476')).toBeInTheDocument();
   });
 
-  it('renders a warning if there are cancelled appointments', () => {
-    render(
-      <WeekSummaryCard
-        ukWeekSummary={{ ...mockWeekSummary, cancelledAppointments: 20 }}
-        clinicalServices={clinicalServices}
-      />,
-    );
-
-    expect(screen.getByText(/There are/)).toBeInTheDocument();
-    expect(screen.getByText('20')).toBeInTheDocument();
-    expect(
-      screen.getByText(/cancelled appointments in this week./),
-    ).toBeInTheDocument();
-  });
-
   it('renders a warning if there are orphaned appointments', () => {
     render(
       <WeekSummaryCard

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
@@ -193,23 +193,6 @@ describe('Day Summary Card', () => {
       ).toBeInTheDocument();
     });
 
-    it('renders a warning if there are cancelled appointments', () => {
-      render(
-        <DaySummaryCard
-          daySummary={{ ...mockDaySummaries[0], cancelledAppointments: 3 }}
-          siteId={'mock-site'}
-          canManageAvailability={true}
-          clinicalServices={clinicalServices}
-        />,
-      );
-
-      expect(screen.getByText(/There are/)).toBeInTheDocument();
-      expect(screen.getByText('3')).toBeInTheDocument();
-      expect(
-        screen.getByText(/cancelled appointments on this day./),
-      ).toBeInTheDocument();
-    });
-
     it('renders a link to view cancelled appointments if there are cancelled appointments', () => {
       render(
         <DaySummaryCard
@@ -523,23 +506,6 @@ describe('Day Summary Card', () => {
       expect(screen.getByText('20')).toBeInTheDocument();
       expect(
         screen.getByText(/manual cancellations on this day./),
-      ).toBeInTheDocument();
-    });
-
-    it('renders a warning if there are cancelled appointments', () => {
-      render(
-        <DaySummaryCard
-          daySummary={{ ...mockEmptyDays[0], cancelledAppointments: 3 }}
-          siteId={'mock-site'}
-          canManageAvailability={true}
-          clinicalServices={clinicalServices}
-        />,
-      );
-
-      expect(screen.getByText(/There are/)).toBeInTheDocument();
-      expect(screen.getByText('3')).toBeInTheDocument();
-      expect(
-        screen.getByText(/cancelled appointments on this day./),
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
# Description

Removing the cancellation calculation on week & day view cards. The manually cancelled calculation **will remain**.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
