### PR TITLE
Appt 1109 - Bulk upload admin users

### DIFF
--- a/postman-collection/Bulk Import.postman_collection.json
+++ b/postman-collection/Bulk Import.postman_collection.json
@@ -85,6 +85,46 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "admin-user/import",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "",
+						"type": "text"
+					},
+					{
+						"key": "ClientId",
+						"value": "",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "file",
+							"value": "",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{baseUrl}}/api/admin-user/import",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"api",
+						"admin-user",
+						"import"
+					]
+				}
+			},
+			"response": []
 		}
 	]
 }

--- a/src/api/Nhs.Appointments.Api/Factories/DataImportHandlerFactory.cs
+++ b/src/api/Nhs.Appointments.Api/Factories/DataImportHandlerFactory.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-using Nhs.Appointments.Core;
+using Nhs.Appointments.Core.BulkImport;
 using Nhs.Appointments.Core.Constants;
 using System;
 
@@ -8,6 +8,7 @@ public class DataImportHandlerFactory(IServiceProvider serviceProvider) : IDataI
 {
     public IDataImportHandler CreateDataImportHandler(string importType) => importType switch
     {
+        BulkImportType.AdminUser => serviceProvider.GetService<IAdminUserDataImportHandler>(),
         BulkImportType.ApiUser => serviceProvider.GetService<IApiUserDataImportHandler>(),
         BulkImportType.Site => serviceProvider.GetService<ISiteDataImportHandler>(),
         BulkImportType.User => serviceProvider.GetService<IUserDataImportHandler>(),

--- a/src/api/Nhs.Appointments.Api/Factories/IDataImportHandlerFactory.cs
+++ b/src/api/Nhs.Appointments.Api/Factories/IDataImportHandlerFactory.cs
@@ -1,4 +1,4 @@
-using Nhs.Appointments.Core;
+using Nhs.Appointments.Core.BulkImport;
 
 namespace Nhs.Appointments.Api.Factories;
 public interface IDataImportHandlerFactory

--- a/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
+++ b/src/api/Nhs.Appointments.Api/FunctionConfigurationExtensions.cs
@@ -23,6 +23,7 @@ using Nhs.Appointments.Api.Json;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Api.Notifications;
 using Nhs.Appointments.Core;
+using Nhs.Appointments.Core.BulkImport;
 using Nhs.Appointments.Core.Features;
 using Nhs.Appointments.Core.Messaging;
 using Nhs.Appointments.Core.Okta;
@@ -107,7 +108,8 @@ public static class FunctionConfigurationExtensions
             .AddTransient<IClinicalServiceProvider, ClinicalServiceProvider>()
             .AddScoped<IMetricsRecorder, InMemoryMetricsRecorder>()
             .AddUserNotifications(configuration)
-            .AddAutoMapper(typeof(CosmosAutoMapperProfile));
+            .AddAutoMapper(typeof(CosmosAutoMapperProfile))
+            .AddTransient<IAdminUserDataImportHandler, AdminUserDataImportHandler>();
 
         var leaseManagerConnection = Environment.GetEnvironmentVariable("LEASE_MANAGER_CONNECTION");
         if (leaseManagerConnection == "local")

--- a/src/api/Nhs.Appointments.Core/ApiUserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/ApiUserDataImportHandler.cs
@@ -1,5 +1,6 @@
 using CsvHelper.Configuration;
 using Microsoft.AspNetCore.Http;
+using Nhs.Appointments.Core.BulkImport;
 
 namespace Nhs.Appointments.Core;
 

--- a/src/api/Nhs.Appointments.Core/BulkImport/AdminUserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/AdminUserDataImportHandler.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Nhs.Appointments.Core.BulkImport;
+public class AdminUserDataImportHandler(IUserService userService) : IAdminUserDataImportHandler
+{
+    public async Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile)
+    {
+        var adminUserImportRows = new List<AdminUserImportRow>();
+        var processor = new CsvProcessor<AdminUserImportRow, AdminUserImportRowMap>(
+            aui => Task.Run(() => adminUserImportRows.Add(aui)),
+            aui => aui.Email,
+            () => new AdminUserImportRowMap());
+
+        using TextReader fileReader = new StreamReader(inputFile.OpenReadStream());
+        var report = (await processor.ProcessFile(fileReader)).ToList();
+
+        if (report.Any(r => !r.Success))
+        {
+            return report.Where(r => !r.Success);
+        }
+
+        foreach (var row in adminUserImportRows)
+        {
+            try
+            {
+                var lowerUserId = row.Email.ToLower();
+
+                var user = await userService.GetUserAsync(lowerUserId);
+
+                if (user is null)
+                {
+                    await userService.SaveAdminUserAsync(lowerUserId);
+                }
+                else
+                {
+                    await userService.RemoveAdminUserAsync(lowerUserId);
+                }
+            }
+            catch (Exception ex)
+            {
+                report.Add(new ReportItem(-1, row.Email, false, ex.Message));
+            }
+        }
+
+        return report;
+    }
+
+    public class AdminUserImportRow
+    {
+        public string Email { get; set; }
+    }
+}

--- a/src/api/Nhs.Appointments.Core/BulkImport/AdminUserImportRowMap.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/AdminUserImportRowMap.cs
@@ -11,14 +11,22 @@ public class AdminUserImportRowMap : ClassMap<AdminUserImportRow>
         {
             var email = x.Row.GetField<string>("Email");
 
-            if (CsvFieldValidator.StringHasValue(email))
+            if (!CsvFieldValidator.StringHasValue(email))
             {
-                return RegularExpressionConstants.EmailAddressRegex().IsMatch(email)
-                    ? email
-                    : throw new ArgumentException($"Admin user email: {email} is not a valid email address.");
+                throw new ArgumentNullException("Email field must have a value.");
             }
 
-            throw new ArgumentNullException("Email field must have a value");
+            if (!RegularExpressionConstants.EmailAddressRegex().IsMatch(email))
+            {
+                throw new ArgumentException($"Admin user email: '{email}' is not a valid email address.");
+            }
+
+            if (!email.EndsWith("nhs.net"))
+            {
+                throw new ArgumentException($"Email must be an nhs.net email domain. Current email: '{email}'");
+            }
+
+            return email;
         });
     }
 }

