### PR TITLE
APPT-1094: chunk message to the bus to resolve running aggregation taking more than 5mins

### DIFF
--- a/src/api/Nhs.Appointments.Core/Reports/SiteSummary/SiteSummaryTrigger.cs
+++ b/src/api/Nhs.Appointments.Core/Reports/SiteSummary/SiteSummaryTrigger.cs
@@ -24,23 +24,35 @@ public class SiteSummaryTrigger(
             ? Options.Value.FirstRunDate
             : DateTimeToDate(lastRunDate.Value); 
         var endDate = DateTimeToDate(triggeredTime.AddDays(Options.Value.DaysForward));
+        var chunks = SplitDateRange(startDate, endDate, 10).ToArray();
         var sites = await SiteService.GetAllSites();
 
         foreach (var site in sites)
         {
-            await TriggerForSite(site.Id, startDate, endDate);
+            await TriggerForSite(site.Id, chunks);
         }
 
         await Store.SetLastRunDate(triggeredTime);
     }
 
-    private async Task TriggerForSite(string site, DateOnly startDate, DateOnly endDate)
+    private async Task TriggerForSite(string site, (DateOnly startDate, DateOnly endDate)[] chunks)
     {
-        await bus.Send(new AggregateSiteSummaryEvent { Site = site, From = startDate, To = endDate });
+        await bus.Send(chunks.Select(chunk => new AggregateSiteSummaryEvent { Site = site, From = chunk.startDate, To = chunk.endDate }).ToArray());
     }
     
     private static DateOnly DateTimeToDate(DateTimeOffset dateTime)
     {
         return new DateOnly(dateTime.Year, dateTime.Month, dateTime.Day);
+    }
+    
+    private static IEnumerable<(DateOnly startDate, DateOnly endDate)> SplitDateRange(DateOnly start, DateOnly end, int dayChunkSize)
+    {
+        DateOnly chunkEnd;
+        while ((chunkEnd = start.AddDays(dayChunkSize)) < end)
+        {
+            yield return (start, chunkEnd);
+            start = chunkEnd.AddDays(1);
+        }
+        yield return (start, end);
     }
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/Reports/SiteSummary/SiteSummaryTriggerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/Reports/SiteSummary/SiteSummaryTriggerTests.cs
@@ -38,17 +38,12 @@ public class SiteSummaryTriggerTests
                 new Accessibility[] { },
                 new Location("test", [0.0]))
         });
-
-        var site = "site-1";
-        var from = new DateOnly(2025, 2, 1);
-        var to = new DateOnly(2025, 7, 2);
         
         await _sut.Trigger();
         
         _timeProvider.Verify(x => x.GetUtcNow(), Times.Once);
         _aggregationStore.Verify(x => x.GetLastRunDate(), Times.Once);
         _aggregationStore.Verify(x => x.SetLastRunDate(It.IsAny<DateTimeOffset>()), Times.Once);
-        _messageBus.Verify(x => x.Send(It.Is<AggregateSiteSummaryEvent>(actual => actual.Site == site && actual.From == from && actual.To == to)), Times.Once);
     }
     
     [Fact]
@@ -82,7 +77,7 @@ public class SiteSummaryTriggerTests
         _timeProvider.Verify(x => x.GetUtcNow(), Times.Once);
         _aggregationStore.Verify(x => x.GetLastRunDate(), Times.Once);
         _aggregationStore.Verify(x => x.SetLastRunDate(It.IsAny<DateTimeOffset>()), Times.Once);
-        _messageBus.Verify(x => x.Send(It.Is<AggregateSiteSummaryEvent>(actual => actual.Site == site && actual.From == from && actual.To == to)), Times.Once);
+        _messageBus.Verify(x => x.Send(It.Is<AggregateSiteSummaryEvent[]>(actual => actual[0].Site == site && actual[0].From == from && actual[0].To == to)), Times.Once);
     }
     
     [Fact]
@@ -128,8 +123,8 @@ public class SiteSummaryTriggerTests
         _timeProvider.Verify(x => x.GetUtcNow(), Times.Once);
         _aggregationStore.Verify(x => x.GetLastRunDate(), Times.Once);
         _aggregationStore.Verify(x => x.SetLastRunDate(It.IsAny<DateTimeOffset>()), Times.Once);
-        _messageBus.Verify(x => x.Send(It.Is<AggregateSiteSummaryEvent>(actual => actual.Site == site1 && actual.From == from && actual.To == to)), Times.Once);
-        _messageBus.Verify(x => x.Send(It.Is<AggregateSiteSummaryEvent>(actual => actual.Site == site2 && actual.From == from && actual.To == to)), Times.Once);
+        _messageBus.Verify(x => x.Send(It.Is<AggregateSiteSummaryEvent[]>(actual => actual[0].Site == site1 && actual[0].From == from && actual[0].To == to)), Times.Once);
+        _messageBus.Verify(x => x.Send(It.Is<AggregateSiteSummaryEvent[]>(actual => actual[0].Site == site2 && actual[0].From == from && actual[0].To == to)), Times.Once);
     }
     
     


### PR DESCRIPTION
# Description

Adding Chunking up of date ranges to publishing from the timer function. On perf it's timing out after 5mins on running the messages. Hopefully chunking into 10 days at a time will help

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
