### PR TITLE
APPT-1109 - Converting email to lowercase before checking it's domain

### DIFF
--- a/src/api/Nhs.Appointments.Core/BulkImport/AdminUserImportRowMap.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/AdminUserImportRowMap.cs
@@ -21,7 +21,7 @@ public class AdminUserImportRowMap : ClassMap<AdminUserImportRow>
                 throw new ArgumentException($"Admin user email: '{email}' is not a valid email address.");
             }
 
-            if (!email.EndsWith("nhs.net"))
+            if (!email.ToLower().EndsWith("nhs.net"))
             {
                 throw new ArgumentException($"Email must be an nhs.net email domain. Current email: '{email}'");
             }

--- a/tests/Nhs.Appointments.Core.UnitTests/BulkImport/AdminUserDataImportHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BulkImport/AdminUserDataImportHandlerTests.cs
@@ -66,7 +66,7 @@ public class AdminUserDataImportHandlerTests
         string[] inputRows =
         [
             "USER.doesnt.exIST1@nhs.net",
-            "User.DoESnT.Exist2@nhs.net"
+            "User.DoESnT.Exist2@NHS.net"
         ];
         var input = CsvFileBuilder.BuildInputCsv(AdminUserHeader, inputRows);
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));


### PR DESCRIPTION
# Description

Adding in the missed conversion to lowercase on the email before testing if it ended in nhs.net.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
