### PR TITLE
APPT-1229 - Automatically using the rescheduled by citizen cancellation reason when rescheduling an appointment (#867)

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/ConfirmProvisionalBookingFunction.cs
@@ -72,8 +72,7 @@ public class ConfirmProvisionalBookingFunction(
         {
             result = await bookingWriteService.ConfirmProvisionalBooking(bookingRequest.bookingReference,
             bookingRequest.contactDetails.Select(x => new ContactItem { Type = x.Type, Value = x.Value }),
-            bookingRequest.bookingToReschedule,
-            bookingRequest.cancellationReason?.ToString());
+            bookingRequest.bookingToReschedule);
         }
 
         switch (result)
@@ -107,7 +106,6 @@ public class ConfirmProvisionalBookingFunction(
         var contactDetails = new ContactItem[] { };
         var bookingToReschedule = string.Empty;
         var relatedBookings = Array.Empty<string>();
-        var cancellationReason = string.Empty;
         if (req.Body != null && req.Body.Length > 0)
         {
             var (errors, payload) = await JsonRequestReader.ReadRequestAsync<ConfirmBookingRequestPayload>(req.Body, true);
@@ -119,7 +117,6 @@ public class ConfirmProvisionalBookingFunction(
             contactDetails = payload?.contactDetails ?? Array.Empty<ContactItem>();
             bookingToReschedule = payload.bookingToReschedule ?? string.Empty;
             relatedBookings = payload.relatedBookings ?? Array.Empty<string>();
-            cancellationReason = payload?.cancellationReason?.ToString();
 
             var payloadErrors = new List<ErrorMessageResponseItem>();
             if (payload?.contactDetails == null && payload.bookingToReschedule == null)
@@ -130,10 +127,8 @@ public class ConfirmProvisionalBookingFunction(
         }
 
         var bookingReference = req.HttpContext.GetRouteValue("bookingReference")?.ToString();
-        CancellationReason? parsedCancellationReason = string.IsNullOrEmpty(cancellationReason)
-            ? null : Enum.Parse<CancellationReason>(cancellationReason);
 
         return (ErrorMessageResponseItem.None,
-            new ConfirmBookingRequest(bookingReference, contactDetails, relatedBookings, bookingToReschedule, parsedCancellationReason));
+            new ConfirmBookingRequest(bookingReference, contactDetails, relatedBookings, bookingToReschedule));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Models/ConfirmBookingRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/ConfirmBookingRequest.cs
@@ -2,10 +2,9 @@ using Nhs.Appointments.Core;
 
 namespace Nhs.Appointments.Api.Models;
 
-public record ConfirmBookingRequestPayload(ContactItem[] contactDetails, string[] relatedBookings, string bookingToReschedule, CancellationReason? cancellationReason); 
+public record ConfirmBookingRequestPayload(ContactItem[] contactDetails, string[] relatedBookings, string bookingToReschedule);
 public record ConfirmBookingRequest(
     string bookingReference,
     ContactItem[] contactDetails,
     string[] relatedBookings,
-    string bookingToReschedule,
-    CancellationReason? cancellationReason) : ConfirmBookingRequestPayload(contactDetails, relatedBookings, bookingToReschedule, cancellationReason);
+    string bookingToReschedule) : ConfirmBookingRequestPayload(contactDetails, relatedBookings, bookingToReschedule);

--- a/src/api/Nhs.Appointments.Core/Booking.cs
+++ b/src/api/Nhs.Appointments.Core/Booking.cs
@@ -94,5 +94,6 @@ public enum AvailabilityStatus
 public enum CancellationReason
 {
     CancelledByCitizen,
-    CancelledBySite
+    CancelledBySite,
+    RescheduledByCitizen
 }

--- a/src/api/Nhs.Appointments.Core/BookingWriteService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingWriteService.cs
@@ -20,7 +20,7 @@ public interface IBookingWriteService
         IEnumerable<ContactItem> contactDetails);
 
     Task<BookingConfirmationResult> ConfirmProvisionalBooking(string bookingReference,
-        IEnumerable<ContactItem> contactDetails, string bookingToReschedule, string cancellationReason = null);
+        IEnumerable<ContactItem> contactDetails, string bookingToReschedule);
 
     Task<IEnumerable<string>> RemoveUnconfirmedProvisionalBookings();
 
