### PR TITLE
APPT-1177: SiteSummaryReport enabled in all environments

### DIFF
--- a/features/dev.feature.flags.json
+++ b/features/dev.feature.flags.json
@@ -4,7 +4,7 @@
     "TestFeatureEnabled": true,
     "JointBookings": false,
     "MultipleServices": true,
-    "SiteSummaryReport": false,
+    "SiteSummaryReport": true,
     "TestFeaturePercentageEnabled": {
       "EnabledFor": [
         {

--- a/features/int.feature.flags.json
+++ b/features/int.feature.flags.json
@@ -3,6 +3,6 @@
     "OktaEnabled": true,
     "JointBookings": false,
     "MultipleServices": true,
-    "SiteSummaryReport": false
+    "SiteSummaryReport": true
   }
 }

--- a/features/pen.feature.flags.json
+++ b/features/pen.feature.flags.json
@@ -3,7 +3,7 @@
     "OktaEnabled": true,
     "JointBookings": false,
     "BulkImport": true,
-    "MultipleServices": false,
-    "SiteSummaryReport": false
+    "MultipleServices": true,
+    "SiteSummaryReport": true
   }
 }

--- a/features/perf.feature.flags.json
+++ b/features/perf.feature.flags.json
@@ -3,6 +3,7 @@
     "OktaEnabled": true,
     "JointBookings": false,
     "BulkImport": true,
-    "MultipleServices": true
+    "MultipleServices": true,
+    "SiteSummaryReport": true
   }
 }

--- a/features/prod.feature.flags.json
+++ b/features/prod.feature.flags.json
@@ -3,6 +3,6 @@
     "OktaEnabled": true,
     "JointBookings": false,
     "MultipleServices": true,
-    "SiteSummaryReport": false
+    "SiteSummaryReport": true
   }
 }

--- a/features/stag.feature.flags.json
+++ b/features/stag.feature.flags.json
@@ -3,6 +3,6 @@
     "OktaEnabled": true,
     "JointBookings": false,
     "MultipleServices": true,
-    "SiteSummaryReport": false
+    "SiteSummaryReport": true
   }
 }


### PR DESCRIPTION
# Description

Enable SiteSummaryReport for 2.4 release
Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
