### PR TITLE
APPT-870 - Allowing for partial match on ODS code when searching a site

### DIFF
--- a/src/client/src/app/lib/components/site-list.test.tsx
+++ b/src/client/src/app/lib/components/site-list.test.tsx
@@ -419,7 +419,7 @@ describe('<SiteList>', () => {
     });
   });
 
-  it('cannot find site on partial ODS code search', async () => {
+  it('can find site on partial ODS code search', async () => {
     const testSites: Site[] = [
       {
         id: '34e990af-5dc9-43a6-8895-b9123216d699',
@@ -495,15 +495,15 @@ describe('<SiteList>', () => {
     const searchInput = screen.getByRole('textbox', {
       name: 'Search active sites by name or ODS code',
     });
-    await user.type(searchInput, '1005');
+    await user.type(searchInput, '004');
 
     const searchButton = screen.getByRole('button', { name: /search/i });
     await user.click(searchButton);
 
     await waitFor(() => {
-      expect(screen.getAllByRole('row')).toHaveLength(1);
+      expect(screen.getAllByRole('row')).toHaveLength(2);
       expect(
-        screen.getByText('No sites found matching "1005"'),
+        screen.getByText('Found 1 site(s) matching "004".'),
       ).toBeInTheDocument();
     });
   });

--- a/src/client/src/app/lib/components/site-list.tsx
+++ b/src/client/src/app/lib/components/site-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Site } from '@types';
-import { Button, Table, TextInput } from '@nhsuk-frontend-components';
+import { Table, TextInput } from '@nhsuk-frontend-components';
 import { sortSitesByName } from '@sorting';
 import { ChangeEvent, useState } from 'react';
 import Link from 'next/link';
@@ -23,7 +23,7 @@ const SiteList = ({ sites }: Props) => {
         sortedSites.filter(
           s =>
             s.name.toLowerCase().includes(searchQuery) ||
-            s.odsCode.toLowerCase() === searchQuery,
+            s.odsCode.toLowerCase().includes(searchQuery),
         ),
       );
       setShowSearchMsg(true);


### PR DESCRIPTION
# Description

Allowing for partial matching on ODS code when searching for sites.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
