### PR TITLE
APPT-1147: Unable to add okta user

### DIFF
--- a/src/api/Nhs.Appointments.Core/Okta/OktaService.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaService.cs
@@ -9,8 +9,9 @@ public class OktaService(IOktaUserDirectory oktaUserDirectory, TimeProvider time
         switch (oktaUser?.Status)
         {
             case null:
-            case OktaUserStatus.Deactivated:
                 return await CreateUser(userEmail, firstName, lastName);
+            case OktaUserStatus.Deactivated:
+                return await ReactivateUser(userEmail);
             case OktaUserStatus.Active:
                 return new UserProvisioningStatus { Success = true };
             case OktaUserStatus.Provisioned:

--- a/src/api/Nhs.Appointments.Core/Okta/OktaUserDirectory.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaUserDirectory.cs
@@ -90,25 +90,25 @@ public class OktaUserDirectory : IOktaUserDirectory
     /// <returns></returns>
     private OktaUserStatus GetUserStatusForMya(UserStatus userStatus)
     {
-        switch (userStatus)
+        switch (userStatus.Value)
         {
             // Okta account management isn't our concern, so treat states where admin action is needed
             // as being active as far as we're concerned
-            case nameof(UserStatus.ACTIVE):
-            case nameof(UserStatus.SUSPENDED):
-            case nameof(UserStatus.RECOVERY):
-            case nameof(UserStatus.PASSWORDEXPIRED):
-            case nameof(UserStatus.LOCKEDOUT):
+            case "ACTIVE":
+            case "SUSPENDED":
+            case "RECOVERY":
+            case "PASSWORD_EXPIRED":
+            case "LOCKED_OUT":
                 return OktaUserStatus.Active;
 
             // A provisioned user needs to set their own password and activate their account to move to the Active state
             // The only workflow we can safely begin for them is "Deactivate User" ("Reactivate" calls this followed by "Activate")
-            case nameof(UserStatus.PROVISIONED):
+            case "PROVISIONED":
                 return OktaUserStatus.Provisioned;
 
             // Is a user is Staged, Deprovisioned, or has never existed, it is safe to begin the "Activate User" workflow for them
-            case nameof(UserStatus.STAGED):
-            case nameof(UserStatus.DEPROVISIONED):
+            case "STAGED":
+            case "DEPROVISIONED":
                 return OktaUserStatus.Deactivated;
 
             default:

--- a/src/api/Nhs.Appointments.Core/Okta/OktaUserDirectory.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/OktaUserDirectory.cs
@@ -9,9 +9,9 @@ namespace Nhs.Appointments.Core.Okta;
 public class OktaUserDirectory : IOktaUserDirectory
 {
     private readonly ILogger<OktaUserDirectory> _logger;
-    private readonly UserApi _userApi;
+    private readonly IUserApi _userApi;
 
-    public OktaUserDirectory(UserApi userApi, ILogger<OktaUserDirectory> logger)
+    public OktaUserDirectory(IUserApi userApi, ILogger<OktaUserDirectory> logger)
     {
         _userApi = userApi;
         _logger = logger;
@@ -90,6 +90,12 @@ public class OktaUserDirectory : IOktaUserDirectory
     /// <returns></returns>
     private OktaUserStatus GetUserStatusForMya(UserStatus userStatus)
     {
+        // Okta's UserStatus class defines static fields like `LOCKEDOUT` but assigns them string values like "LOCKED_OUT".
+        // Because the field name and value don't always match (e.g., LOCKEDOUT => "LOCKED_OUT"),
+        // we cannot rely on enum field names or use nameof(...). Instead, we match on userStatus.Value,
+        // comparing directly against known status string values returned by Okta's API.
+        // This approach ensures compatibility with Okta's inconsistent enum-style implementation.
+
         switch (userStatus.Value)
         {
             // Okta account management isn't our concern, so treat states where admin action is needed

--- a/src/api/Nhs.Appointments.Core/Okta/ServiceProviderExtensions.cs
+++ b/src/api/Nhs.Appointments.Core/Okta/ServiceProviderExtensions.cs
@@ -32,7 +32,7 @@ public static class ServiceProviderExtensions
         }
 
         services.AddSingleton<IOktaUserDirectory, OktaUserDirectory>();
-        services.AddSingleton<UserApi>(sp =>
+        services.AddSingleton<IUserApi>(sp =>
         {
             var oktaOptions = sp.GetRequiredService<IOptions<OktaConfiguration>>().Value;
 

--- a/tests/Nhs.Appointments.Core.UnitTests/Nhs.Appointments.Core.UnitTests.csproj
+++ b/tests/Nhs.Appointments.Core.UnitTests/Nhs.Appointments.Core.UnitTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Okta.Sdk" Version="9.2.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Nhs.Appointments.Core.UnitTests/Okta/OktaUserDirectoryTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/Okta/OktaUserDirectoryTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging;
+using Nhs.Appointments.Core.Okta;
+using Okta.Sdk.Api;
+using Okta.Sdk.Model;
+using OktaUser = Okta.Sdk.Model.User;
+
+namespace Nhs.Appointments.Core.UnitTests.Okta;
+public class OktaUserDirectoryTests
+{
+    private readonly Mock<ILogger<OktaUserDirectory>> _loggerMock = new();
+    private readonly Mock<IUserApi> _userApiMock = new();
+    private readonly OktaUserDirectory _sut;
+
+    public OktaUserDirectoryTests()
+    {
+        _sut = new OktaUserDirectory(_userApiMock.Object, _loggerMock.Object);
+    }
+
+    [Theory]
+    [InlineData("ACTIVE", OktaUserStatus.Active)]
+    [InlineData("SUSPENDED", OktaUserStatus.Active)]
+    [InlineData("RECOVERY", OktaUserStatus.Active)]
+    [InlineData("PASSWORD_EXPIRED", OktaUserStatus.Active)]
+    [InlineData("LOCKED_OUT", OktaUserStatus.Active)]
+    [InlineData("PROVISIONED", OktaUserStatus.Provisioned)]
+    [InlineData("STAGED", OktaUserStatus.Deactivated)]
+    [InlineData("DEPROVISIONED", OktaUserStatus.Deactivated)]
+    [InlineData("TestDefault", OktaUserStatus.Unknown)]
+    public async Task GetUserAsync_UsesStatus_MappsCorrectly(string oktaStatus, OktaUserStatus expectedMyaStatus)
+    {
+        var user = "user";
+        var oktaUser = new OktaUser();
+        oktaUser.Status = new UserStatus(oktaStatus);
+        _userApiMock.Setup(x => x.GetUserAsync(
+            It.IsAny<string>(), 
+            It.IsAny<string>(), 
+            It.IsAny<CancellationToken>()
+        )).ReturnsAsync(oktaUser);
+
+        var result = await _sut.GetUserAsync(user);
+
+        result.Status.Should().Be(expectedMyaStatus);
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/OktaServiceTests.cs
@@ -67,7 +67,7 @@ public class OktaServiceTests
     }
 
     [Fact]
-    public async Task CreateIfNotExists_UserDeactivated()
+    public async Task CreateIfNotExists_UserDeactivated_ReactivateUser()
     {
         var oktaUserResponse = new OktaUserResponse
         {
@@ -75,8 +75,7 @@ public class OktaServiceTests
             Status = OktaUserStatus.Deactivated
         };
         _oktaUserDirectory.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(oktaUserResponse);
-        _oktaUserDirectory.Setup(x => x.CreateUserAsync(
-            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
+        _oktaUserDirectory.Setup(x => x.ReactivateUserAsync(It.IsAny<string>())).ReturnsAsync(true);
 
         var result = await _sut.CreateIfNotExists(userEmail, firstName, lastName);
 
@@ -93,7 +92,8 @@ public class OktaServiceTests
 
         var oktaUserResponse = new OktaUserResponse
         {
-            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero), Status = OktaUserStatus.Provisioned
+            Created = new DateTimeOffset(2025, 3, 15, 15, 44, 44, TimeSpan.Zero), 
+            Status = OktaUserStatus.Provisioned
         };
         _oktaUserDirectory.Setup(x => x.GetUserAsync(It.IsAny<string>())).ReturnsAsync(oktaUserResponse);
         _oktaUserDirectory.Setup(x => x.ReactivateUserAsync(It.IsAny<string>())).ReturnsAsync(true);


### PR DESCRIPTION
# Description

We are fixing 2 issues. 
First one was to convert status mapping switch statement to use userStatus enum value instead of name because of inconsistency in okta enum naming.  
Second issue was that in case of deactivated account, we were trying to create account instead of reactivate and that was failing. 


# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
