### PR TITLE
APPT-XXX: Enforce version of hashicorp azurerm

### DIFF
--- a/infrastructure/environments/int/main.tf
+++ b/infrastructure/environments/int/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.5.0"
+      version = "4.37.0"
     }
   }
 

--- a/infrastructure/environments/pen/main.tf
+++ b/infrastructure/environments/pen/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.5.0"
+      version = "4.37.0"
     }
   }
 

--- a/infrastructure/environments/perf/main.tf
+++ b/infrastructure/environments/perf/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.5.0"
+      version = "4.37.0"
     }
   }
 

--- a/infrastructure/environments/prod-ukw/main.tf
+++ b/infrastructure/environments/prod-ukw/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.5.0"
+      version = "4.37.0"
     }
   }
 

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.5.0"
+      version = "4.37.0"
     }
   }
 

--- a/infrastructure/environments/stag-ukw/main.tf
+++ b/infrastructure/environments/stag-ukw/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.5.0"
+      version = "4.37.0"
     }
   }
 

--- a/infrastructure/environments/stag/main.tf
+++ b/infrastructure/environments/stag/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.5.0"
+      version = "4.37.0"
     }
   }
 


### PR DESCRIPTION
# Description

Terraform is broken, think this is because of a change in version of hashicorp. Lets try it!

https://github.com/hashicorp/terraform-provider-azurerm/issues/30273

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
