### PR TITLE
APPT-1192 - Adding okta config variables into the high load functions…

### DIFF
--- a/infrastructure/resources/high_load_functions.tf
+++ b/infrastructure/resources/high_load_functions.tf
@@ -63,6 +63,10 @@ resource "azurerm_windows_function_app" "nbs_mya_high_load_func_app" {
     Auth__Providers__1__ClientSecret                                       = var.okta_client_secret
     Auth__Providers__1__ClientCodeExchangeUri                              = "${local.client_code_exchange_uri}?provider=okta"
     Auth__Providers__1__ReturnUri                                          = "${local.auth_provider_return_uri}?provider=okta"
+    Okta__Domain                                                           = var.okta_domain
+    Okta__ManagementId                                                     = var.okta_management_id
+    Okta__PrivateKeyKid                                                    = var.okta_private_key_kid
+    Okta__PEM                                                              = var.okta_pem
     Auth__Providers__1__RequiresStateForAuthorize                          = true
     "AzureWebJobs.NotifyBookingCancelled.Disabled"                         = true
     "AzureWebJobs.NotifyBookingMade.Disabled"                              = true
@@ -183,6 +187,10 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_high_load_func_app_preview
     Auth__Providers__1__ClientSecret                                       = var.okta_client_secret
     Auth__Providers__1__ClientCodeExchangeUri                              = "${local.client_code_exchange_uri}?provider=okta"
     Auth__Providers__1__ReturnUri                                          = "${local.auth_provider_return_uri}?provider=okta"
+    Okta__Domain                                                           = var.okta_domain
+    Okta__ManagementId                                                     = var.okta_management_id
+    Okta__PrivateKeyKid                                                    = var.okta_private_key_kid
+    Okta__PEM                                                              = var.okta_pem
     Auth__Providers__1__RequiresStateForAuthorize                          = true
     "AzureWebJobs.NotifyBookingCancelled.Disabled"                         = true
     "AzureWebJobs.NotifyBookingMade.Disabled"                              = true


### PR DESCRIPTION
… (#840)

# Description

The bulk import uses the high load function app on staging and the Okta variables were missing so this PR adds those in

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
