### PR TITLE
APPT-1042: missing var definition in terraform

### DIFF
--- a/infrastructure/resources/variables.tf
+++ b/infrastructure/resources/variables.tf
@@ -133,6 +133,18 @@ variable "booking_reminders_cron_schedule" {
   type = string
 }
 
+variable "daily_site_summary_aggregation_cron_schedule" {
+  type = string
+}
+
+variable "site_summary_days_forward" {
+  type = string
+}
+
+variable "site_summary_first_run_date" {
+  type = string
+}
+
 variable "splunk_hec_token" {
   type      = string
   sensitive = true


### PR DESCRIPTION
# Description

Fixing a broken terraform, this adds the variable definition for reporting

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
