### PR TITLE
APPT-1222 - Making cancellation reason nullable on the booking document

### DIFF
--- a/src/api/Nhs.Appointments.Core/Booking.cs
+++ b/src/api/Nhs.Appointments.Core/Booking.cs
@@ -44,7 +44,7 @@ public class Booking
 
 
     [JsonProperty("cancellationReason")]
-    public CancellationReason CancellationReason { get; set; }
+    public CancellationReason? CancellationReason { get; set; }
 }
 
 public class AttendeeDetails


### PR DESCRIPTION
# Description

The CancellationReason enum was not nullable on the booking document so it was defaulting to CancelledByCitizen. This PR makes it nullable:
<img width="522" height="566" alt="image" src="https://github.com/user-attachments/assets/fe99c61c-108e-4d45-b5c6-a89da892a236" />


Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