--- a/src/api/Nhs.Appointments.Core/BulkImport/AdminUserImportRowMap.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/AdminUserImportRowMap.cs
@@ -1,0 +1,24 @@
+using CsvHelper.Configuration;
+using Nhs.Appointments.Core.Constants;
+using static Nhs.Appointments.Core.BulkImport.AdminUserDataImportHandler;
+
+namespace Nhs.Appointments.Core.BulkImport;
+public class AdminUserImportRowMap : ClassMap<AdminUserImportRow>
+{
+    public AdminUserImportRowMap()
+    {
+        Map(m => m.Email).Convert(x =>
+        {
+            var email = x.Row.GetField<string>("Email");
+
+            if (CsvFieldValidator.StringHasValue(email))
+            {
+                return RegularExpressionConstants.EmailAddressRegex().IsMatch(email)
+                    ? email
+                    : throw new ArgumentException($"Admin user email: {email} is not a valid email address.");
+            }
+
+            throw new ArgumentNullException("Email field must have a value");
+        });
+    }
+}

--- a/src/api/Nhs.Appointments.Core/BulkImport/IDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/IDataImportHandler.cs
@@ -1,12 +1,13 @@
 using Microsoft.AspNetCore.Http;
 
-namespace Nhs.Appointments.Core;
+namespace Nhs.Appointments.Core.BulkImport;
 
 public interface IDataImportHandler
 {
     Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile);
 }
 
+public interface IAdminUserDataImportHandler : IDataImportHandler { }
 public interface IApiUserDataImportHandler : IDataImportHandler { }
 public interface ISiteDataImportHandler : IDataImportHandler { }
 public interface IUserDataImportHandler : IDataImportHandler { }

--- a/src/api/Nhs.Appointments.Core/BulkImport/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/SiteDataImporterHandler.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Http;
 
-namespace Nhs.Appointments.Core;
+namespace Nhs.Appointments.Core.BulkImport;
 
 public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodesService wellKnowOdsCodesService) : ISiteDataImportHandler
 {

--- a/src/api/Nhs.Appointments.Core/BulkImport/SiteMap.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/SiteMap.cs
@@ -1,8 +1,8 @@
 using CsvHelper.Configuration;
 using Nhs.Appointments.Core.Constants;
-using static Nhs.Appointments.Core.SiteDataImporterHandler;
+using static Nhs.Appointments.Core.BulkImport.SiteDataImporterHandler;
 
-namespace Nhs.Appointments.Core;
+namespace Nhs.Appointments.Core.BulkImport;
 
 public class SiteMap : ClassMap<SiteImportRow>
 {

--- a/src/api/Nhs.Appointments.Core/BulkImport/UserDataImportHandler.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/UserDataImportHandler.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Nhs.Appointments.Core.Features;
 
-namespace Nhs.Appointments.Core;
+namespace Nhs.Appointments.Core.BulkImport;
 
 public class UserDataImportHandler(
     IUserService userService, 

--- a/src/api/Nhs.Appointments.Core/BulkImport/UserImportRowMap.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/UserImportRowMap.cs
@@ -1,9 +1,9 @@
 using CsvHelper;
 using CsvHelper.Configuration;
 using Nhs.Appointments.Core.Constants;
-using static Nhs.Appointments.Core.UserDataImportHandler;
+using static Nhs.Appointments.Core.BulkImport.UserDataImportHandler;
 
-namespace Nhs.Appointments.Core;
+namespace Nhs.Appointments.Core.BulkImport;
 
 public class UserImportRowMap : ClassMap<UserImportRow>
 {
@@ -123,7 +123,7 @@ public class UserImportRowMap : ClassMap<UserImportRow>
         var siteHasValue = CsvFieldValidator.StringHasValue(siteValue);
         var regionHasValue = CsvFieldValidator.StringHasValue(regionValue);
 
-        if ((siteHasValue && regionHasValue) || (!siteHasValue && !regionHasValue))
+        if (siteHasValue && regionHasValue || !siteHasValue && !regionHasValue)
             throw new ArgumentException("Exactly one of Site or Region must be populated.");
     }
 }

--- a/src/api/Nhs.Appointments.Core/Constants/BulkImportType.cs
+++ b/src/api/Nhs.Appointments.Core/Constants/BulkImportType.cs
@@ -1,6 +1,8 @@
 namespace Nhs.Appointments.Core.Constants;
 public static class BulkImportType
 {
+    public const string AdminUser = "admin-user";
+    // TODO: Can apiUser be removed completely?
     public const string ApiUser = "apiUser";
     public const string Site = "site";
     public const string User = "user";

--- a/src/api/Nhs.Appointments.Core/IUserService.cs
+++ b/src/api/Nhs.Appointments.Core/IUserService.cs
@@ -11,4 +11,6 @@ public interface IUserService
     Task SaveUserAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
     Task<UserIdentityStatus> GetUserIdentityStatusAsync(string siteId, string userId);
     Task UpdateRegionalUserRoleAssignmentsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
+    Task SaveAdminUserAsync(string userId);
+    Task RemoveAdminUserAsync(string userId);
 }

--- a/src/api/Nhs.Appointments.Core/IUserStore.cs
+++ b/src/api/Nhs.Appointments.Core/IUserStore.cs
@@ -12,4 +12,6 @@ public interface IUserStore
 
     Task<OperationResult> RecordEulaAgreementAsync(string userId, DateOnly versionDate);
     Task UpdateUserRegionPermissionsAsync(string userId, string scope, IEnumerable<RoleAssignment> roleAssignments);
+    Task SaveAdminUserAsync(User adminUser);
+    Task RemoveAdminUserAsync(string userId);
 }

--- a/src/api/Nhs.Appointments.Core/Nhs.Appointments.Core.csproj
+++ b/src/api/Nhs.Appointments.Core/Nhs.Appointments.Core.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.5" />
 		<PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.1.0" />
 		<PackageReference Include="Polly" Version="8.5.2" />
-        <PackageReference Include="Okta.Sdk" Version="9.2.3"/>
+        <PackageReference Include="Okta.Sdk" Version="9.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/api/Nhs.Appointments.Core/UserService.cs
+++ b/src/api/Nhs.Appointments.Core/UserService.cs
@@ -148,6 +148,25 @@ public class UserService(
                 return false;
         }
     }
+
+    public async Task SaveAdminUserAsync(string userId)
+    {
+        var roleAssignments = new List<RoleAssignment>
+        {
+            new() { Role = "system:admin-user", Scope = "global" }
+        };
+
+        var user = new User
+        {
+            Id = userId.ToLower(),
+            RoleAssignments = [.. roleAssignments]
+        };
+
+        await userStore.SaveAdminUserAsync(user);
+    }
+
+    public async Task RemoveAdminUserAsync(string userId)
+        => await userStore.RemoveAdminUserAsync(userId);
 }
 
 public record UpdateUserRoleAssignmentsResult(bool success, string errorUser, IEnumerable<string> errorRoles)