@@ -74,13 +74,12 @@ public class BookingWriteService(
         return result;
     }
 
-    public async Task<BookingConfirmationResult> ConfirmProvisionalBooking(string bookingReference,
-        IEnumerable<ContactItem> contactDetails, string bookingToReschedule, string cancellationReason = null)
+    public async Task<BookingConfirmationResult> ConfirmProvisionalBooking(string bookingReference, IEnumerable<ContactItem> contactDetails, string bookingToReschedule)
     {
         var isRescheduleOperation = !string.IsNullOrEmpty(bookingToReschedule);
 
-        var result = !string.IsNullOrEmpty(cancellationReason) && Enum.TryParse<CancellationReason>(cancellationReason, ignoreCase: true, out var parsedReason)
-            ? await bookingDocumentStore.ConfirmProvisional(bookingReference, contactDetails, bookingToReschedule, parsedReason)
+        var result = isRescheduleOperation
+            ? await bookingDocumentStore.ConfirmProvisional(bookingReference, contactDetails, bookingToReschedule, CancellationReason.RescheduledByCitizen)
             : await bookingDocumentStore.ConfirmProvisional(bookingReference, contactDetails, bookingToReschedule);
 
         await SendConfirmNotification(bookingReference, result, isRescheduleOperation);

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBookingFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/ConfirmBookingFeatureSteps.cs
@@ -26,8 +26,7 @@ public abstract class ConfirmBookingFeatureSteps(string flag, bool enabled) : Bo
         var payload = new ConfirmBookingRequestPayload(
            contactDetails: [],
            relatedBookings: [],
-           bookingToReschedule: string.Empty,
-           null
+           bookingToReschedule: string.Empty
        );
         var jsonPayload = JsonSerializer.Serialize(payload);
         var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
@@ -42,8 +41,7 @@ public abstract class ConfirmBookingFeatureSteps(string flag, bool enabled) : Bo
         var payload = new ConfirmBookingRequestPayload(
             contactDetails: [],
             relatedBookings: new[] { relatedBookingsReference },
-            bookingToReschedule: "test-booking-to-reschedule",
-            null
+            bookingToReschedule: "test-booking-to-reschedule"
         );
         var jsonPayload = JsonSerializer.Serialize(payload);
         var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Reschedule.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Reschedule.feature
@@ -1,4 +1,4 @@
-﻿Feature: Appointment reschedule
+Feature: Appointment reschedule
 
     Scenario: Reschedule an appointment
         Given the site is configured for MYA
@@ -15,7 +15,7 @@
         And I confirm the rescheduled booking
         Then the rescheduled booking is no longer marked as provisional
         And  the original booking has been 'Cancelled'
-        And 'CancelledByCitizen' cancellation reason has been used
+        And 'RescheduledByCitizen' cancellation reason has been used
         
     Scenario: Cannot reschedule an appointment if the nhs number for both bookings does not match
         Given the site is configured for MYA

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/RescheduleFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/RescheduleFeatureSteps.cs
@@ -31,8 +31,7 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Booking
                         new { type = "email", value = "test@test.com" },
                         new { type = "phone", value = "07777777777" }
                     },
-                bookingToReschedule,
-                cancellationReason = CancellationReason.CancelledByCitizen.ToString()
+                bookingToReschedule
             };
             Response = await Http.PostAsJsonAsync(
                 $"http://localhost:7071/api/booking/{_reschduledBookingReference}/confirm", payload);

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/BaseCreateAvailabilityFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CreateAvailability/BaseCreateAvailabilityFeatureSteps.cs
@@ -149,8 +149,7 @@ public abstract class BaseCreateAvailabilityFeatureSteps(string flag, bool enabl
         var payload = new ConfirmBookingRequestPayload(
             contactDetails: [],
             relatedBookings: [],
-            "",
-            null
+            ""
         );
         
         _response = await Http.PostAsJsonAsync($"http://localhost:7071/api/booking/{customId}/confirm", payload);

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/ConfirmProvisionalBookingFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/ConfirmProvisionalBookingFunctionTests.cs
@@ -36,30 +36,30 @@ public class ConfirmProvisionalBookingFunctionTests
     public async Task RunAsync_CallsConfirmProvisionalBooking_WhenJointBookingsDisabled(params string[] relatedBookings)
     {
         _featureToggleHelper.Setup(x => x.IsFeatureEnabled(It.Is<string>(p => p == "JointBookings"))).ReturnsAsync(false);
-        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>(), It.IsAny<string>()))
+        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>()))
             .ReturnsAsync(BookingConfirmationResult.Success);
 
         var request = CreateRequest(relatedBookings);
 
         await _sut.RunAsync(request);
         _featureToggleHelper.Verify(x => x.IsFeatureEnabled(It.Is<string>(p => p == "JointBookings")), Times.Once);
