### PR TITLE
APPT-845: staging and prod config for notifications

### DIFF
--- a/data/CosmosDbSeeder/items/prod/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/prod/core_data/notification_config.json
@@ -9,27 +9,51 @@
       "eventType": "UserRolesChanged"
     },
     {
-      "services": [ "RSV:Adult" ],
-      "emailTemplate": "3db879be-aba8-49c1-895d-900785724b13",
-      "smsTemplate": "e8efc144-825c-4857-8441-05ab5c70e8a6",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+" ],
+      "emailTemplate": "229db6c5-8b14-4f71-802b-4d9495a0fb39",
+      "smsTemplate": "",
+      "eventType": "BookingMade"
+    },
+    {
+      "services": [ "FLU:2_3", "FLU:18_64", "FLU:65+" ],
+      "emailTemplate": "16949eb5-a36c-4c5c-b422-15ea87ae365d",
+      "smsTemplate": "",
+      "eventType": "BookingMade"
+    },
+    {
+      "services": [ "COVID_FLU:18_64", "COVID_FLU:65+" ],
+      "emailTemplate": "8c4248e6-3e2a-40d7-b380-c72dc957a910",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
       "services": [ "RSV:Adult" ],
-      "emailTemplate": "69d737f9-3080-4e57-8459-e5cc7208593e",
-      "smsTemplate": "9fbc4334-c3a4-43e2-aa26-bebaccdcfe8f",
+      "emailTemplate": "9d96219d-75d4-4c0b-8453-1641c52553b2",
+      "smsTemplate": "",
+      "eventType": "BookingMade"
+    },
+    {
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "",
+      "smsTemplate": "d3ada59d-6ea1-4647-aa62-ab06755a83fe",
+      "eventType": "BookingMade"
+    },
+    {
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "b09aef8b-8f26-4382-815b-3c5cffd6b48b",
+      "smsTemplate": "d3a2245a-cd8a-4ffa-8389-bb8b32d25037",
       "eventType": "BookingReminder"
     },
     {
-      "services": [ "RSV:Adult" ],
-      "emailTemplate": "5384bd93-38e3-4813-b395-3d8337c72cfa",
-      "smsTemplate": "af4a5929-a67e-449a-b504-4e67c9112acf",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "4d8ba173-0f58-420e-ba56-f21d4382aa8c",
+      "smsTemplate": "1d5690c2-6da7-4fd8-be68-42929ca1033c",
       "eventType": "BookingCancelled"
-    },    
+    },
     {
-      "services": [ "RSV:Adult" ],
-      "emailTemplate": "37041c45-d02d-4150-a239-0607acc18789",
-      "smsTemplate": "98869efe-da43-4546-ba43-db18d7191e34",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "9d17e6d8-3267-4875-8869-47385b67685e",
+      "smsTemplate": "6f2051d2-18c0-411e-9bd7-085503ffe268",
       "eventType": "BookingRescheduled"
     }
   ]