--- a/src/api/Nhs.Appointments.Persistance/UserStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/UserStore.cs
@@ -157,4 +157,10 @@ public class UserStore(ITypedDocumentCosmosStore<UserDocument> cosmosStore, IMap
     {
         return await cosmosStore.GetByIdOrDefaultAsync<User>(userId);
     }
+
+    public async Task SaveAdminUserAsync(User adminUser)
+        => await InsertAsync(adminUser);
+
+    public async Task RemoveAdminUserAsync(string userId) =>
+        await cosmosStore.DeleteDocument(userId, cosmosStore.GetDocumentType());
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/BulkImportFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/BulkImportFunctionTests.cs
@@ -10,6 +10,7 @@ using Nhs.Appointments.Api.Factories;
 using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
+using Nhs.Appointments.Core.BulkImport;
 using Nhs.Appointments.Core.Features;
 using Nhs.Appointments.Core.UnitTests;
 

--- a/tests/Nhs.Appointments.Core.UnitTests/BulkImport/AdminUserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BulkImport/AdminUserDataImportHandlerTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.AspNetCore.Http;
+using Nhs.Appointments.Core.BulkImport;
+using System.Text;
+
+namespace Nhs.Appointments.Core.UnitTests.BulkImport;
+public class AdminUserDataImportHandlerTests
+{
+    private readonly Mock<IUserService> _userServiceMock = new();
+
+    private readonly AdminUserDataImportHandler _sut;
+    private const string AdminUserHeader = "Email";
+
+    public AdminUserDataImportHandlerTests()
+    {
+        _sut = new AdminUserDataImportHandler(_userServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task ReportsEmailAddressNotProvided()
+    {
+        string[] inputRows = [ "test.user@nhs.net", " " ];
+        var input = CsvFileBuilder.BuildInputCsv(AdminUserHeader, inputRows);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var result = await _sut.ProcessFile(file);
+
+        result.Count().Should().Be(1);
+        result.All(r => r.Success).Should().BeFalse();
+        result.Last().Message.Should().Be("Value cannot be null. (Parameter 'Email field must have a value.')");
+    }
+
+    [Fact]
+    public async Task ReportsInvalidEmailAddress()
+    {
+        string[] inputRows = ["invalid-email-address"];
+        var input = CsvFileBuilder.BuildInputCsv(AdminUserHeader, inputRows);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var result = await _sut.ProcessFile(file);
+
+        result.Count().Should().Be(1);
+        result.All(r => r.Success).Should().BeFalse();
+        result.First().Message.Should().Be("Admin user email: 'invalid-email-address' is not a valid email address.");
+    }
+
+    [Fact]
+    public async Task ReportsInvalidEmailDomain()
+    {
+        string[] inputRows = ["invalid.email@domain.com"];
+        var input = CsvFileBuilder.BuildInputCsv(AdminUserHeader, inputRows);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        var result = await _sut.ProcessFile(file);
+
+        result.Count().Should().Be(1);
+        result.All(r => r.Success).Should().BeFalse();
+        result.First().Message.Should().Be("Email must be an nhs.net email domain. Current email: 'invalid.email@domain.com'");
+    }
+
+    [Fact]
+    public async Task SavesAdminUser_WhenTheyDontAlreadyExist_AndConvertsEmailToLowercase()
+    {
+        string[] inputRows =
+        [
+            "USER.doesnt.exIST1@nhs.net",
+            "User.DoESnT.Exist2@nhs.net"
+        ];
+        var input = CsvFileBuilder.BuildInputCsv(AdminUserHeader, inputRows);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        _userServiceMock.Setup(x => x.GetUserAsync(It.IsAny<string>()))
+            .ReturnsAsync(null as User);
+
+        var result = await _sut.ProcessFile(file);
+
+        result.Count().Should().Be(2);
+        result.All(r => r.Success).Should().BeTrue();
+
+        _userServiceMock.Verify(x => x.SaveAdminUserAsync("user.doesnt.exist1@nhs.net"), Times.Once);
+        _userServiceMock.Verify(x => x.SaveAdminUserAsync("user.doesnt.exist2@nhs.net"), Times.Once);
+    }
+
+    [Fact]
+    public async Task RemovesAdminUser_WhenTheyAlreadyExist()
+    {
+        string[] inputRows = ["user.already.exists@nhs.net"];
+        var input = CsvFileBuilder.BuildInputCsv(AdminUserHeader, inputRows);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        _userServiceMock.Setup(x => x.GetUserAsync(It.IsAny<string>()))
+            .ReturnsAsync(new User
+            {
+                Id = "user.already.exists@nhs.net",
+                RoleAssignments =
+                [
+                    new()
+                    {
+                        Role = "system:admin-user",
+                        Scope = "global"
+                    }
+                ]
+            });
+
+        var result = await _sut.ProcessFile(file);
+
+        result.Count().Should().Be(1);
+        result.All(r => r.Success).Should().BeTrue();
+
+        _userServiceMock.Verify(x => x.RemoveAdminUserAsync("user.already.exists@nhs.net"), Times.Once);
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/BulkImport/ApiUserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BulkImport/ApiUserDataImportHandlerTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using System.Text;
 
-namespace Nhs.Appointments.Core.UnitTests;
+namespace Nhs.Appointments.Core.UnitTests.BulkImport;
 public class ApiUserDataImportHandlerTests
 {
     private readonly Mock<IUserService> _userServiceMock = new();

--- a/tests/Nhs.Appointments.Core.UnitTests/BulkImport/SiteDataImporterHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BulkImport/SiteDataImporterHandlerTests.cs
@@ -3,7 +3,7 @@ using Nhs.Appointments.Core.BulkImport;
 using System.Runtime.Intrinsics.Arm;
 using System.Text;
 
-namespace Nhs.Appointments.Core.UnitTests;
+namespace Nhs.Appointments.Core.UnitTests.BulkImport;
 public class SiteDataImporterHandlerTests
 {
     private readonly Mock<ISiteService> _siteServiceMock = new();

--- a/tests/Nhs.Appointments.Core.UnitTests/BulkImport/UserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BulkImport/UserDataImportHandlerTests.cs
@@ -3,7 +3,7 @@ using Nhs.Appointments.Core.BulkImport;
 using Nhs.Appointments.Core.Features;
 using System.Text;
 
-namespace Nhs.Appointments.Core.UnitTests;
+namespace Nhs.Appointments.Core.UnitTests.BulkImport;
 public class UserDataImportHandlerTests
 {
     private readonly Mock<IUserService> _userServiceMock = new();

--- a/tests/Nhs.Appointments.Core.UnitTests/SiteDataImporterHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/SiteDataImporterHandlerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using Nhs.Appointments.Core.BulkImport;
 using System.Runtime.Intrinsics.Arm;
 using System.Text;
 

--- a/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/UserDataImportHandlerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using Nhs.Appointments.Core.BulkImport;
 using Nhs.Appointments.Core.Features;
 using System.Text;
 

--- a/tests/Nhs.Appointments.Core.UnitTests/UserServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/UserServiceTests.cs
@@ -447,5 +447,33 @@ namespace Nhs.Appointments.Core.UnitTests
 
             _messageBus.Verify(x => x.Send(It.IsAny<object>()), Times.Never);
         }
+
+        [Fact]
+        public async Task SaveAdminUser_AssignsAdminUserRole()
+        {
+            var adminEmail = "admin.user@nhs.net";
+            var expectedUser = new User
+            {
+                Id = adminEmail,
+                LatestAcceptedEulaVersion = null,
+                RoleAssignments =
+                [
+                    new()
+                    {
+                        Role = "system:admin-user",
+                        Scope = "global"
+                    }
+                ]
+            };
+
+            await _sut.SaveAdminUserAsync("admin.user@nhs.net");
+
+            _userStore.Verify(x => x.SaveAdminUserAsync(It.Is<User>(
+                u => u.Id == adminEmail &&
+                     u.RoleAssignments.Length == 1 &&
+                     u.RoleAssignments.First().Role == expectedUser.RoleAssignments.First().Role &&
+                     u.RoleAssignments.First().Scope == expectedUser.RoleAssignments.First().Scope &&
+                     u.LatestAcceptedEulaVersion == expectedUser.LatestAcceptedEulaVersion)), Times.Once);
+        }
     }
 }


### PR DESCRIPTION
# Description

Add the ability to add and remove admin users via the bulk upload. Validation is as follows:
- Email address is mandatory
- Must be a valid email address
- Email address must end in nhs.net

1. If an email in the bulk import already exists in the DB, we will delete that user from the DB
2. If an email in the bulk import does not exist in the DB already, add them with only admin permissions

I have also created a new BulkImport folder in the core project and unit test project to clean up the code base a little.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