-        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>(), It.IsAny<string>()));
-        _bookingService.Verify(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>()));
+        _bookingService.Verify(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>()), Times.Once);
     }
 
     [Fact]
     public async Task RunAsync_CallsConfirmProvisionalBooking_WhenNoChildBookings()
     {
         _featureToggleHelper.Setup(x => x.IsFeatureEnabled(It.Is<string>(p => p == "JointBookings"))).ReturnsAsync(true);
-        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>(), It.IsAny<string>()))
+        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>()))
             .ReturnsAsync(BookingConfirmationResult.Success);
 
         var request = CreateRequest([]);
 
         await _sut.RunAsync(request);
         _featureToggleHelper.Verify(x => x.IsFeatureEnabled(It.Is<string>(p => p == "JointBookings")), Times.Once);
-        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>(), It.IsAny<string>()));
-        _bookingService.Verify(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>()));
+        _bookingService.Verify(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>()), Times.Once);
     }
 
     [Theory]
@@ -74,7 +74,7 @@ public class ConfirmProvisionalBookingFunctionTests
 
         await _sut.RunAsync(request);
         _featureToggleHelper.Verify(x => x.IsFeatureEnabled(It.Is<string>(p => p == "JointBookings")), Times.Once);
-        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>(), It.IsAny<string>()));
+        _bookingService.Setup(x => x.ConfirmProvisionalBooking(It.IsAny<string>(), It.IsAny<IEnumerable<ContactItem>>(), It.IsAny<string>()));
         _bookingService.Verify(x => x.ConfirmProvisionalBookings(It.IsAny<string[]>(), It.IsAny<IEnumerable<ContactItem>>()), Times.Once);
     }
 

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/ConfirmBookingRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/ConfirmBookingRequestValidatorTests.cs
@@ -12,7 +12,7 @@ public class ConfirmBookingRequestValidatorTests
     [Fact]
     public void Validate_ReturnError_WhenReferenceIsBlank()
     {
-        var testRequest = new ConfirmBookingRequest(string.Empty, [new ContactItem { Type = ContactItemType.Email, Value = "test@tempuri.org" }], null, string.Empty, null);
+        var testRequest = new ConfirmBookingRequest(string.Empty, [new ContactItem { Type = ContactItemType.Email, Value = "test@tempuri.org" }], null, string.Empty);
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -22,7 +22,7 @@ public class ConfirmBookingRequestValidatorTests
     [Fact]
     public void Validate_ReturnsSuccess_WhenRequestIsValid()
     {
-        var testRequest = new ConfirmBookingRequest("my-ref", [new ContactItem{Type = ContactItemType.Email, Value = "test@tempuri.org"}], null, string.Empty, null);
+        var testRequest = new ConfirmBookingRequest("my-ref", [new ContactItem{Type = ContactItemType.Email, Value = "test@tempuri.org"}], null, string.Empty);
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeTrue();
         result.Errors.Should().HaveCount(0);


### PR DESCRIPTION
### (cherry picked from commit f01867ace4dd41ec4fa5dab3a29e9c72c794e735)

# Description

When rescheduling an appointment, the cancellation reason is not needed in the payload as we should automatically use rescheduled by citizen. This PR adds that into the enum and updates the confirm provisional booking endpoint when rescheduling an appointment

<img width="464" height="640" alt="image"
src="https://github.com/user-attachments/assets/e14c8b69-17e2-4257-a1d6-5171ede7f17c" />

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests