### PR TITLE
APPT-1111 Configure deploy pipeline to auto-deploy to the Dev environment.

### DIFF
--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -105,6 +105,7 @@ stages:
                 terraform plan -no-color -input=false -var="GOV_NOTIFY_API_KEY=$(GOV_NOTIFY_API_KEY)" -var="SPLUNK_HEC_TOKEN=$(SPLUNK_HEC_TOKEN)" -var="NHS_MAIL_CLIENT_SECRET=$(AUTH_PROVIDER_CLIENT_SECRET)" -var="OKTA_CLIENT_SECRET=$(OKTA_CLIENT_SECRET)" -var="OKTA_PRIVATE_KEY_KID=$(OKTA_PRIVATE_KEY_KID)" -var="OKTA_PEM=$(OKTA_PEM)" -var="BUILD_NUMBER=${{parameters.buildNumber}}"
       - job: ApproveTerraformPlan
         dependsOn: RunTerraformPlan
+        condition: not('${{parameters.env}}', 'dev')
         displayName: "Approve Terraform Plan"
         pool: server
         steps:
@@ -114,7 +115,11 @@ stages:
               notifyUsers: ""
               instructions: Review plan and approve
       - deployment: ApplyTerraform
-        dependsOn: ApproveTerraformPlan
+        dependsOn:
+          - ${{ if eq(parameters.env, 'dev') }}:
+              - RunTerraformPlan
+          - ${{ if not(parameters.env, 'dev') }}:
+              - ApproveTerraformPlan
         displayName: "Apply Terraform"
         environment: nbs-mya-${{parameters.env}}
         strategy:


### PR DESCRIPTION
# Description

Only ApproveTerraform plan if the environment is not-Dev. Apply terraform only depends on approval if not-Dev, else it depends on RunTerraform.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
