### PR TITLE
APPT-976: Only run tfstate script for pen environment

### DIFF
--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -76,6 +76,7 @@ stages:
 
           - task: AzureCLI@2
             displayName: "Create Terraform State Container"
+            condition: eq('${{parameters.env}}', 'pen')
             inputs:
               scriptType: pscore
               scriptLocation: scriptPath


### PR DESCRIPTION
# Description

I foolishly left this off the original PR, and it's caused an error when attempting to deploy main to dev. 

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