--- a/data/CosmosDbSeeder/items/stag/core_data/notification_config.json
+++ b/data/CosmosDbSeeder/items/stag/core_data/notification_config.json
@@ -9,99 +9,51 @@
       "eventType": "UserRolesChanged"
     },
     {
-      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+" ],
       "emailTemplate": "d34d6234-27ce-4e27-829c-b41d6d2eead4",
-      "smsTemplate": "b0d985f8-a068-4bb5-9f26-d2520d3c809e",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
+      "services": [ "FLU:2_3", "FLU:18_64", "FLU:65+" ],
       "emailTemplate": "5c95148c-d665-4f47-92a0-4548e4b114ab",
-      "smsTemplate": "6bb0d711-ea4e-49a9-9b69-25af30ad4074",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
+      "services": [ "COVID_FLU:18_64", "COVID_FLU:65+" ],
       "emailTemplate": "cdfe56d9-8478-4b06-809e-5e75ace569c1",
-      "smsTemplate": "87f81bd0-7860-4424-82f3-6ec8e5e04c37",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["RSV:Adult"],
-      "emailTemplate": "a89c6a69-2c7f-422a-9420-db581517c823",
-      "smsTemplate": "3f493a78-0ee9-44f1-aff6-fd484f94d1ff",
+      "services": [ "RSV:Adult" ],
+      "emailTemplate": "e25bfe4f-f675-47e3-943f-283f6c7d35ae",
+      "smsTemplate": "",
       "eventType": "BookingMade"
     },
     {
-      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
-      "emailTemplate": "0d3126b2-1db2-4f7c-9ea7-f734dc699b42",
-      "smsTemplate": "acc62fb6-389f-4786-b685-b8ed126a3ea5",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "",
+      "smsTemplate": "3ea6a33c-a62d-4b79-a330-85d349db6f0d",
+      "eventType": "BookingMade"
+    },
+    {
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "1f5dd1b6-7d7c-4bb7-905a-724bb48e98c6",
+      "smsTemplate": "11f891a3-bd91-40d4-be4d-5fdcbda342bc",
       "eventType": "BookingReminder"
     },
     {
-      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
-      "emailTemplate": "61371ce6-59ae-4d53-8c2d-18c0b92cc592",
-      "smsTemplate": "1be8b191-3de5-4205-9028-7814864ad887",
-      "eventType": "BookingReminder"
-    },
-    {
-      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
-      "emailTemplate": "005c6708-e82e-4eb2-b806-3a7fd951164a",
-      "smsTemplate": "e6934c4b-9fb5-403b-b4be-efeb1dcedc7d",
-      "eventType": "BookingReminder"
-    },
-    {
-      "services": ["RSV:Adult"],
-      "emailTemplate": "c51af46c-bd1d-448d-8d3e-7abe8f2e6ca8",
-      "smsTemplate": "338c19e6-d9c8-4e85-910b-e81b7b6ff8b5",
-      "eventType": "BookingReminder"
-    },
-    {
-      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
-      "emailTemplate": "bd0e95d1-8adf-4b5e-8abd-d02f11281b18",
-      "smsTemplate": "0c08601c-e42d-4b0e-b23e-262b7ca9c793",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "86711740-dec7-4f1a-810c-0f0d45306e36",
+      "smsTemplate": "709e9817-ee98-411a-99c6-123abcd08051",
       "eventType": "BookingCancelled"
     },
     {
-      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
-      "emailTemplate": "eb4a32c1-0839-47bf-878a-5b8ae77d6560",
-      "smsTemplate": "5320797b-3f5e-4dc0-afe1-d7613c721939",
-      "eventType": "BookingCancelled"
-    },
-    {
-      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
-      "emailTemplate": "5de858aa-3c15-48a8-845e-57e9f41ddac4",
-      "smsTemplate": "1b57a890-2953-4c3a-a13e-dd35da9f406f",
-      "eventType": "BookingCancelled"
-    },
-    {
-      "services": ["RSV:Adult"],
-      "emailTemplate": "c2176f0f-21f9-4094-86d6-c592fb685015",
-      "smsTemplate": "5cddbebe-0905-41ab-acc6-1c8011e496c7",
-      "eventType": "BookingCancelled"
-    },
-    {
-      "services": ["COVID:5_11", "COVID:12_17", "COVID:18+"],
-      "emailTemplate": "88aa1820-ffb5-41c5-b997-f2e566f50c6e",
-      "smsTemplate": "deeaddb6-3255-46fd-a5a1-3c98af05e6d8",
-      "eventType": "BookingRescheduled"
-    },
-    {
-      "services": ["FLU:2_3", "FLU:18_64", "FLU:65+"],
-      "emailTemplate": "413d1010-095b-4c33-b2bc-c44ea554765e",
-      "smsTemplate": "f17ce7a1-84f3-4458-9748-ff68945b750c",
-      "eventType": "BookingRescheduled"
-    },
-    {
-      "services": ["COVID_FLU:18_64", "COVID_FLU:65+"],
-      "emailTemplate": "3bcd14e5-f9f7-4b3d-901b-5fb4c40fc789",
-      "smsTemplate": "8293edf5-6a91-4458-b374-6d9970773b01",
-      "eventType": "BookingRescheduled"
-    },
-    {
-      "services": ["RSV:Adult"],
-      "emailTemplate": "6fc813a9-1c8e-40a1-adab-e207719887dd",
-      "smsTemplate": "dd254efe-2d1a-4b1a-84b5-ebd8a56127b0",
+      "services": [ "COVID:5_11", "COVID:12_17", "COVID:18+", "FLU:2_3", "FLU:18_64", "FLU:65+", "COVID_FLU:18_64", "COVID_FLU:65+", "RSV:Adult" ],
+      "emailTemplate": "ca6cc4e3-5c7a-447f-b528-56deb0c7e3fd",
+      "smsTemplate": "10f83ca9-83ee-4cb9-85a5-1a59231f09bf",
       "eventType": "BookingRescheduled"
     }
   ]


### PR DESCRIPTION
# Description
Updating notification configuration for Staging and Production to benefit from new email and sms templates.

Cherry-picking from main branch as it's needed in R2.3. https://github.com/NHSDigital/nbs-appointments-management-service/pull/811

# Checklist:
- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [X] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [X] I have ran npm tsc / lint (in the future these will be ran automatically)
- [X] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests

