### PR TITLE
APPT-1203 SitesByArea SitesSupportService filtering

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
@@ -46,11 +46,9 @@ public class GetSitesByAreaFunction(
         Description =
             "Optional parameter to be used alongside from and until. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range")]
     [OpenApiParameter("from", In = ParameterLocation.Query, Required = false, Type = typeof(string),
-        CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma,
         Description =
             "Optional parameter to be used alongside services and until. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range. DateFormat yyyy-MM-dd.")]
     [OpenApiParameter("until", In = ParameterLocation.Query, Required = false, Type = typeof(string),
-        CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma,
         Description =
             "Optional parameter to be used alongside services and from. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range. DateFormat yyyy-MM-dd.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, "application/json", typeof(IEnumerable<SiteWithDistance>),

--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
@@ -73,16 +73,14 @@ public class GetSitesByAreaFunction(
     {
         SiteSupportsServiceFilter siteSupportsServiceFilter = null;
 
-        //should pass validation rules
-        if (request.services is { Length: 1 } && request.from != null && request.until != null)
+        //if all 3 params are provided correctly, use the SiteSupportsServiceFilter
+        if (request.Services is { Length: 1 } && request.FromDate != null && request.UntilDate != null)
         {
-            var fromDate = DateOnly.ParseExact(request.from, "yyyy-MM-dd");
-            var untilDate = DateOnly.ParseExact(request.until, "yyyy-MM-dd");
-            siteSupportsServiceFilter = new SiteSupportsServiceFilter(request.services.Single(), fromDate, untilDate);
+            siteSupportsServiceFilter = new SiteSupportsServiceFilter(request.Services.Single(), request.FromDate.Value, request.UntilDate.Value);
         }
 
-        var sites = await siteService.FindSitesByArea(request.longitude, request.latitude, request.searchRadius,
-            request.maximumRecords, request.accessNeeds, request.ignoreCache, siteSupportsServiceFilter);
+        var sites = await siteService.FindSitesByArea(request.Longitude, request.Latitude, request.SearchRadius,
+            request.MaximumRecords, request.AccessNeeds, request.IgnoreCache, siteSupportsServiceFilter);
         return ApiResult<IEnumerable<SiteWithDistance>>.Success(sites);
     }
 

--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
@@ -9,13 +9,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
-using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
-using Nhs.Appointments.Core.Inspectors;
 
 namespace Nhs.Appointments.Api.Functions;
 
@@ -42,12 +39,18 @@ public class GetSitesByAreaFunction(
     [OpenApiParameter("accessNeeds", In = ParameterLocation.Query, Required = false, Type = typeof(string[]),
         CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma,
         Description = "Required access needs used to filter sites")]
-    [OpenApiParameter("services", In = ParameterLocation.Query, Required = false, Type = typeof(string[]), CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma, 
-        Description = "Optional parameter to be used alongside from and until. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range")]
-    [OpenApiParameter("from", In = ParameterLocation.Query, Required = false, Type = typeof(string), CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma, 
-        Description = "Optional parameter to be used alongside services and until. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range. DateFormat yyyy-MM-dd.")]
-    [OpenApiParameter("until", In = ParameterLocation.Query, Required = false, Type = typeof(string), CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma, 
-        Description = "Optional parameter to be used alongside services and from. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range. DateFormat yyyy-MM-dd.")]
+    [OpenApiParameter("services", In = ParameterLocation.Query, Required = false, Type = typeof(string[]),
+        CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma,
+        Description =
+            "Optional parameter to be used alongside from and until. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range")]
+    [OpenApiParameter("from", In = ParameterLocation.Query, Required = false, Type = typeof(string),
+        CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma,
+        Description =
+            "Optional parameter to be used alongside services and until. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range. DateFormat yyyy-MM-dd.")]
+    [OpenApiParameter("until", In = ParameterLocation.Query, Required = false, Type = typeof(string),
+        CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma,
+        Description =
+            "Optional parameter to be used alongside services and from. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range. DateFormat yyyy-MM-dd.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, "application/json", typeof(IEnumerable<SiteWithDistance>),
         Description = "List of sites within a geographical area that support requested access needs")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, "application/json",
@@ -60,7 +63,8 @@ public class GetSitesByAreaFunction(
     // [RequiresPermission(Permissions.QuerySites, typeof(NoSiteRequestInspector))]
     [Function("GetSitesByAreaFunction")]
     public override Task<IActionResult> RunAsync(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "sites")] HttpRequest req)
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "sites")]
+        HttpRequest req)
     {
         return base.RunAsync(req);
     }
@@ -69,7 +73,7 @@ public class GetSitesByAreaFunction(
         ILogger logger)
     {
         SiteSupportsServiceFilter siteSupportsServiceFilter = null;
-        
+
         //should pass validation rules
         if (request.services is { Length: 1 } && request.from != null && request.until != null)
         {
@@ -77,7 +81,7 @@ public class GetSitesByAreaFunction(
             var untilDate = DateOnly.ParseExact(request.until, "yyyy-MM-dd");
             siteSupportsServiceFilter = new SiteSupportsServiceFilter(request.services.Single(), fromDate, untilDate);
         }
-        
+
         var sites = await siteService.FindSitesByArea(request.longitude, request.latitude, request.searchRadius,
             request.maximumRecords, request.accessNeeds, request.ignoreCache, siteSupportsServiceFilter);
         return ApiResult<IEnumerable<SiteWithDistance>>.Success(sites);
@@ -110,17 +114,18 @@ public class GetSitesByAreaFunction(
         var services = req.Query.ContainsKey("services")
             ? req.Query["services"].ToString().Split(',')
             : null;
-        
+
         var from = req.Query.ContainsKey("from")
             ? req.Query["from"].ToString()
             : null;
-        
+
         var until = req.Query.ContainsKey("until")
             ? req.Query["until"].ToString()
             : null;
-        
+
         return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetSitesByAreaRequest request)>((
             errors.AsReadOnly(),
-            new GetSitesByAreaRequest(longitude, latitude, searchRadius, maximumRecords, accessNeeds, ignoreCache, services, from, until)));
+            new GetSitesByAreaRequest(longitude, latitude, searchRadius, maximumRecords, accessNeeds, ignoreCache,
+                services, from, until)));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
@@ -11,8 +11,10 @@ using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using Nhs.Appointments.Api.Auth;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
+using Nhs.Appointments.Core.Inspectors;
 
 namespace Nhs.Appointments.Api.Functions;
 
@@ -59,8 +61,7 @@ public class GetSitesByAreaFunction(
         typeof(ErrorMessageResponseItem), Description = "Unauthorized request to a protected API")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Forbidden, "application/json", typeof(ErrorMessageResponseItem),
         Description = "Request failed due to insufficient permissions")]
-    //TODO add back in!!
-    // [RequiresPermission(Permissions.QuerySites, typeof(NoSiteRequestInspector))]
+    [RequiresPermission(Permissions.QuerySites, typeof(NoSiteRequestInspector))]
     [Function("GetSitesByAreaFunction")]
     public override Task<IActionResult> RunAsync(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "sites")]

--- a/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetSitesByAreaFunction.cs
@@ -41,6 +41,12 @@ public class GetSitesByAreaFunction(
     [OpenApiParameter("accessNeeds", In = ParameterLocation.Query, Required = false, Type = typeof(string[]),
         CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma,
         Description = "Required access needs used to filter sites")]
+    [OpenApiParameter("services", In = ParameterLocation.Query, Required = false, Type = typeof(string[]), CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma, 
+        Description = "Optional parameter to be used alongside from and until. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range")]
+    [OpenApiParameter("from", In = ParameterLocation.Query, Required = false, Type = typeof(string), CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma, 
+        Description = "Optional parameter to be used alongside services and until. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range. DateFormat yyyy-MM-dd.")]
+    [OpenApiParameter("until", In = ParameterLocation.Query, Required = false, Type = typeof(string), CollectionDelimiter = OpenApiParameterCollectionDelimiterType.Comma, 
+        Description = "Optional parameter to be used alongside services and from. When all three of these parameters are used, it filters the results to only those sites that support the services within that date range. DateFormat yyyy-MM-dd.")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, "application/json", typeof(IEnumerable<SiteWithDistance>),
         Description = "List of sites within a geographical area that support requested access needs")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, "application/json",
@@ -88,8 +94,21 @@ public class GetSitesByAreaFunction(
         var latitude = double.Parse(req.Query["lat"]);
         var searchRadius = int.Parse(req.Query["searchRadius"]);
         var maximumRecords = int.Parse(req.Query["maxRecords"]);
+
+        var services = req.Query.ContainsKey("services")
+            ? req.Query["services"].ToString().Split(',')
+            : null;
+        
+        var from = req.Query.ContainsKey("from")
+            ? req.Query["from"].ToString()
+            : null;
+        
+        var until = req.Query.ContainsKey("until")
+            ? req.Query["until"].ToString()
+            : null;
+        
         return Task.FromResult<(IReadOnlyCollection<ErrorMessageResponseItem> errors, GetSitesByAreaRequest request)>((
             errors.AsReadOnly(),
-            new GetSitesByAreaRequest(longitude, latitude, searchRadius, maximumRecords, accessNeeds, ignoreCache)));
+            new GetSitesByAreaRequest(longitude, latitude, searchRadius, maximumRecords, accessNeeds, ignoreCache, services, from, until)));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Models/GetSitesByAreaRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/GetSitesByAreaRequest.cs
@@ -1,3 +1,41 @@
+using System;
+
 namespace Nhs.Appointments.Api.Models;
 
-public record GetSitesByAreaRequest(double longitude, double latitude, int searchRadius, int maximumRecords, string[] accessNeeds, bool ignoreCache, string[] services, string from, string until);
+public record GetSitesByAreaRequest(
+    double Longitude,
+    double Latitude,
+    int SearchRadius,
+    int MaximumRecords,
+    string[] AccessNeeds,
+    bool IgnoreCache,
+    string[] Services,
+    string From,
+    string Until)
+{
+    public DateOnly? FromDate
+    {
+        get
+        {
+            if(string.IsNullOrEmpty(From))
+            {
+                return null;
+            }
+
+            return DateOnly.ParseExact(From, "yyyy-MM-dd");
+        }
+    }
+
+    public DateOnly? UntilDate
+    {
+        get
+        {
+            if(string.IsNullOrEmpty(Until))
+            {
+                return null;
+            }
+
+            return DateOnly.ParseExact(Until, "yyyy-MM-dd");
+        }
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Models/GetSitesByAreaRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/GetSitesByAreaRequest.cs
@@ -1,3 +1,3 @@
 namespace Nhs.Appointments.Api.Models;
 
-public record GetSitesByAreaRequest(double longitude, double latitude, int searchRadius, int maximumRecords, string[] accessNeeds, bool ignoreCache);
+public record GetSitesByAreaRequest(double longitude, double latitude, int searchRadius, int maximumRecords, string[] accessNeeds, bool ignoreCache, string[] services, string from, string until);

--- a/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System;
+using FluentValidation;
 using Nhs.Appointments.Api.Models;
 
 namespace Nhs.Appointments.Api.Validators;
@@ -23,5 +24,10 @@ public class GetSitesByAreaRequestValidator : AbstractValidator<GetSitesByAreaRe
             .LessThanOrEqualTo(50)
             .GreaterThan(0)
             .Configure(rule => rule.MessageBuilder = _ => "Provide a number of maximum records (between 1 - 50 records).");
+        RuleFor(x => x.from)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty().WithMessage("Provide a date in 'yyyy-MM-dd'")
+            .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))
+            .WithMessage("Provide a date in the format 'yyyy-MM-dd'");
     }
 }

--- a/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
@@ -11,23 +11,58 @@ public class GetSitesByAreaRequestValidator : AbstractValidator<GetSitesByAreaRe
         RuleFor(x => x.longitude)
             .LessThanOrEqualTo(180)
             .GreaterThanOrEqualTo(-180)
-            .Configure(rule => rule.MessageBuilder = _ => "Provide a valid longitude value (between -180 <-> 180 degrees).");
+            .Configure(rule =>
+                rule.MessageBuilder = _ => "Provide a valid longitude value (between -180 <-> 180 degrees).");
         RuleFor(x => x.latitude)
             .LessThanOrEqualTo(90)
             .GreaterThanOrEqualTo(-90)
-            .Configure(rule => rule.MessageBuilder = _ => "Provide a valid latitude value (between -90 <-> 90 degrees).");
+            .Configure(rule =>
+                rule.MessageBuilder = _ => "Provide a valid latitude value (between -90 <-> 90 degrees).");
         RuleFor(x => x.searchRadius)
             .LessThanOrEqualTo(100000)
             .GreaterThanOrEqualTo(1000)
-            .Configure(rule => rule.MessageBuilder = _ => "Provide a search radius in meters (between 1000 - 100,000m).");
+            .Configure(rule =>
+                rule.MessageBuilder = _ => "Provide a search radius in meters (between 1000 - 100,000m).");
         RuleFor(x => x.maximumRecords)
             .LessThanOrEqualTo(50)
             .GreaterThan(0)
-            .Configure(rule => rule.MessageBuilder = _ => "Provide a number of maximum records (between 1 - 50 records).");
-        // RuleFor(x => x.from)
-        //     .Cascade(CascadeMode.Stop)
-        //     .NotEmpty().WithMessage("Provide a date in 'yyyy-MM-dd'")
-        //     .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))
-        //     .WithMessage("Provide a date in the format 'yyyy-MM-dd'");
+            .Configure(rule =>
+                rule.MessageBuilder = _ => "Provide a number of maximum records (between 1 - 50 records).");
+        RuleFor(x => x)
+            .Cascade(CascadeMode.Stop)
+            .Must(x =>
+                (
+                    //none of the filters are provided
+                    (x.services == null || x.services.Length == 0) &&
+                    string.IsNullOrEmpty(x.from) & string.IsNullOrEmpty(x.until))
+                || //OR
+                //all of the filters are provided together
+                (x.services?.Length > 0 && !string.IsNullOrEmpty(x.from) && !string.IsNullOrEmpty(x.until))
+            )
+            .WithMessage(
+                "All of the 'supports service filters' (services, from, until) must be provided, or none of them.")
+            .DependentRules(() =>
+            {
+                When(x => x.services?.Length > 0 && !string.IsNullOrEmpty(x.from) && !string.IsNullOrEmpty(x.until),
+                    () =>
+                    {
+                        RuleFor(x => x.services)
+                            .Must(services => services.Length == 1)
+                            .WithMessage("'Services' currently only supports one service");
+                        RuleFor(x => x)
+                            .Cascade(CascadeMode.Stop)
+                            .Must(x => DateOnly.TryParseExact(x.from, "yyyy-MM-dd", out _))
+                            .WithMessage("'From' must be a date in the format 'yyyy-MM-dd'")
+                            .Must(x => DateOnly.TryParseExact(x.until, "yyyy-MM-dd", out _))
+                            .WithMessage("'Until' must be a date in the format 'yyyy-MM-dd'")
+                            .Must(x =>
+                            {
+                                var fromDate = DateOnly.ParseExact(x.from, "yyyy-MM-dd");
+                                var untilDate = DateOnly.ParseExact(x.until, "yyyy-MM-dd");
+                                return untilDate >= fromDate;
+                            })
+                            .WithMessage("'Until' date must be greater than or equal to 'From' date");
+                    });
+            });
     }
 }

--- a/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
@@ -24,10 +24,10 @@ public class GetSitesByAreaRequestValidator : AbstractValidator<GetSitesByAreaRe
             .LessThanOrEqualTo(50)
             .GreaterThan(0)
             .Configure(rule => rule.MessageBuilder = _ => "Provide a number of maximum records (between 1 - 50 records).");
-        RuleFor(x => x.from)
-            .Cascade(CascadeMode.Stop)
-            .NotEmpty().WithMessage("Provide a date in 'yyyy-MM-dd'")
-            .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))
-            .WithMessage("Provide a date in the format 'yyyy-MM-dd'");
+        // RuleFor(x => x.from)
+        //     .Cascade(CascadeMode.Stop)
+        //     .NotEmpty().WithMessage("Provide a date in 'yyyy-MM-dd'")
+        //     .Must(x => DateOnly.TryParseExact(x, "yyyy-MM-dd", out var _))
+        //     .WithMessage("Provide a date in the format 'yyyy-MM-dd'");
     }
 }

--- a/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
@@ -8,22 +8,22 @@ public class GetSitesByAreaRequestValidator : AbstractValidator<GetSitesByAreaRe
 {
     public GetSitesByAreaRequestValidator()
     {
-        RuleFor(x => x.longitude)
+        RuleFor(x => x.Longitude)
             .LessThanOrEqualTo(180)
             .GreaterThanOrEqualTo(-180)
             .Configure(rule =>
                 rule.MessageBuilder = _ => "Provide a valid longitude value (between -180 <-> 180 degrees).");
-        RuleFor(x => x.latitude)
+        RuleFor(x => x.Latitude)
             .LessThanOrEqualTo(90)
             .GreaterThanOrEqualTo(-90)
             .Configure(rule =>
                 rule.MessageBuilder = _ => "Provide a valid latitude value (between -90 <-> 90 degrees).");
-        RuleFor(x => x.searchRadius)
+        RuleFor(x => x.SearchRadius)
             .LessThanOrEqualTo(100000)
             .GreaterThanOrEqualTo(1000)
             .Configure(rule =>
                 rule.MessageBuilder = _ => "Provide a search radius in meters (between 1000 - 100,000m).");
-        RuleFor(x => x.maximumRecords)
+        RuleFor(x => x.MaximumRecords)
             .LessThanOrEqualTo(50)
             .GreaterThan(0)
             .Configure(rule =>
@@ -33,32 +33,32 @@ public class GetSitesByAreaRequestValidator : AbstractValidator<GetSitesByAreaRe
             .Must(x =>
                 (
                     //none of the filters are provided
-                    (x.services == null || x.services.Length == 0) &&
-                    string.IsNullOrEmpty(x.from) & string.IsNullOrEmpty(x.until))
+                    (x.Services == null || x.Services.Length == 0) &&
+                    string.IsNullOrEmpty(x.From) & string.IsNullOrEmpty(x.Until))
                 || //OR
                 //all of the filters are provided together
-                (x.services?.Length > 0 && !string.IsNullOrEmpty(x.from) && !string.IsNullOrEmpty(x.until))
+                (x.Services?.Length > 0 && !string.IsNullOrEmpty(x.From) && !string.IsNullOrEmpty(x.Until))
             )
             .WithMessage(
                 "All of the 'supports service filters' (services, from, until) must be provided, or none of them.")
             .DependentRules(() =>
             {
-                When(x => x.services?.Length > 0 && !string.IsNullOrEmpty(x.from) && !string.IsNullOrEmpty(x.until),
+                When(x => x.Services?.Length > 0 && !string.IsNullOrEmpty(x.From) && !string.IsNullOrEmpty(x.Until),
                     () =>
                     {
-                        RuleFor(x => x.services)
+                        RuleFor(x => x.Services)
                             .Must(services => services.Length == 1)
                             .WithMessage("'Services' currently only supports one service");
                         RuleFor(x => x)
                             .Cascade(CascadeMode.Stop)
-                            .Must(x => DateOnly.TryParseExact(x.from, "yyyy-MM-dd", out _))
+                            .Must(x => DateOnly.TryParseExact(x.From, "yyyy-MM-dd", out _))
                             .WithMessage("'From' must be a date in the format 'yyyy-MM-dd'")
-                            .Must(x => DateOnly.TryParseExact(x.until, "yyyy-MM-dd", out _))
+                            .Must(x => DateOnly.TryParseExact(x.Until, "yyyy-MM-dd", out _))
                             .WithMessage("'Until' must be a date in the format 'yyyy-MM-dd'")
                             .Must(x =>
                             {
-                                var fromDate = DateOnly.ParseExact(x.from, "yyyy-MM-dd");
-                                var untilDate = DateOnly.ParseExact(x.until, "yyyy-MM-dd");
+                                var fromDate = DateOnly.ParseExact(x.From, "yyyy-MM-dd");
+                                var untilDate = DateOnly.ParseExact(x.Until, "yyyy-MM-dd");
                                 return untilDate >= fromDate;
                             })
                             .WithMessage("'Until' date must be greater than or equal to 'From' date");

--- a/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
+++ b/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
@@ -8,6 +8,6 @@ public interface IAvailabilityStore
    Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to);
    Task<SessionInstance> CancelSession(string site, DateOnly date, Session session);
 
-   Task<bool> SiteSupportsService(string siteId, string service,
-       List<string> dailyAvailabilityIds);
+   Task<bool> SiteOffersServiceDuringPeriod(string siteId, string service,
+       List<string> datesInPeriod);
 }

--- a/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
+++ b/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
@@ -7,5 +7,7 @@ public interface IAvailabilityStore
         Session sessionToEdit = null);
    Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to);
    Task<SessionInstance> CancelSession(string site, DateOnly date, Session session);
-   Task<IEnumerable<string>> GetSitesSupportingService(string service, List<string> sites, DateOnly from, DateOnly to, int maxRecords = 50, int batchSize = 100);
+
+   Task<bool> SiteSupportsService(string siteId, string service,
+       List<string> dailyAvailabilityIds);
 }

--- a/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
+++ b/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
@@ -5,6 +5,7 @@ public interface IAvailabilityStore
     Task<IEnumerable<SessionInstance>> GetSessions(string site, DateOnly from, DateOnly to);
    Task ApplyAvailabilityTemplate(string site, DateOnly date, Session[] sessions, ApplyAvailabilityMode mode,
         Session sessionToEdit = null);
-    Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to);
-    Task<SessionInstance> CancelSession(string site, DateOnly date, Session session);
+   Task<IEnumerable<DailyAvailability>> GetDailyAvailability(string site, DateOnly from, DateOnly to);
+   Task<SessionInstance> CancelSession(string site, DateOnly date, Session session);
+   Task<IEnumerable<string>> GetSitesSupportingService(string service, List<string> sites, DateOnly from, DateOnly to, int maxRecords = 50, int batchSize = 100);
 }

--- a/src/api/Nhs.Appointments.Core/Site.cs
+++ b/src/api/Nhs.Appointments.Core/Site.cs
@@ -34,6 +34,15 @@ public record SiteWithDistance(
     [JsonProperty("distance")] int Distance
 );
 
+/// <summary>
+/// Filter sites based on whether they support the provided service within the date range
+/// </summary>
+public record SiteSupportsServiceFilter(
+    string service,
+    DateOnly from,
+    DateOnly until
+);
+
 public record AccessibilityRequest
 (
     [JsonProperty("accessibilities")]

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -57,8 +57,7 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
         
         var sitesInDistance = sitesWithDistance
             .Where(s => s.Distance <= searchRadius)
-            .Where(filterPredicate)
-            .ToList();
+            .Where(filterPredicate);
         
         return await GetSitesSupportingService(
             sitesInDistance, 

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace Nhs.Appointments.Core;
 
@@ -23,7 +24,7 @@ public interface ISiteService
     Task<IEnumerable<Site>> GetSitesInRegion(string region);
 }
 
-public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilityStore, IMemoryCache memoryCache, TimeProvider time) : ISiteService
+public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilityStore, IMemoryCache memoryCache, ILogger<SiteService> logger, TimeProvider time) : ISiteService
 {
     private const string CacheKey = "sites";
     public async Task<IEnumerable<SiteWithDistance>> FindSitesByArea(double longitude, double latitude, int searchRadius, int maximumRecords, IEnumerable<string> accessNeeds, bool ignoreCache = false, SiteSupportsServiceFilter siteSupportsServiceFilter = null)
@@ -110,6 +111,8 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
             results.AddRange(batchResults);
             iterations++;
         }
+        
+        logger.LogInformation("GetSitesSupportingService returned {resultCount} results after {iterationCount} iterations for service {service}", results.Count, iterations, service);
 
         return results;
     }

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -108,7 +108,7 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
             iterations++;
         }
         
-        logger.LogInformation("GetSitesSupportingService returned {resultCount} results after {iterationCount} iterations for service {service}", results.Count, iterations, service);
+        logger.LogInformation("GetSitesSupportingService returned {resultCount} result(s) after {iterationCount} iteration(s) for service '{service}'", results.Count, iterations, service);
 
         return results;
     }

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -75,7 +75,7 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
         
         var results = new List<SiteWithDistance>();
 
-        var generatedIds = GetDateStringsInRange(from, to);
+        var dateStringsInRange = GetDateStringsInRange(from, to);
         var iterations = 0;
         
         //while we are still short of the max, keep appending results
@@ -92,16 +92,16 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
                 break;
             }
 
-            var siteSupportTasks = orderedSiteBatch.Select(async swd =>
+            var siteOffersServiceDuringPeriodTasks = orderedSiteBatch.Select(async swd =>
             {
-                var siteSupported = await availabilityStore.SiteSupportsService(swd.Site.Id, service, generatedIds);
-                if (siteSupported)
+                var siteOffersServiceDuringPeriod = await availabilityStore.SiteOffersServiceDuringPeriod(swd.Site.Id, service, dateStringsInRange);
+                if (siteOffersServiceDuringPeriod)
                 {
                     concurrentBatchResults.Add(swd);
                 }
             }).ToArray();
 
-            await Task.WhenAll(siteSupportTasks);
+            await Task.WhenAll(siteOffersServiceDuringPeriodTasks);
             
             //the concurrentBatchResults lose their original order, so we need to order the end result
             results.AddRange(concurrentBatchResults.OrderBy(site => site.Distance).Take(maxRecords));
@@ -113,7 +113,7 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
         return results;
     }
     
-    private static List<string> GetDateStringsInRange(DateOnly from, DateOnly to)
+       private static List<string> GetDateStringsInRange(DateOnly from, DateOnly to)
     {
         var result = new List<string>();
 

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -24,7 +24,7 @@ public interface ISiteService
     Task<IEnumerable<Site>> GetSitesInRegion(string region);
 }
 
-public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilityStore, IMemoryCache memoryCache, ILogger<SiteService> logger, TimeProvider time) : ISiteService
+public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilityStore, IMemoryCache memoryCache, ILogger<ISiteService> logger, TimeProvider time) : ISiteService
 {
     private const string CacheKey = "sites";
     public async Task<IEnumerable<SiteWithDistance>> FindSitesByArea(double longitude, double latitude, int searchRadius, int maximumRecords, IEnumerable<string> accessNeeds, bool ignoreCache = false, SiteSupportsServiceFilter siteSupportsServiceFilter = null)

--- a/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
@@ -99,18 +99,16 @@ public class AvailabilityDocumentStore(
         using (metricsRecorder.BeginScope("SiteSupportsService"))
         {
             var docType = documentStore.GetDocumentType();
-        
+            
             var query = new QueryDefinition(
-                    query: "SELECT VALUE COUNT(1) "+
+                    query: "SELECT VALUE COUNT(1) " +
                            "FROM booking_data bd " +
-                           "JOIN s IN bd.sessions" +
-                           "WHERE bd.id IN @docIds AND bd.site = @site AND bd.docType = @docType AND ARRAY_CONTAINS(s.services, @service)")
+                           "JOIN s IN bd.sessions " +
+                           "WHERE ARRAY_CONTAINS(@docIds, bd.id) AND bd.site = @site AND bd.docType = @docType AND ARRAY_CONTAINS(s.services, @service)")
                 .WithParameter("@docType", docType)
                 .WithParameter("@docIds", dailyAvailabilityIds)
                 .WithParameter("@site", siteId)
                 .WithParameter("@service", service);
-
-            var debugSql = query.QueryText;
         
             var dailyAvailabilityCount = (await documentStore.RunSqlQueryAsync<int>(query)).Single();
             return dailyAvailabilityCount > 0;

--- a/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
@@ -94,9 +94,9 @@ public class AvailabilityDocumentStore(
         };
     }
 
-    public async Task<bool> SiteSupportsService(string siteId, string service, List<string> dailyAvailabilityIds)
+    public async Task<bool> SiteOffersServiceDuringPeriod(string siteId, string service, List<string> datesInPeriod)
     {
-        using (metricsRecorder.BeginScope("SiteSupportsService"))
+        using (metricsRecorder.BeginScope("SiteOffersServiceDuringPeriod"))
         {
             var docType = documentStore.GetDocumentType();
             
@@ -106,7 +106,7 @@ public class AvailabilityDocumentStore(
                            "JOIN s IN bd.sessions " +
                            "WHERE ARRAY_CONTAINS(@docIds, bd.id) AND bd.site = @site AND bd.docType = @docType AND ARRAY_CONTAINS(s.services, @service)")
                 .WithParameter("@docType", docType)
-                .WithParameter("@docIds", dailyAvailabilityIds)
+                .WithParameter("@docIds", datesInPeriod)
                 .WithParameter("@site", siteId)
                 .WithParameter("@service", service);
         

--- a/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
@@ -93,6 +93,51 @@ public class AvailabilityDocumentStore(
         };
     }
 
+    public async Task<IEnumerable<string>> GetSitesSupportingService(string service, List<string> sites, DateOnly from, DateOnly to,
+        int maxRecords = 50, int batchSize = 100)
+    {
+        //convert date range into X ids
+        var generatedIds = new List<string>();
+
+        var iterations = 0;
+        
+        var results = new List<string>();
+
+        //while we are still short of the max, keep appending results
+        //ideally, the first batch would contain more than or equal to the max results, so won't need to iterate often...
+        while (results.Count < maxRecords)
+        {
+            //TODO go and limit provided sites to batch size to try and make up maxRecords
+            var siteBatch = sites.Skip(iterations * batchSize).Take(batchSize).ToList();
+
+            //break out if no more sites to query, just have to return the built results, this is likely to be less than the maxResults
+            if (siteBatch.Count == 0)
+            {
+                break;
+            }
+            
+            var docType = documentStore.GetDocumentType();
+            using (metricsRecorder.BeginScope("GetSitesSupportingService"))
+            {
+                var siteIds = (await documentStore.RunQueryAsync<DailyAvailabilityDocument>(b =>
+                        b.DocumentType == docType
+                        && generatedIds.Contains(b.Id)
+                        && siteBatch.Contains(b.Site) 
+                        && b.Sessions.SelectMany(x => x.Services).Contains(service)))
+                    .Take(maxRecords)
+                    //TODO order the results by the provided site order
+                    .Order(x => x.Site, siteBatch)
+                    .Select(x => x.Site);
+
+                results.AddRange(siteIds);
+            }
+            
+            iterations++;
+        }
+
+        return results;
+    }
+
     private async Task EditExistingSession(string documentId, string site, Session newSession, Session sessionToEdit)
     {
         var dayDocument = await GetOrDefaultAsync(documentId, site);

--- a/src/api/Nhs.Appointments.Persistance/ITypedDocumentCosmosStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/ITypedDocumentCosmosStore.cs
@@ -9,6 +9,7 @@ public interface ITypedDocumentCosmosStore<TDocument>
     Task<TModel> GetByIdOrDefaultAsync<TModel>(string documentId, string partitionKey);
     Task<TModel> GetByIdOrDefaultAsync<TModel>(string documentId);
     Task<IEnumerable<TModel>> RunQueryAsync<TModel>(Expression<Func<TDocument, bool>> predicate);
+    string GeneratedSql(Expression<Func<TDocument, bool>> predicate);
     Task<IEnumerable<TModel>> RunSqlQueryAsync<TModel>(QueryDefinition query);
     Task<TModel> GetDocument<TModel>(string documentId);
     Task<TModel> GetDocument<TModel>(string documentId, string partitionKey);

--- a/src/api/Nhs.Appointments.Persistance/ITypedDocumentCosmosStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/ITypedDocumentCosmosStore.cs
@@ -9,7 +9,6 @@ public interface ITypedDocumentCosmosStore<TDocument>
     Task<TModel> GetByIdOrDefaultAsync<TModel>(string documentId, string partitionKey);
     Task<TModel> GetByIdOrDefaultAsync<TModel>(string documentId);
     Task<IEnumerable<TModel>> RunQueryAsync<TModel>(Expression<Func<TDocument, bool>> predicate);
-    string GeneratedSql(Expression<Func<TDocument, bool>> predicate);
     Task<IEnumerable<TModel>> RunSqlQueryAsync<TModel>(QueryDefinition query);
     Task<TModel> GetDocument<TModel>(string documentId);
     Task<TModel> GetDocument<TModel>(string documentId, string partitionKey);

--- a/src/api/Nhs.Appointments.Persistance/TypedDocumentCosmosStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/TypedDocumentCosmosStore.cs
@@ -113,6 +113,11 @@ public class TypedDocumentCosmosStore<TDocument> : ITypedDocumentCosmosStore<TDo
         var queryFeed = GetContainer().GetItemLinqQueryable<TDocument>().Where(predicate).ToFeedIterator();
         return IterateResults(queryFeed, rs => _mapper.Map<TModel>(rs));
     }
+    
+    public string GeneratedSql(Expression<Func<TDocument, bool>> predicate)
+    {
+        return GetContainer().GetItemLinqQueryable<TDocument>().Where(predicate).ToQueryDefinition().QueryText;
+    }
 
     public async Task DeleteDocument(string documentId, string partitionKey)
     {

--- a/src/api/Nhs.Appointments.Persistance/TypedDocumentCosmosStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/TypedDocumentCosmosStore.cs
@@ -113,11 +113,6 @@ public class TypedDocumentCosmosStore<TDocument> : ITypedDocumentCosmosStore<TDo
         var queryFeed = GetContainer().GetItemLinqQueryable<TDocument>().Where(predicate).ToFeedIterator();
         return IterateResults(queryFeed, rs => _mapper.Map<TModel>(rs));
     }
-    
-    public string GeneratedSql(Expression<Func<TDocument, bool>> predicate)
-    {
-        return GetContainer().GetItemLinqQueryable<TDocument>().Where(predicate).ToQueryDefinition().QueryText;
-    }
 
     public async Task DeleteDocument(string documentId, string partitionKey)
     {

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -125,6 +125,13 @@ public abstract partial class BaseFeatureSteps : Feature
 
         response.EnsureSuccessStatusCode();
     }
+    
+    [Given("the following sessions exist for site '(.+)'")]
+    [And("the following sessions exist for site '(.+)'")]
+    public Task SetupSessionsForSite(string site, DataTable dataTable)
+    {
+        return SetupSessions(site, dataTable);
+    }
 
     [Given("the following sessions")]
     [And("the following sessions")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/BaseFeatureSteps.cs
@@ -297,6 +297,13 @@ public abstract partial class BaseFeatureSteps : Feature
     {
         return SetupBookings("beeae4e0-dd4a-4e3a-8f4d-738f9418fb51", dataTable, BookingType.Confirmed);
     }
+    
+    [Given("the following bookings have been made for site '(.+)'")]
+    [And("the following bookings have been made for site '(.+)'")]
+    public Task SetupBookingsForSite(string site, DataTable dataTable)
+    {
+        return SetupBookings(site, dataTable, BookingType.Confirmed);
+    }
 
     [Given("the following recent bookings have been made")]
     [And("the following recent bookings have been made")]
@@ -327,6 +334,10 @@ public abstract partial class BaseFeatureSteps : Feature
     [And("the following orphaned bookings exist")]
     public Task SetupOrphanedBookings(DataTable dataTable) =>
         SetupBookings("beeae4e0-dd4a-4e3a-8f4d-738f9418fb51", dataTable, BookingType.Orphaned);
+    
+    [And("the following orphaned bookings exist for site '(.+)'")]
+    public Task SetupOrphanedBookingsForSite(string site, DataTable dataTable) =>
+        SetupBookings(site, dataTable, BookingType.Orphaned);
 
     protected async Task SetupBookings(string siteDesignation, DataTable dataTable, BookingType bookingType)
     {

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
@@ -238,8 +238,7 @@ Feature: Site search
       | Max Records | Search Radius | Longitude | Latitude | Service | From              | Until             |
       | 3           | 6000          | 0.082     | 51.5     | COVID   | 2 days from today | 3 days from today |
     Then no sites are returned
-
-
+    
   Scenario: Retrieve sites by service filter - results when service sessions are on different days
     Given The following sites exist in the system
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
@@ -442,3 +441,59 @@ Feature: Site search
       | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
       | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
     Then no sites are returned
+
+  Scenario: Retrieve sites by service filter - only return sites with requested access needs
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | 9635bee5-895c-4368-a106-2d6bc1d74087 | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 7e7bc5ed-a188-499d-9eab-1566d9e3b972 | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | 0.13086317  | 51.483479 |
+      | 3558dad9-d0a6-49f4-942a-c951d07eb283 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+      | ad8ef3bd-cf15-47a6-8510-8bffcd52bd7b | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+    And the following sessions exist for site '9635bee5-895c-4368-a106-2d6bc1d74087'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '7e7bc5ed-a188-499d-9eab-1566d9e3b972'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '3558dad9-d0a6-49f4-942a-c951d07eb283'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult  | 5           | 1        |
+    And the following sessions exist for site 'ad8ef3bd-cf15-47a6-8510-8bffcd52bd7b'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    When I make the following request with service filtering and with access needs
+      | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    | AccessNeeds  |
+      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow | attr_one     |
+    Then the following sites and distances are returned
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
+      | ad8ef3bd-cf15-47a6-8510-8bffcd52bd7b | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+
+  Scenario: Retrieve sites by service filter - only return sites with all requested access needs
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                            | Longitude   | Latitude  |
+      | 6997851c-0bcd-462e-b1f5-b1c02f24d37d | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false,accessibility/attr_two=true   | 0.14566747  | 51.482472 |
+      | 1efc8a32-ad71-4066-821e-e535317c309a | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=true,accessibility/attr_two=false   | 0.13086317  | 51.483479 |
+      | ab746a05-345f-4c06-829b-2d5d52ec341b | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=false,accessibility/attr_two=false  | 0.040992272 | 51.455788 |
+      | 8eb79504-1545-4fd9-a358-430a649e0352 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true,accessibility/attr_two=true    | 0.082750916 | 51.494056 |
+      | ae579504-1545-4fd9-a358-430a649e0354 | Site-5 | 5 Roadside | 0113 1111111 | N12     | R5     | ICB5 | Info 5                 | accessibility/attr_one=true,accessibility/attr_two=true    | 0.081750916 | 51.484056 |
+    And the following sessions exist for site '6997851c-0bcd-462e-b1f5-b1c02f24d37d'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '1efc8a32-ad71-4066-821e-e535317c309a'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site 'ab746a05-345f-4c06-829b-2d5d52ec341b'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult  | 5           | 1        |
+    And the following sessions exist for site '8eb79504-1545-4fd9-a358-430a649e0352'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site 'ae579504-1545-4fd9-a358-430a649e0354'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | FLU:2-3    | 5           | 1        |
+    When I make the following request with service filtering and with access needs
+      | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    | AccessNeeds        |
+      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow | attr_one,attr_two  |
+    Then the following sites and distances are returned
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                          | Longitude   | Latitude  | Distance |
+      | 8eb79504-1545-4fd9-a358-430a649e0352 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true,accessibility/attr_two=true  | 0.082750916 | 51.494056 | 662      |

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
@@ -2,7 +2,7 @@ Feature: Site search
 
   Scenario: Retrieve all sites within a designated distance
     Given The following sites exist in the system
-      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                   | Longitude   | Latitude  |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
       | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
       | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
       | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
@@ -11,14 +11,14 @@ Feature: Site search
       | Max Records | Search Radius | Longitude | Latitude |
       | 50          | 6000          | 0.082     | 51.5     |
     Then the following sites and distances are returned
-      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                   | Longitude   | Latitude  | Distance |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
       | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
       | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
 
   Scenario: Only return the number of sites requested
     Given The following sites exist in the system
-      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                   | Longitude    | Latitude   |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude    | Latitude   |
       | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-5 | 5 Roadside | 0113 5555555 | J12     | R5     | ICB5 | Info 5                 | accessibility/attr_one=true  | -0.082750916 | -51.494056 |
       | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-6 | 6 Roadside | 0113 6666666 | K12     | R6     | ICB6 | Info 6                 | accessibility/attr_one=false | -0.14566747  | -51.482472 |
       | 10a54cc1-f052-4c7b-bfc8-de4e5ee7e193 | Site-7 | 7 Roadside | 0113 7777777 | L12     | R7     | ICB7 | Info 7                 | accessibility/attr_one=true  | 0.13086317   | -51.583479 |
@@ -27,18 +27,186 @@ Feature: Site search
       | Max Records | Search Radius | Longitude | Latitude |
       | 2           | 100000        | -0.082    | -51.5    |
     Then the following sites and distances are returned
-      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                   | Longitude    | Latitude   | Distance |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude    | Latitude   | Distance |
       | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-5 | 5 Roadside | 0113 5555555 | J12     | R5     | ICB5 | Info 5                 | accessibility/attr_one=true  | -0.082750916 | -51.494056 | 662      |
       | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-6 | 6 Roadside | 0113 6666666 | K12     | R6     | ICB6 | Info 6                 | accessibility/attr_one=false | -0.14566747  | -51.482472 | 4819     |
 
   Scenario: Only return sites with requested access needs
     Given The following sites exist in the system
-      | Site                                 | Name    | Address     | PhoneNumber  | OdsCode | Region | ICB   | InformationForCitizens | Accessibilities                                               | Longitude | Latitude |
+      | Site                                 | Name    | Address     | PhoneNumber  | OdsCode | Region | ICB   | InformationForCitizens | Accessibilities                                          | Longitude | Latitude |
       | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-9  | 9 Roadside  | 0113 9999999 | J12     | R9     | ICB9  | Info 9                 | accessibility/attr_one=true,accessibility/attr_two=true  | -0.0827   | -51.5    |
-      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-10 | 10 Roadside | 0113 1010101 | K12     | R10    | ICB10 | Info 10                 | accessibility/attr_one=true,accessibility/attr_two=false | -0.0827   | -51.5    |
+      | 6877d86e-c2df-4def-8508-e1eccf0ea6be | Site-10 | 10 Roadside | 0113 1010101 | K12     | R10    | ICB10 | Info 10                | accessibility/attr_one=true,accessibility/attr_two=false | -0.0827   | -51.5    |
     When I make the following request with access needs
       | Max Records | Search Radius | Longitude | Latitude | AccessNeeds       |
       | 50          | 100000        | -0.082    | -51.5    | attr_one,attr_two |
     Then the following sites and distances are returned
-      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                              | Longitude | Latitude | Distance |
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                         | Longitude | Latitude | Distance |
       | beeae4e0-dd4a-4e3a-8f4d-738f9418fb51 | Site-9 | 9 Roadside | 0113 9999999 | J12     | R9     | ICB9 | Info 9                 | accessibility/attr_one=true,accessibility/attr_two=true | -0.0827   | -51.5    | 48       |
+
+  Scenario: Retrieve sites by service filter - single result
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | a03982ab-f9a8-4d4b-97ca-419d1154896f | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+    And the following sessions exist for site 'a03982ab-f9a8-4d4b-97ca-419d1154896f'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
+      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+    Then the following sites and distances are returned
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
+      | a03982ab-f9a8-4d4b-97ca-419d1154896f | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+
+  Scenario: Retrieve sites by service filter - multiple results limited to max records and the order is maintained
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | 3ac1981b-5d62-424a-b403-9d08a40739ce | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 3525af0d-9d89-4b32-ad6b-b85ae94589dc | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | 0.13086317  | 51.483479 |
+      | f178d668-a8d7-4fa6-a4b1-b886feef29a6 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+      | 156141af-89ab-4a30-83d4-a4d27a8322c2 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+    And the following sessions exist for site '156141af-89ab-4a30-83d4-a4d27a8322c2'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site 'f178d668-a8d7-4fa6-a4b1-b886feef29a6'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '3525af0d-9d89-4b32-ad6b-b85ae94589dc'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '3ac1981b-5d62-424a-b403-9d08a40739ce'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
+      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+    Then the following sites and distances are returned
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
+      | 156141af-89ab-4a30-83d4-a4d27a8322c2 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+      | 3525af0d-9d89-4b32-ad6b-b85ae94589dc | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | 0.13086317  | 51.483479 | 3849     |
+      | 3ac1981b-5d62-424a-b403-9d08a40739ce | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
+      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+    Then the following sites and distances are returned
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
+      | 156141af-89ab-4a30-83d4-a4d27a8322c2 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+      | 3525af0d-9d89-4b32-ad6b-b85ae94589dc | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | 0.13086317  | 51.483479 | 3849     |
+      | 3ac1981b-5d62-424a-b403-9d08a40739ce | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
+      | f178d668-a8d7-4fa6-a4b1-b886feef29a6 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
+
+  Scenario: Retrieve sites by service filter - no results if no sessions
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | beeae4e0-dd4a-4e4a-8f4d-738f9418fb51 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | 6877d86e-c2df-1def-8508-e1eccf0ea6be | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 5914b64a-66bb-4ee2-ab8a-94958c1fdfcb | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
+      | 10a54cc1-c052-4c7b-bfc8-de4e5ee7e193 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
+      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+    Then no sites are returned
+
+  Scenario: Retrieve sites by service filter - no results if no sessions for service exist
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | 355ca42f-586c-4f7a-a274-4d53844e3e0c | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | 8da01caa-f589-4914-9c4c-42d7adb185ae | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 96f49dd3-f0cb-4b1b-826d-d07065e14c86 | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
+      | 7627459e-15b5-44e7-9318-1b1f3ca5c414 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+    And the following sessions exist for site '355ca42f-586c-4f7a-a274-4d53844e3e0c'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult  | 5           | 1        |
+    And the following sessions exist for site '8da01caa-f589-4914-9c4c-42d7adb185ae'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID-19   | 5           | 1        |
+    And the following sessions exist for site '96f49dd3-f0cb-4b1b-826d-d07065e14c86'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | FLU:2-3    | 5           | 1        |
+    And the following sessions exist for site '7627459e-15b5-44e7-9318-1b1f3ca5c414'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COV        | 5           | 1        |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
+      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+    Then no sites are returned
+
+  Scenario: Retrieve sites by service filter - no results if no sessions for service exist in the date range required
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | b37000df-f261-40ce-b86b-68b31540e804 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | 6092852c-b454-4249-9e12-0c0152056708 | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 96e527f3-5791-4567-a6a7-6691f5dcecb5 | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
+      | 38d0905e-9395-4954-ba72-0ae5a81ff876 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+    And the following sessions exist for site 'b37000df-f261-40ce-b86b-68b31540e804'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '6092852c-b454-4249-9e12-0c0152056708'
+      | Date                 | From  | Until | Services   | Slot Length | Capacity |
+      | 4 days from today    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '96e527f3-5791-4567-a6a7-6691f5dcecb5'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '38d0905e-9395-4954-ba72-0ae5a81ff876'
+      | Date                 | From  | Until | Services     | Slot Length | Capacity |
+      | 4 days from today    | 09:00 | 17:00 | COVID        | 5           | 1        |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From              | Until             |
+      | 3           | 6000          | 0.082     | 51.5     | COVID   | 2 days from today | 3 days from today |
+    Then no sites are returned
+
+
+  Scenario: Retrieve sites by service filter - results when service sessions are on different days
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | 9ac67f31-cc79-46c0-b0d2-e3be1d7b8caa | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | a1a30efa-9506-47aa-b6a6-fa0e74c848f4 | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 45a73a10-87c1-4826-a740-e1ebc4585618 | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
+      | 61da1c54-0b24-470a-8978-bb7c66a15816 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+    And the following sessions exist for site '9ac67f31-cc79-46c0-b0d2-e3be1d7b8caa'
+      | Date        | From  | Until | Services   | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site 'a1a30efa-9506-47aa-b6a6-fa0e74c848f4'
+      | Date                 | From  | Until | Services   | Slot Length | Capacity |
+      | 2 days from today    | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '45a73a10-87c1-4826-a740-e1ebc4585618'
+      | Date               | From  | Until | Services   | Slot Length | Capacity |
+      | 3 days from today  | 09:00 | 17:00 | COVID      | 5           | 1        |
+    And the following sessions exist for site '61da1c54-0b24-470a-8978-bb7c66a15816'
+      | Date                 | From  | Until | Services     | Slot Length | Capacity |
+      | 4 days from today    | 09:00 | 17:00 | COVID        | 5           | 1        |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
+      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+    Then the following sites and distances are returned
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
+      | 9ac67f31-cc79-46c0-b0d2-e3be1d7b8caa | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+      | a1a30efa-9506-47aa-b6a6-fa0e74c848f4 | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
+      | 61da1c54-0b24-470a-8978-bb7c66a15816 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
+
+  Scenario: Retrieve sites by service filter - results when service sessions have multiple services
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | 4dbaffc9-f476-494b-817a-37dc8aa151c9 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | b06f4be6-16e3-40be-b373-b67a47301185 | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 2ba498ab-42b5-4536-9f11-796077922ce1 | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
+      | d2f9f101-b145-42ef-93e0-ae449efb9a78 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+    And the following sessions exist for site '4dbaffc9-f476-494b-817a-37dc8aa151c9'
+      | Date        | From  | Until | Services          | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult, COVID  | 5           | 1        |
+    And the following sessions exist for site 'b06f4be6-16e3-40be-b373-b67a47301185'
+      | Date                 | From  | Until | Services        | Slot Length | Capacity |
+      | 2 days from today    | 09:00 | 17:00 | COVID, FLU:2-3  | 5           | 1        |
+    And the following sessions exist for site '2ba498ab-42b5-4536-9f11-796077922ce1'
+      | Date               | From  | Until | Services           | Slot Length | Capacity |
+      | 3 days from today  | 09:00 | 17:00 | COVID, COVID:5-18  | 5           | 1        |
+    And the following sessions exist for site 'd2f9f101-b145-42ef-93e0-ae449efb9a78'
+      | Date                 | From  | Until | Services        | Slot Length | Capacity |
+      | 4 days from today    | 09:00 | 17:00 | COVID, FLU:2-3  | 5           | 1        |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
+      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+    Then the following sites and distances are returned
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
+      | 4dbaffc9-f476-494b-817a-37dc8aa151c9 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+      | b06f4be6-16e3-40be-b373-b67a47301185 | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
+      | d2f9f101-b145-42ef-93e0-ae449efb9a78 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
@@ -295,3 +295,150 @@ Feature: Site search
       | 4dbaffc9-f476-494b-817a-37dc8aa151c9 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
       | b06f4be6-16e3-40be-b373-b67a47301185 | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
       | d2f9f101-b145-42ef-93e0-ae449efb9a78 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
+    
+# This shows the temporary quicker solution for this hotfix 2.2.2 (APPT-1203) and how it isn't a perfect solution and should be fixed properly in the future
+  Scenario: Retrieve sites by service filter - returns sites that are fully booked and support the service (intended behaviour)
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | 2d1780ea-73cf-43c1-ad19-1f0cb288e35b | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | 586bc02d-310a-4b02-a117-d0d104de16bb | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | a01e7aec-4721-410b-853d-1bed6ade4c3c | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | 0.13086317  | 51.483479 |
+      | a5f2f93e-26e8-45ac-a09b-2485517f1d9c | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+    And the following sessions exist for site '2d1780ea-73cf-43c1-ad19-1f0cb288e35b'
+      | Date        | From  | Until | Services  | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 09:10 | COVID     | 10           | 1       |
+    And the following bookings have been made for site '2d1780ea-73cf-43c1-ad19-1f0cb288e35b'
+      | Date        | Time  | Duration | Service | Reference   |
+      | Tomorrow    | 09:00 | 10       | COVID   | 56345-11111 |
+    And the following sessions exist for site '586bc02d-310a-4b02-a117-d0d104de16bb'
+      | Date                 | From  | Until | Services  | Slot Length | Capacity |
+      | 2 days from today    | 09:00 | 09:10 | COVID     | 10           | 1       |
+    And the following bookings have been made for site '586bc02d-310a-4b02-a117-d0d104de16bb'
+      | Date                 | Time  | Duration | Service | Reference   |
+      | 2 days from today    | 09:00 | 10       | COVID   | 56345-22222 |
+    And the following sessions exist for site 'a01e7aec-4721-410b-853d-1bed6ade4c3c'
+      | Date               | From  | Until | Services  | Slot Length | Capacity |
+      | 3 days from today  | 09:00 | 09:10 | COVID     | 10           | 1       |
+    And the following bookings have been made for site 'a01e7aec-4721-410b-853d-1bed6ade4c3c'
+      | Date                 | Time  | Duration | Service | Reference   |
+      | 3 days from today    | 09:00 | 10       | COVID   | 56345-33333 |
+    And the following sessions exist for site 'a5f2f93e-26e8-45ac-a09b-2485517f1d9c'
+      | Date                 | From  | Until | Services | Slot Length | Capacity |
+      | 4 days from today    | 09:00 | 09:10 | COVID    | 10           | 1       |
+    And the following bookings have been made for site 'a5f2f93e-26e8-45ac-a09b-2485517f1d9c'
+      | Date                 | Time  | Duration | Service | Reference   |
+      | 4 days from today    | 09:00 | 10       | COVID   | 56345-44444 |
+    When I check daily availability for site '2d1780ea-73cf-43c1-ad19-1f0cb288e35b' for 'COVID' between 'Tomorrow' and '4 days from today'
+    Then the following availability is returned for 'Tomorrow'
+      | From  | Until | Count |
+      | 00:00 | 12:00 | 0     |
+      | 12:00 | 00:00 | 0     |
+    When I check daily availability for site '586bc02d-310a-4b02-a117-d0d104de16bb' for 'COVID' between 'Tomorrow' and '4 days from today'
+    Then the following availability is returned for '2 days from today'
+      | From  | Until | Count |
+      | 00:00 | 12:00 | 0     |
+      | 12:00 | 00:00 | 0     |
+    When I check daily availability for site 'a01e7aec-4721-410b-853d-1bed6ade4c3c' for 'COVID' between 'Tomorrow' and '4 days from today'
+    Then the following availability is returned for '3 days from today'
+      | From  | Until | Count |
+      | 00:00 | 12:00 | 0     |
+      | 12:00 | 00:00 | 0     |
+    When I check daily availability for site 'a5f2f93e-26e8-45ac-a09b-2485517f1d9c' for 'COVID' between 'Tomorrow' and '4 days from today'
+    Then the following availability is returned for '4 days from today'
+      | From  | Until | Count |
+      | 00:00 | 12:00 | 0     |
+      | 12:00 | 00:00 | 0     |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
+      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+    Then the following sites and distances are returned
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
+      | 2d1780ea-73cf-43c1-ad19-1f0cb288e35b | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+      | a01e7aec-4721-410b-853d-1bed6ade4c3c | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | 0.13086317  | 51.483479 | 3849     |
+      | 586bc02d-310a-4b02-a117-d0d104de16bb | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
+      | a5f2f93e-26e8-45ac-a09b-2485517f1d9c | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
+
+  Scenario: Retrieve sites by service filter - returns sites that are partially booked and support the service (intended behaviour)
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | 20e7b709-83c6-416b-b5d8-27d03222e1bf | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | 9bf7f58b-ca1a-425a-869e-7a574e183a2c | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 6beadf23-2c8c-4080-8be6-896c73634efb | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | 0.13086317  | 51.483479 |
+      | aa8ceff5-d152-4687-b8ea-030df7d5efb1 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+    And the following sessions exist for site '20e7b709-83c6-416b-b5d8-27d03222e1bf'
+      | Date        | From  | Until | Services  | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 09:20 | COVID     | 10           | 1       |
+    And the following bookings have been made for site '20e7b709-83c6-416b-b5d8-27d03222e1bf'
+      | Date        | Time  | Duration | Service | Reference   |
+      | Tomorrow    | 09:00 | 10       | COVID   | 56345-11111 |
+    And the following sessions exist for site '9bf7f58b-ca1a-425a-869e-7a574e183a2c'
+      | Date                 | From  | Until | Services  | Slot Length | Capacity |
+      | 2 days from today    | 09:00 | 09:20 | COVID     | 10           | 1       |
+    And the following bookings have been made for site '9bf7f58b-ca1a-425a-869e-7a574e183a2c'
+      | Date                 | Time  | Duration | Service | Reference   |
+      | 2 days from today    | 09:00 | 10       | COVID   | 56345-22222 |
+    And the following sessions exist for site '6beadf23-2c8c-4080-8be6-896c73634efb'
+      | Date               | From  | Until | Services  | Slot Length | Capacity |
+      | 3 days from today  | 09:00 | 09:20 | COVID     | 10           | 1       |
+    And the following bookings have been made for site '6beadf23-2c8c-4080-8be6-896c73634efb'
+      | Date                 | Time  | Duration | Service | Reference   |
+      | 3 days from today    | 09:00 | 10       | COVID   | 56345-33333 |
+    And the following sessions exist for site 'aa8ceff5-d152-4687-b8ea-030df7d5efb1'
+      | Date                 | From  | Until | Services | Slot Length | Capacity |
+      | 4 days from today    | 09:00 | 09:20 | COVID    | 10           | 1       |
+    And the following bookings have been made for site 'aa8ceff5-d152-4687-b8ea-030df7d5efb1'
+      | Date                 | Time  | Duration | Service | Reference   |
+      | 4 days from today    | 09:00 | 10       | COVID   | 56345-44444 |
+    When I check daily availability for site '20e7b709-83c6-416b-b5d8-27d03222e1bf' for 'COVID' between 'Tomorrow' and '4 days from today'
+    Then the following availability is returned for 'Tomorrow'
+      | From  | Until | Count |
+      | 00:00 | 12:00 | 1     |
+      | 12:00 | 00:00 | 0     |
+    When I check daily availability for site '9bf7f58b-ca1a-425a-869e-7a574e183a2c' for 'COVID' between 'Tomorrow' and '4 days from today'
+    Then the following availability is returned for '2 days from today'
+      | From  | Until | Count |
+      | 00:00 | 12:00 | 1     |
+      | 12:00 | 00:00 | 0     |
+    When I check daily availability for site '6beadf23-2c8c-4080-8be6-896c73634efb' for 'COVID' between 'Tomorrow' and '4 days from today'
+    Then the following availability is returned for '3 days from today'
+      | From  | Until | Count |
+      | 00:00 | 12:00 | 1     |
+      | 12:00 | 00:00 | 0     |
+    When I check daily availability for site 'aa8ceff5-d152-4687-b8ea-030df7d5efb1' for 'COVID' between 'Tomorrow' and '4 days from today'
+    Then the following availability is returned for '4 days from today'
+      | From  | Until | Count |
+      | 00:00 | 12:00 | 1     |
+      | 12:00 | 00:00 | 0     |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
+      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+    Then the following sites and distances are returned
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
+      | 20e7b709-83c6-416b-b5d8-27d03222e1bf | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
+      | 6beadf23-2c8c-4080-8be6-896c73634efb | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | 0.13086317  | 51.483479 | 3849     |
+      | 9bf7f58b-ca1a-425a-869e-7a574e183a2c | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
+      | aa8ceff5-d152-4687-b8ea-030df7d5efb1 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
+
+  Scenario: Retrieve sites by service filter - returns no sites if they have orphaned bookings for that service, but no sessions for that service
+    Given The following sites exist in the system
+      | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
+      | dbd61ab0-281a-4df0-b1b7-6b6793f8e119 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
+      | dfd0ac4e-d5ae-4c63-87c9-c84a84c9a7d1 | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 |
+      | 5fdbbb82-45ee-4d0c-bbe0-57d25b55512a | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | 0.13086317  | 51.483479 |
+      | 6f2108ef-d1b3-4479-a5dc-cf2bb68dceb9 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
+    And the following orphaned bookings exist for site 'dbd61ab0-281a-4df0-b1b7-6b6793f8e119'
+      | Date        | Time  | Duration | Service | Reference   |
+      | Tomorrow    | 09:00 | 10       | COVID   | 56345-11111 |
+    And the following orphaned bookings exist for site 'dfd0ac4e-d5ae-4c63-87c9-c84a84c9a7d1'
+      | Date                 | Time  | Duration | Service | Reference   |
+      | 2 days from today    | 09:00 | 10       | COVID   | 56345-22222 |
+    And the following orphaned bookings exist for site '5fdbbb82-45ee-4d0c-bbe0-57d25b55512a'
+      | Date                 | Time  | Duration | Service | Reference   |
+      | 3 days from today    | 09:00 | 10       | COVID   | 56345-33333 |
+    And the following orphaned bookings exist for site '6f2108ef-d1b3-4479-a5dc-cf2bb68dceb9'
+      | Date                 | Time  | Duration | Service | Reference   |
+      | 4 days from today    | 09:00 | 10       | COVID   | 56345-44444 |
+    When I make the following request with service filtering
+      | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
+      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+    Then no sites are returned

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
@@ -106,13 +106,13 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         var latitude = row.Cells.ElementAt(3).Value;
 
         var service = row.Cells.ElementAt(4).Value;
-        var from = row.Cells.ElementAt(5).Value;
-        var until = row.Cells.ElementAt(6).Value;
+        var from = ParseNaturalLanguageDateOnly(row.Cells.ElementAt(5).Value);
+        var until = ParseNaturalLanguageDateOnly(row.Cells.ElementAt(6).Value);
 
         var accessNeeds = row.Cells.ElementAt(7).Value;
 
         _response = await Http.GetAsync(
-            $"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&services={service}&from={from}&until={until}&accessNeeds={accessNeeds}&ignoreCache=true");
+            $"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&services={service}&from={from.ToString("yyyy-MM-dd")}&until={until.ToString("yyyy-MM-dd")}&accessNeeds={accessNeeds}&ignoreCache=true");
         _statusCode = _response.StatusCode;
         (_, _sitesResponse) =
             await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Gherkin.Ast;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Linq;
+using Nhs.Appointments.Api.Availability;
 using Nhs.Appointments.Api.Json;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
@@ -19,7 +20,8 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.SiteManagement;
 [FeatureFile("./Scenarios/SiteManagement/SiteSearch.feature")]
 public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDisposable
 {
-    private IEnumerable<SiteWithDistance> _actualResponse;
+    private IEnumerable<SiteWithDistance> _sitesResponse;
+    private QueryAvailabilityResponse _queryResponse;
     private HttpResponseMessage _response;
     private HttpStatusCode _statusCode;
 
@@ -41,11 +43,59 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         _response = await Http.GetAsync(
             $"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&accessNeeds={accessNeeds}&ignoreCache=true");
         _statusCode = _response.StatusCode;
-        (_, _actualResponse) =
+        (_, _sitesResponse) =
             await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(
                 await _response.Content.ReadAsStreamAsync());
     }
+    
+    [When(@"I check ([\w:]+) availability for site '(.+)' for '(.+)' between '(.+)' and '(.+)'")]
+    public async Task CheckAvailability(string queryType, string site, string service, string from, string until)
+    {
+        var convertedQueryType = queryType switch
+        {
+            "daily" => QueryType.Days,
+            "hourly" => QueryType.Hours,
+            "slot" => QueryType.Slots,
+            _ => throw new Exception($"{queryType} is not a valid queryType")
+        };
 
+        var payload = new
+        {
+            sites = new[] { GetSiteId(site) },
+            service,
+            from = ParseNaturalLanguageDateOnly(from),
+            until = ParseNaturalLanguageDateOnly(until),
+            queryType = convertedQueryType.ToString()
+        };
+
+        _response = await Http.PostAsJsonAsync($"http://localhost:7071/api/availability/query", payload);
+        _statusCode = _response.StatusCode;
+        (_, _queryResponse) = await JsonRequestReader.ReadRequestAsync<QueryAvailabilityResponse>(await _response.Content.ReadAsStreamAsync());
+    }
+
+    [Then(@"the following availability is returned for '(.+)'")]
+    [And(@"the following availability is returned for '(.+)'")]
+    public void Assert(string date, Gherkin.Ast.DataTable expectedHourlyAvailabilityTable)
+    {
+        var expectedDate = ParseNaturalLanguageDateOnly(date);
+        var expectedHourBlocks = expectedHourlyAvailabilityTable.Rows.Skip(1).Select(row =>
+            new QueryAvailabilityResponseBlock(
+                TimeOnly.ParseExact(row.Cells.ElementAt(0).Value, "HH:mm"),
+                TimeOnly.ParseExact(row.Cells.ElementAt(1).Value, "HH:mm"),
+                int.Parse(row.Cells.ElementAt(2).Value)
+            ));
+
+        var expectedAvailability = new QueryAvailabilityResponseInfo(
+            expectedDate,
+            expectedHourBlocks);
+
+        _statusCode.Should().Be(HttpStatusCode.OK);
+        _queryResponse
+            .Single().availability
+            .Single(x => x.date == expectedDate)
+            .Should().BeEquivalentTo(expectedAvailability, options => options.WithStrictOrdering());
+    }
+    
     [When("I make the following request with service filtering and with access needs")]
     public async Task RequestSitesWithServiceFilteringAndAccessNeeds(DataTable dataTable)
     {
@@ -64,7 +114,7 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         _response = await Http.GetAsync(
             $"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&services={service}&from={from}&until={until}&accessNeeds={accessNeeds}&ignoreCache=true");
         _statusCode = _response.StatusCode;
-        (_, _actualResponse) =
+        (_, _sitesResponse) =
             await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(
                 await _response.Content.ReadAsStreamAsync());
     }
@@ -86,7 +136,7 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         _response = await Http.GetAsync(
             $"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&services={service}&from={from.ToString("yyyy-MM-dd")}&until={until.ToString("yyyy-MM-dd")}&ignoreCache=true");
         _statusCode = _response.StatusCode;
-        (_, _actualResponse) =
+        (_, _sitesResponse) =
             await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(
                 await _response.Content.ReadAsStreamAsync());
     }
@@ -103,7 +153,7 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         _response = await Http.GetAsync(
             $"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&ignoreCache=true");
         _statusCode = _response.StatusCode;
-        (_, _actualResponse) =
+        (_, _sitesResponse) =
             await JsonRequestReader.ReadRequestAsync<IEnumerable<SiteWithDistance>>(
                 await _response.Content.ReadAsStreamAsync());
     }
@@ -130,17 +180,17 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
             ), Distance: int.Parse(row.Cells.ElementAt(11).Value)
         )).ToList();
 
-        _actualResponse.Should().HaveCount(dataTable.Rows.Count() - 1);
+        _sitesResponse.Should().HaveCount(dataTable.Rows.Count() - 1);
 
         _statusCode.Should().Be(HttpStatusCode.OK);
-        _actualResponse.Should().BeEquivalentTo(expectedSites);
+        _sitesResponse.Should().BeEquivalentTo(expectedSites);
     }
 
     [Then("no sites are returned")]
     public void Assert()
     {
         _statusCode.Should().Be(HttpStatusCode.OK);
-        _actualResponse.Should().BeEmpty();
+        _sitesResponse.Should().BeEmpty();
     }
 
     private static async Task DeleteSiteData(CosmosClient cosmosClient, string testId)

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesByAreaFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/GetSitesByAreaFunctionTests.cs
@@ -40,7 +40,7 @@ public class GetSitesByAreaFunctionTests
         var request = CreateRequest(34.6, 2.1, 10, 10, true, accessNeeds);
         var result = await _sut.RunAsync(request) as ContentResult;
         result?.StatusCode.Should().Be(400);
-        _siteService.Verify(x => x.FindSitesByArea(34.6, 2.1, 10, 10, Array.Empty<string>(), false), Times.Never());
+        _siteService.Verify(x => x.FindSitesByArea(34.6, 2.1, 10, 10, Array.Empty<string>(), false, null), Times.Never());
     }
 
     [Fact]
@@ -68,13 +68,13 @@ public class GetSitesByAreaFunctionTests
                 Distance: 100)
         };
         _siteService
-            .Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false))
+            .Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false, null))
             .ReturnsAsync(sites);
         var request = CreateRequest(longitude, latitude, searchRadius, maxRecords, true, accessNeeds);
         var result = await _sut.RunAsync(request) as ContentResult;
         result?.StatusCode.Should().Be(200);
         _siteService.Verify(
-            x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false),
+            x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, new[] { accessNeeds }, false, null),
             Times.Once());
     }
 
@@ -102,13 +102,13 @@ public class GetSitesByAreaFunctionTests
                 Distance: 100)
         };
         _siteService
-            .Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false))
+            .Setup(x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false, null))
             .ReturnsAsync(sites);
         var request = CreateRequest(longitude, latitude, searchRadius, maxRecords, false);
         var result = await _sut.RunAsync(request) as ContentResult;
         result?.StatusCode.Should().Be(200);
         _siteService.Verify(
-            x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false),
+            x => x.FindSitesByArea(longitude, latitude, searchRadius, maxRecords, Array.Empty<string>(), false, null),
             Times.Once());
     }
 

--- a/tests/Nhs.Appointments.Api.UnitTests/NotificationsTestServiceProviderExtensions.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/NotificationsTestServiceProviderExtensions.cs
@@ -29,8 +29,11 @@ public static class NotificationsTestServiceProviderExtensions
                 TypedDocumentCosmosStore<RolesDocument>>()
             .AddSingleton<ITypedDocumentCosmosStore<SiteDocument>,
                 TypedDocumentCosmosStore<SiteDocument>>()
+            .AddSingleton<ITypedDocumentCosmosStore<DailyAvailabilityDocument>,
+                TypedDocumentCosmosStore<DailyAvailabilityDocument>>()
             .AddSingleton<ISiteStore, SiteStore>()
             .AddSingleton<IRolesStore, RolesStore>()
+            .AddSingleton<IAvailabilityStore, AvailabilityDocumentStore>()
             .AddSingleton<INotificationConfigurationStore, NotificationConfigurationStore>()
             .AddSingleton<ISiteService, SiteService>()
             .AddSingleton<INotificationConfigurationService, NotificationConfigurationService>();

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
@@ -8,6 +8,9 @@ public class GetSitesByAreaRequestValidatorTests
 {
     private readonly GetSitesByAreaRequestValidator _sut = new();
 
+    private const string PartialErrorMessage =
+        "All of the 'supports service filters' (services, from, until) must be provided, or none of them.";
+
     [Theory]
     [InlineData(181)]
     [InlineData(-181)]
@@ -119,5 +122,274 @@ public class GetSitesByAreaRequestValidatorTests
         var result = _sut.Validate(request);
         result.IsValid.Should().BeTrue();
         result.Errors.Should().HaveCount(0);            
+    }
+    
+    [Fact]
+    public void Validate_ReturnsSuccess_WhenRequestIsValid_SiteSupportService()
+    {
+        var request = new GetSitesByAreaRequest(
+            180,
+            90,
+            6000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            ["RSV:Adult"],
+            "2025-10-02",
+            "2025-10-30"
+        );
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().HaveCount(0);            
+    }
+    
+    /// <summary>
+    /// This might be relaxed later when multiple service querying is supported
+    /// </summary>
+    [Fact]
+    public void Validate_ReturnsError_SiteSupportService_MultipleServicesProvided()
+    {
+        var request = new GetSitesByAreaRequest(
+            180,
+            90,
+            6000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            ["RSV:Adult", "COVID:19"],
+            "2025-10-02",
+            "2025-10-30"
+        );
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be("'Services' currently only supports one service");     
+    }
+    
+    [Fact]
+    public void Validate_ReturnsError_SiteSupportService_FromDateFormatting()
+    {
+        var request = new GetSitesByAreaRequest(
+            180,
+            90,
+            6000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            ["RSV:Adult"],
+            "20251002",
+            "2025-10-30"
+        );
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be("'From' must be a date in the format 'yyyy-MM-dd'");     
+    }
+    
+    [Fact]
+    public void Validate_ReturnsError_SiteSupportService_UntilDateFormatting()
+    {
+        var request = new GetSitesByAreaRequest(
+            180,
+            90,
+            6000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            ["RSV:Adult"],
+            "2025-10-02",
+            "20251030"
+        );
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be("'Until' must be a date in the format 'yyyy-MM-dd'");     
+    }
+    
+    [Theory]
+    [InlineData(180, 90, 100000, 50)]
+    [InlineData(-180, -90, 1000, 1)]
+    public void Validate_ReturnsSuccess_WhenRequestIsValid_EmptyServices(double longitude, double latitude, int searchRadius, int maxRecords)
+    {
+        var request = new GetSitesByAreaRequest(
+            longitude,
+            latitude,
+            searchRadius,
+            maxRecords,
+            ["access_need_a", "access_need_b"],
+            false,
+            [],
+            null,
+            null
+        );
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().HaveCount(0);            
+    }
+    
+    [Fact]
+    public void Validate_ReturnsError_WhenPartialSupportsServiceFiltersProvided_ServicesOnly()
+    {
+        var request = new GetSitesByAreaRequest(
+            0.123,
+            0.456,
+            50000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            ["RSV:Adult"],
+            null,
+            null
+        );
+        
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be(PartialErrorMessage);
+    }
+    
+    [Fact]
+    public void Validate_ReturnsError_WhenPartialSupportsServiceFiltersProvided_FromOnly()
+    {
+        var request = new GetSitesByAreaRequest(
+            0.123,
+            0.456,
+            50000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            null,
+            "2025-10-03",
+            null
+        );
+        
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be(PartialErrorMessage);
+    }
+    
+    [Fact]
+    public void Validate_ReturnsError_WhenPartialSupportsServiceFiltersProvided_UntilOnly()
+    {
+        var request = new GetSitesByAreaRequest(
+            0.123,
+            0.456,
+            50000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            null,
+            null,
+            "2025-10-03"
+        );
+        
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be(PartialErrorMessage);
+    }
+    
+    [Fact]
+    public void Validate_ReturnsError_WhenPartialSupportsServiceFiltersProvided_ServicesAndFromOnly()
+    {
+        var request = new GetSitesByAreaRequest(
+            0.123,
+            0.456,
+            50000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            ["RSV:Adult"],
+            "2025-08-20",
+            null
+        );
+        
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be(PartialErrorMessage);
+    }
+    
+    [Fact]
+    public void Validate_ReturnsError_WhenPartialSupportsServiceFiltersProvided_ServicesAndUntilOnly()
+    {
+        var request = new GetSitesByAreaRequest(
+            0.123,
+            0.456,
+            50000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            ["RSV:Adult"],
+            null,
+            "2025-08-20"
+        );
+        
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be(PartialErrorMessage);
+    }
+    
+    [Fact]
+    public void Validate_ReturnsError_WhenPartialSupportsServiceFiltersProvided_FromAndUntilOnly()
+    {
+        var request = new GetSitesByAreaRequest(
+            0.123,
+            0.456,
+            50000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            null,
+            "2025-08-18",
+            "2025-08-20"
+        );
+        
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be(PartialErrorMessage);
+    }
+    
+    [Fact]
+    public void Validate_ReturnsError_WhenPartialSupportsServiceFiltersProvided_UntilDateLessThanFromDate()
+    {
+        var request = new GetSitesByAreaRequest(
+            0.123,
+            0.456,
+            50000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            ["RSV:Adult"],
+            "2025-08-18",
+            "2025-08-17"
+        );
+        
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be("'Until' date must be greater than or equal to 'From' date");
+    }
+    
+    [Fact]
+    public void Validate_ReturnsSuccess_WhenPartialSupportsServiceFiltersProvided_UntilDateEqualToFromDate()
+    {
+        var request = new GetSitesByAreaRequest(
+            0.123,
+            0.456,
+            50000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            ["RSV:Adult"],
+            "2025-08-18",
+            "2025-08-18"
+        );
+        
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeTrue();
     }
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
@@ -19,7 +19,10 @@ public class GetSitesByAreaRequestValidatorTests
             50000,
             50,
             ["access_need_a", "access_need_b"],
-            false
+            false,
+            null,
+            null,
+            null
         );
         
         var result = _sut.Validate(request);
@@ -39,7 +42,10 @@ public class GetSitesByAreaRequestValidatorTests
             50000,
             50,
             ["access_need_a", "access_need_b"],
-            false
+            false,
+            null,
+            null,
+            null
         );
         
         var result = _sut.Validate(request);
@@ -59,7 +65,10 @@ public class GetSitesByAreaRequestValidatorTests
             searchRadius,
             50,
             ["access_need_a", "access_need_b"],
-            false
+            false,
+            null,
+            null,
+            null
         );
         
         var result = _sut.Validate(request);
@@ -79,7 +88,10 @@ public class GetSitesByAreaRequestValidatorTests
             50000,
             maxRecords,
             ["access_need_a", "access_need_b"],
-            false
+            false,
+            null,
+            null,
+            null
         );
         
         var result = _sut.Validate(request);
@@ -99,7 +111,10 @@ public class GetSitesByAreaRequestValidatorTests
             searchRadius,
             maxRecords,
             ["access_need_a", "access_need_b"],
-            false
+            false,
+            null,
+            null,
+            null
         );
         var result = _sut.Validate(request);
         result.IsValid.Should().BeTrue();

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
@@ -31,7 +31,7 @@ public class GetSitesByAreaRequestValidatorTests
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(GetSitesByAreaRequest.longitude));
+        result.Errors.Single().PropertyName.Should().Be(nameof(GetSitesByAreaRequest.Longitude));
     }
     
     [Theory]
@@ -54,7 +54,7 @@ public class GetSitesByAreaRequestValidatorTests
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(GetSitesByAreaRequest.latitude));
+        result.Errors.Single().PropertyName.Should().Be(nameof(GetSitesByAreaRequest.Latitude));
     }
     
     [Theory]
@@ -77,7 +77,7 @@ public class GetSitesByAreaRequestValidatorTests
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(GetSitesByAreaRequest.searchRadius));
+        result.Errors.Single().PropertyName.Should().Be(nameof(GetSitesByAreaRequest.SearchRadius));
     }
     
     [Theory]
@@ -100,7 +100,7 @@ public class GetSitesByAreaRequestValidatorTests
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
-        result.Errors.Single().PropertyName.Should().Be(nameof(GetSitesByAreaRequest.maximumRecords));
+        result.Errors.Single().PropertyName.Should().Be(nameof(GetSitesByAreaRequest.MaximumRecords));
     }
 
     [Theory]

--- a/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace Nhs.Appointments.Core.UnitTests;
 
@@ -8,11 +9,12 @@ public class SiteServiceTests
     private readonly Mock<IMemoryCache> _memoryCache = new();
     private readonly Mock<ISiteStore> _siteStore = new();
     private readonly Mock<IAvailabilityStore> _availabilityStore = new();
+    private readonly Mock<ILogger<ISiteService>> _logger = new();
     private readonly SiteService _sut;
 
     public SiteServiceTests()
     {
-        _sut = new SiteService(_siteStore.Object, _availabilityStore.Object, _memoryCache.Object, TimeProvider.System);
+        _sut = new SiteService(_siteStore.Object, _availabilityStore.Object, _memoryCache.Object, _logger.Object, TimeProvider.System);
         _memoryCache.Setup(x => x.CreateEntry(It.IsAny<object>())).Returns(_cacheEntry.Object);
     }
 

--- a/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
@@ -479,7 +479,7 @@ public class SiteServiceTests
         _siteStore.Setup(x => x.GetAllSites()).ReturnsAsync(sites.Select(s => s.Site));
         var result = await _sut.FindSitesByArea(0.0, 50, 50000, 50, [""]);
         result.Should().BeEquivalentTo(sites);
-        _availabilityStore.Verify(x => x.SiteSupportsService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>()), Times.Never);
+        _availabilityStore.Verify(x => x.SiteOffersServiceDuringPeriod(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>()), Times.Never);
     }
     
     [Fact]
@@ -519,14 +519,14 @@ public class SiteServiceTests
                 Distance: 3573)
         };
         _siteStore.Setup(x => x.GetAllSites()).ReturnsAsync(sites.Select(s => s.Site));
-        _availabilityStore.Setup(x => x.SiteSupportsService(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(true);
+        _availabilityStore.Setup(x => x.SiteOffersServiceDuringPeriod(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(true);
         var result = await _sut.FindSitesByArea(0.0, 50, 50000, 50, [""], false, new SiteSupportsServiceFilter("RSV:Adult", new DateOnly(2025,10,3), new DateOnly(2025,10,15)));
         result.Should().BeEquivalentTo(sites);
 
         var docIds = new List<string>() { "20251003", "20251004", "20251005","20251006","20251007","20251008","20251009","20251010", "20251011", "20251012","20251013","20251014","20251015"};
         
-        _availabilityStore.Verify(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "RSV:Adult", docIds), Times.Once);
-        _availabilityStore.Verify(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6bb", "RSV:Adult", docIds), Times.Once);
+        _availabilityStore.Verify(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "RSV:Adult", docIds), Times.Once);
+        _availabilityStore.Verify(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6bb", "RSV:Adult", docIds), Times.Once);
         
         _logger.Verify(x => x.Log(
                 LogLevel.Information,
@@ -614,20 +614,20 @@ public class SiteServiceTests
         
         _siteStore.Setup(x => x.GetAllSites()).ReturnsAsync(sites.Select(s => s.Site));
         
-        _availabilityStore.Setup(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6ba", It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(false);
-        _availabilityStore.Setup(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6bb", It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(false);
-        _availabilityStore.Setup(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6bc", It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(true);
-        _availabilityStore.Setup(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6bd", It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(true);
+        _availabilityStore.Setup(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6ba", It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(false);
+        _availabilityStore.Setup(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6bb", It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(false);
+        _availabilityStore.Setup(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6bc", It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(true);
+        _availabilityStore.Setup(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6bd", It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(true);
         
         var result = await _sut.FindSitesByArea(0.0, 50, 50000, 1, [""], false, new SiteSupportsServiceFilter("RSV:Adult", new DateOnly(2025,10,3), new DateOnly(2025,10,06)));
         result.Should().BeEquivalentTo([validSites.First()]);
 
         var docIds = new List<string>() { "20251003", "20251004", "20251005", "20251006"};
         
-        _availabilityStore.Verify(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "RSV:Adult", docIds), Times.Once);
-        _availabilityStore.Verify(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6bb", "RSV:Adult", docIds), Times.Once);
-        _availabilityStore.Verify(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6bc", "RSV:Adult", docIds), Times.Once);
-        _availabilityStore.Verify(x => x.SiteSupportsService("6877d86e-c2df-4def-8508-e1eccf0ea6bd", "RSV:Adult", docIds), Times.Once);
+        _availabilityStore.Verify(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6ba", "RSV:Adult", docIds), Times.Once);
+        _availabilityStore.Verify(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6bb", "RSV:Adult", docIds), Times.Once);
+        _availabilityStore.Verify(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6bc", "RSV:Adult", docIds), Times.Once);
+        _availabilityStore.Verify(x => x.SiteOffersServiceDuringPeriod("6877d86e-c2df-4def-8508-e1eccf0ea6bd", "RSV:Adult", docIds), Times.Once);
         
         _logger.Verify(x => x.Log(
                 LogLevel.Information,

--- a/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs
@@ -7,11 +7,12 @@ public class SiteServiceTests
     private readonly Mock<ICacheEntry> _cacheEntry = new();
     private readonly Mock<IMemoryCache> _memoryCache = new();
     private readonly Mock<ISiteStore> _siteStore = new();
+    private readonly Mock<IAvailabilityStore> _availabilityStore = new();
     private readonly SiteService _sut;
 
     public SiteServiceTests()
     {
-        _sut = new SiteService(_siteStore.Object, _memoryCache.Object, TimeProvider.System);
+        _sut = new SiteService(_siteStore.Object, _availabilityStore.Object, _memoryCache.Object, TimeProvider.System);
         _memoryCache.Setup(x => x.CreateEntry(It.IsAny<object>())).Returns(_cacheEntry.Object);
     }
 


### PR DESCRIPTION
# Description

Update to the GetSitesByAreaFunction to allow new optional filtering to be used by NBS to restrict the long/lat area results to only return sites that support the service being queried (this means that a site has posted ANY availability within the daterange, it doesn't mean they have capacity remaining - i.e we aren't doing full allocation and free slot checks at this top level stage)

This is supposed to be 'temporary' in that we are going to attempt to consolidate this API endpoint and the first api/query call into a new single API endpoint in future (APPT-841)

**Having said that, the intention is for this to go out as a hotfix to address A/W needs, so it needs to be performant and behave as expected.**

Have added a LOT of integration tests to prove expected behaviours, as well as old behaviour is still supported if needed to be rolled back to by NBS.

Have added logging in for the 'Batching' of calls so that we can verify in logs in Production whether the batch size needs increasing/decreasing for certain services...?

The API does 2 calls, one to get all the cached sites in API and calculated distance bounds in memory. Then I use all the potentially valid sites (ordered distance ascending) to try and batch build up the required results. If needed, it can iterate multiple times to find a site that is the furthest away (whilst still within range) if its the only one to support the service.

Fixes # (issue)

# Checklist:

- [x] My work is behind a feature toggle (if appropriate)
- [x] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [x] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [x] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
