### PR TITLE
APPT-1146 - Ensuring regional user email addresses are lowercase

### DIFF
--- a/src/api/Nhs.Appointments.Core/BulkImport/UserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/UserDataImportHandler.cs
@@ -75,7 +75,7 @@ public class UserDataImportHandler(
                 var isRegionPermission = !string.IsNullOrEmpty(userRow.Region);
                 if (isRegionPermission)
                 {
-                    await userService.UpdateRegionalUserRoleAssignmentsAsync(userRow.UserId, $"region:{userRow.Region}", userRow.RoleAssignments);
+                    await userService.UpdateRegionalUserRoleAssignmentsAsync(userRow.UserId.ToLower(), $"region:{userRow.Region}", userRow.RoleAssignments);
                 }
                 else
                 {

--- a/tests/Nhs.Appointments.Core.UnitTests/BulkImport/UserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BulkImport/UserDataImportHandlerTests.cs
@@ -410,6 +410,7 @@ public class UserDataImportHandlerTests
         [
             "test1@nhs.net,Jane,Smith,,,,,,R1",
             "test2@nhs.net,John,Smith,,,,,,R2",
+            "MiXed.CASE.email@nhs.net,John,Smith,,,,,,R2"
         ];
         var input = CsvFileBuilder.BuildInputCsv(UsersHeader, inputRows);
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
@@ -425,11 +426,12 @@ public class UserDataImportHandlerTests
 
         var report = await _sut.ProcessFile(file);
 
-        report.Count().Should().Be(2);
+        report.Count().Should().Be(3);
         report.All(r => r.Success).Should().BeTrue();
 
         _userServiceMock.Verify(u => u.UpdateRegionalUserRoleAssignmentsAsync("test1@nhs.net", "region:R1", It.IsAny<IEnumerable<RoleAssignment>>()), Times.Exactly(1));
         _userServiceMock.Verify(u => u.UpdateRegionalUserRoleAssignmentsAsync("test2@nhs.net", "region:R2", It.IsAny<IEnumerable<RoleAssignment>>()), Times.Exactly(1));
+        _userServiceMock.Verify(u => u.UpdateRegionalUserRoleAssignmentsAsync("mixed.case.email@nhs.net", "region:R2", It.IsAny<IEnumerable<RoleAssignment>>()), Times.Exactly(1));
 
         _userServiceMock.Verify(u => u.UpdateUserRoleAssignmentsAsync("test1@nhs.net", "region:R1", It.IsAny<IEnumerable<RoleAssignment>>(), false), Times.Never);
         _userServiceMock.Verify(u => u.UpdateUserRoleAssignmentsAsync("test2@nhs.net", "region:R2", It.IsAny<IEnumerable<RoleAssignment>>(), false), Times.Never);


### PR DESCRIPTION
# Description

When bulk importing regional users, we missed a step to convert their email addresses to lowercase meaning they couldn't see any sites in the site list. This PR fixes the lowercase conversion before adding them to the DB.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
