### PR TITLE
Appt 1210 - Site Status front end

### DIFF
--- a/data/CosmosDbSeeder/items/local/core_data/site_ABC02.json
+++ b/data/CosmosDbSeeder/items/local/core_data/site_ABC02.json
@@ -49,5 +49,6 @@
       "value": "false"
     }
   ],
-  "informationForCitizens": ""
+  "informationForCitizens": "",
+  "status": "Online"
 }

--- a/src/api/Nhs.Appointments.Persistance/SiteStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/SiteStore.cs
@@ -169,7 +169,6 @@ public class SiteStore(ITypedDocumentCosmosStore<SiteDocument> cosmosStore) : IS
         PatchOperation[] patchOperations = [ patchOperation ];
 
         await cosmosStore.PatchDocument(documentType, siteId, patchOperations);
-
         return new OperationResult(true);
     }
 }

--- a/src/client/src/app/lib/components/nhsuk-frontend/card.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/card.tsx
@@ -29,15 +29,25 @@ const Card = ({
       className={`nhsuk-card nhsuk-card--${type} ${href ? 'nhsuk-card--clickable' : ''}`}
     >
       <div className={`nhsuk-card__content nhsuk-card__content--${type}`}>
-        <h2 className="nhsuk-card__heading nhsuk-heading-m">
-          {href ? (
-            <Link className="nhsuk-card__link" href={href}>
-              {title}
+        <div className="nhsuk-summary-card__title-wrapper">
+          <h2 className="nhsuk-card__heading nhsuk-heading-m">
+            {href ? (
+              <Link className="nhsuk-card__link" href={href}>
+                {title}
+              </Link>
+            ) : (
+              title
+            )}
+          </h2>
+          <div className="nhsuk-summary-card__actions">
+            <Link className="nhsuk-link" href="/">
+              Test
             </Link>
-          ) : (
-            title
-          )}
-        </h2>
+            <Link className="nhsuk-link" href="/">
+              Test 2
+            </Link>
+          </div>
+        </div>
 
         {description ? (
           <p className="nhsuk-card__description">{description}</p>

--- a/src/client/src/app/lib/components/nhsuk-frontend/card.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/card.tsx
@@ -10,6 +10,7 @@ type Props = {
   description?: string;
   href?: string;
   children?: ReactNode;
+  actionLinks?: ReactNode;
 };
 
 /**
@@ -23,13 +24,14 @@ const Card = ({
   description,
   href,
   children,
+  actionLinks,
 }: Props) => {
   return (
     <div
       className={`nhsuk-card nhsuk-card--${type} ${href ? 'nhsuk-card--clickable' : ''}`}
     >
       <div className={`nhsuk-card__content nhsuk-card__content--${type}`}>
-        <div className="nhsuk-summary-card__title-wrapper">
+        <div className="card-title-wrapper">
           <h2 className="nhsuk-card__heading nhsuk-heading-m">
             {href ? (
               <Link className="nhsuk-card__link" href={href}>
@@ -39,14 +41,9 @@ const Card = ({
               title
             )}
           </h2>
-          <div className="nhsuk-summary-card__actions">
-            <Link className="nhsuk-link" href="/">
-              Test
-            </Link>
-            <Link className="nhsuk-link" href="/">
-              Test 2
-            </Link>
-          </div>
+          {actionLinks ? (
+            <div className="card-action-link">{actionLinks}</div>
+          ) : null}
         </div>
 
         {description ? (

--- a/src/client/src/app/lib/components/nhsuk-frontend/summary-list.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/summary-list.tsx
@@ -16,6 +16,11 @@ export type SummaryListItem = {
   title: string;
   value?: string | string[];
   action?: LinkActionProps | OnClickActionProps;
+  tag?: Tag;
+};
+
+type Tag = {
+  colour: string;
 };
 
 type Props = {
@@ -47,7 +52,13 @@ const SummaryList = ({ items, borders = true }: Props) => {
             </dt>
             {typeof item.value === 'string' ? (
               <dd className="nhsuk-summary-list__value" aria-label={item.value}>
-                {item.value}
+                {item.tag !== undefined ? (
+                  <span className={`nhsuk-tag nhsuk-tag--${item.tag?.colour}`}>
+                    {item.value}
+                  </span>
+                ) : (
+                  item.value
+                )}
               </dd>
             ) : (
               <dd

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -585,5 +585,13 @@ export const updateSiteStatus = async (site: string, status: SiteStatus) => {
     JSON.stringify(payload),
   );
 
-  return handleEmptyResponse(response);
+  const notificationType = 'ams-notification';
+  const notificationMessage =
+    status === 'Online'
+      ? 'The site is now online and is available for appointments.'
+      : 'The site is now offline and will not be available for appointments.';
+  await raiseNotification(notificationType, notificationMessage);
+
+  handleEmptyResponse(response);
+  revalidatePath(`/site/${site}/details`);
 };

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -27,6 +27,8 @@ import {
   BookingStatus,
   UserIdentityStatus,
   WeekSummaryV2,
+  SiteStatus,
+  UpdateSiteStatusRequest,
 } from '@types';
 import { appointmentsApi } from '@services/api/appointmentsApi';
 import { ApiResponse, ClinicalService } from '@types';
@@ -566,6 +568,20 @@ export const cancelSession = async (
 
   const response = await appointmentsApi.post(
     'session/cancel',
+    JSON.stringify(payload),
+  );
+
+  return handleEmptyResponse(response);
+};
+
+export const updateSiteStatus = async (site: string, status: SiteStatus) => {
+  const payload: UpdateSiteStatusRequest = {
+    site,
+    status,
+  };
+
+  const response = await appointmentsApi.post(
+    'site-status',
     JSON.stringify(payload),
   );
 

--- a/src/client/src/app/lib/services/siteService.ts
+++ b/src/client/src/app/lib/services/siteService.ts
@@ -35,21 +35,32 @@ export const mapSiteOverviewSummaryData = (
   return { items, border: false };
 };
 
-export const mapCoreSiteSummaryData = (site: Site) => {
+export const mapCoreSiteSummaryData = (
+  site: Site,
+  siteStatusEnabled: boolean,
+) => {
   if (!site) {
     return undefined;
   }
 
-  const items: SummaryListItem[] = [
-    {
-      title: 'Name',
-      value: site.name,
-    },
-    {
-      title: 'Address',
-      value: site.address.match(/[^,]+,|[^,]+$/g) || [], // Match each word followed by a comma, or the last word without a comma
-    },
-  ];
+  const items: SummaryListItem[] = [];
+
+  if (siteStatusEnabled && site.status) {
+    items.push({
+      title: 'Status',
+      value: site.status?.toString(),
+      tag: { colour: site.status === 'Online' ? 'green' : 'red' },
+    });
+  }
+
+  items.push({
+    title: 'Name',
+    value: site.name,
+  });
+  items.push({
+    title: 'Address',
+    value: site.address.match(/[^,]+,|[^,]+$/g) || [], // Match each word followed by a comma, or the last word without a comma
+  });
 
   if (site.location.type === 'Point') {
     items.push({

--- a/src/client/src/app/lib/services/siteService.ts
+++ b/src/client/src/app/lib/services/siteService.ts
@@ -45,11 +45,18 @@ export const mapCoreSiteSummaryData = (
 
   const items: SummaryListItem[] = [];
 
-  if (siteStatusEnabled && site.status) {
+  if (siteStatusEnabled) {
     items.push({
       title: 'Status',
-      value: site.status?.toString(),
-      tag: { colour: site.status === 'Online' ? 'green' : 'red' },
+      value: site.status?.toString() ?? 'Online',
+      tag: {
+        colour:
+          site.status === 'Online' ||
+          site.status === null ||
+          site.status === undefined
+            ? 'green'
+            : 'red',
+      },
     });
   }
 

--- a/src/client/src/app/lib/services/siteService.ts
+++ b/src/client/src/app/lib/services/siteService.ts
@@ -4,12 +4,13 @@ import { Site, WellKnownOdsEntry } from '@types';
 export const mapSiteOverviewSummaryData = (
   site: Site,
   wellKnownOdsCodeEntries: WellKnownOdsEntry[],
+  siteStatusEnabled: boolean,
 ) => {
   if (!site) {
     return undefined;
   }
 
-  const items: SummaryListItem[] = [
+  let items: SummaryListItem[] = [
     {
       title: 'Address',
       value: site.address.match(/[^,]+,|[^,]+$/g) || [], // Match each word followed by a comma, or the last word without a comma
@@ -32,6 +33,10 @@ export const mapSiteOverviewSummaryData = (
     },
   ];
 
+  if (siteStatusEnabled) {
+    items = [siteStatusSummaryItem(site), ...items];
+  }
+
   return { items, border: false };
 };
 
@@ -43,31 +48,16 @@ export const mapCoreSiteSummaryData = (
     return undefined;
   }
 
-  const items: SummaryListItem[] = [];
-
-  if (siteStatusEnabled) {
-    items.push({
-      title: 'Status',
-      value: site.status?.toString() ?? 'Online',
-      tag: {
-        colour:
-          site.status === 'Online' ||
-          site.status === null ||
-          site.status === undefined
-            ? 'green'
-            : 'red',
-      },
-    });
-  }
-
-  items.push({
-    title: 'Name',
-    value: site.name,
-  });
-  items.push({
-    title: 'Address',
-    value: site.address.match(/[^,]+,|[^,]+$/g) || [], // Match each word followed by a comma, or the last word without a comma
-  });
+  let items: SummaryListItem[] = [
+    {
+      title: 'Name',
+      value: site.name,
+    },
+    {
+      title: 'Address',
+      value: site.address.match(/[^,]+,|[^,]+$/g) || [], // Match each word followed by a comma, or the last word without a comma
+    },
+  ];
 
   if (site.location.type === 'Point') {
     items.push({
@@ -81,6 +71,10 @@ export const mapCoreSiteSummaryData = (
     });
 
     items.push({ title: 'Phone Number', value: site.phoneNumber });
+  }
+
+  if (siteStatusEnabled) {
+    items = [siteStatusSummaryItem(site), ...items];
   }
 
   return { items, border: false };
@@ -113,4 +107,19 @@ export const mapSiteReferenceSummaryData = (
   ];
 
   return { items, border: false };
+};
+
+const siteStatusSummaryItem = (site: Site) => {
+  return {
+    title: 'Status',
+    value: site.status?.toString() ?? 'Online',
+    tag: {
+      colour:
+        site.status === 'Online' ||
+        site.status === null ||
+        site.status === undefined
+          ? 'green'
+          : 'red',
+    },
+  };
 };

--- a/src/client/src/app/lib/types/index.tsx
+++ b/src/client/src/app/lib/types/index.tsx
@@ -160,7 +160,7 @@ type Site = {
   location: Location;
   accessibilities: Accessibility[];
   informationForCitizens: string;
-  site: SiteStatus | null;
+  status: SiteStatus | null;
 };
 
 type Location = {

--- a/src/client/src/app/lib/types/index.tsx
+++ b/src/client/src/app/lib/types/index.tsx
@@ -160,6 +160,7 @@ type Site = {
   location: Location;
   accessibilities: Accessibility[];
   informationForCitizens: string;
+  site: SiteStatus | null;
 };
 
 type Location = {
@@ -377,6 +378,13 @@ const clinicalServices: ClinicalService[] = [
   { label: 'RSV Adult', value: 'RSV:Adult' },
 ];
 
+type SiteStatus = 'Online' | 'Offline';
+
+type UpdateSiteStatusRequest = {
+  site: string;
+  status: SiteStatus;
+};
+
 export type {
   ApplyAvailabilityTemplateRequest,
   ApiErrorResponse,
@@ -429,6 +437,8 @@ export type {
   WeekSummaryV2,
   DaySummaryV2,
   ClinicalService,
+  SiteStatus,
+  UpdateSiteStatusRequest,
 };
 
 export { MyaError, UnauthorizedError, daysOfTheWeek, clinicalServices };

--- a/src/client/src/app/lib/types/index.tsx
+++ b/src/client/src/app/lib/types/index.tsx
@@ -160,7 +160,7 @@ type Site = {
   location: Location;
   accessibilities: Accessibility[];
   informationForCitizens: string;
-  status: SiteStatus | null;
+  status?: SiteStatus | null;
 };
 
 type Location = {

--- a/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.test.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.test.tsx
@@ -1,0 +1,60 @@
+import { useRouter } from 'next/navigation';
+import EditSiteStatusForm from './edit-site-status-form';
+import { mockOfflineSite, mockSite } from '@testing/data';
+import { screen } from '@testing-library/dom';
+import * as appointmentsService from '@services/appointmentsService';
+import render from '@testing/render';
+import { UserEvent } from '@testing-library/user-event';
+
+jest.mock('@services/appointmentsService');
+
+jest.mock('next/navigation');
+const mockUseRouter = useRouter as jest.Mock;
+const mockReplace = jest.fn();
+
+const mockUpdateSiteStatus = jest.spyOn(
+  appointmentsService,
+  'updateSiteStatus',
+);
+
+let user: UserEvent;
+
+describe('Edit Site Status Form', () => {
+  beforeEach(() => {
+    mockUseRouter.mockReturnValue({
+      replace: mockReplace,
+    });
+  });
+
+  it('renders', async () => {
+    render(<EditSiteStatusForm site={mockSite} />);
+
+    expect(
+      screen.getByRole('group', { name: 'What do you want to do?' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', { name: 'Take site offline' }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole('radio', { name: 'Keep site online' }),
+    ).toBeVisible();
+  });
+
+  it('submits the form with the correct value', async () => {
+    const renderResult = render(<EditSiteStatusForm site={mockOfflineSite} />);
+    user = renderResult.user;
+
+    const onlineRadio = screen.getByRole('radio', { name: 'Make site online' });
+    await user.click(onlineRadio);
+
+    const saveButton = screen.getByRole('button', {
+      name: 'Save and continue',
+    });
+    await user.click(saveButton);
+
+    expect(mockUpdateSiteStatus).toHaveBeenCalledWith(
+      mockOfflineSite.id,
+      'Online',
+    );
+  });
+});

--- a/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.tsx
@@ -1,0 +1,78 @@
+import {
+  Button,
+  FormGroup,
+  Radio,
+  RadioGroup,
+  SmallSpinnerWithText,
+} from '@components/nhsuk-frontend';
+import { updateSiteStatus } from '@services/appointmentsService';
+import { Site, SiteStatus } from '@types';
+import { useRouter } from 'next/router';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+type FormFields = {
+  siteStatus: SiteStatus;
+};
+
+const EditSiteStatusForm = ({ site }: { site: Site }) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting, isSubmitSuccessful, errors },
+  } = useForm<FormFields>({
+    defaultValues: {
+      siteStatus: site.status ?? 'Online',
+    },
+  });
+
+  const { replace } = useRouter();
+
+  const onlineLabel =
+    site.status === 'Online' || undefined
+      ? 'Keep site online'
+      : 'Make site online';
+  const offlineLabel =
+    site.status === 'Offline' ? 'Keep site offline' : 'Take site offline';
+
+  const submitForm: SubmitHandler<FormFields> = async (form: FormFields) => {
+    await updateSiteStatus(site.id, form.siteStatus);
+
+    replace(`/site/${site.id}/details`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submitForm)}>
+      <FormGroup
+        legend="What do you want to do?"
+        error={errors.siteStatus?.message}
+      >
+        <RadioGroup>
+          <Radio
+            label={onlineLabel}
+            id="site-status-online"
+            value="Online"
+            {...register('siteStatus', {
+              required: { value: true, message: 'Select an option' },
+            })}
+          />
+          <Radio
+            label={offlineLabel}
+            id="site-status-offline"
+            value="Offline"
+            {...register('siteStatus', {
+              required: { value: true, message: 'Select an option' },
+            })}
+          />
+        </RadioGroup>
+      </FormGroup>
+
+      {isSubmitting || isSubmitSuccessful ? (
+        <SmallSpinnerWithText text="Working..." />
+      ) : (
+        <Button type="submit">Save and continue</Button>
+      )}
+    </form>
+  );
+};
+
+export default EditSiteStatusForm;

--- a/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.tsx
@@ -1,13 +1,15 @@
+'use client';
 import {
   Button,
   FormGroup,
+  InsetText,
   Radio,
   RadioGroup,
   SmallSpinnerWithText,
 } from '@components/nhsuk-frontend';
 import { updateSiteStatus } from '@services/appointmentsService';
 import { Site, SiteStatus } from '@types';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
 type FormFields = {
@@ -64,6 +66,13 @@ const EditSiteStatusForm = ({ site }: { site: Site }) => {
             })}
           />
         </RadioGroup>
+        <InsetText>
+          <p>
+            The change will take effect immediately. Taking your site offline
+            will mean patients can no longer book appointments until the site is
+            online again.
+          </p>
+        </InsetText>
       </FormGroup>
 
       {isSubmitting || isSubmitSuccessful ? (

--- a/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-page.test.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-page.test.tsx
@@ -1,0 +1,72 @@
+import { fetchSite } from '@services/appointmentsService';
+import { mockOfflineSite, mockSite } from '@testing/data';
+import { Site } from '@types';
+import { EditSiteStatusPage } from './edit-site-status-page';
+import { render, screen } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { verifySummaryListItem } from '@components/nhsuk-frontend/summary-list.test';
+
+jest.mock('next/navigation');
+const mockUseRouter = useRouter as jest.Mock;
+const mockPush = jest.fn();
+
+jest.mock('@services/appointmentsService');
+const fetchSiteMock = fetchSite as jest.Mock<Promise<Site>>;
+
+describe('Edit Site Status Page', () => {
+  beforeEach(() => {
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+    });
+    fetchSiteMock.mockResolvedValue(mockSite);
+  });
+
+  it('renders', async () => {
+    const jsx = await EditSiteStatusPage({
+      siteId: mockSite.id,
+    });
+    render(jsx);
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Site Alpha Manage site visibility',
+      }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Save and continue' }),
+    ).toBeInTheDocument();
+  });
+
+  it('displays the correct status and radio button labels for online site', async () => {
+    const jsx = await EditSiteStatusPage({
+      siteId: mockSite.id,
+    });
+    render(jsx);
+
+    verifySummaryListItem('Current site status', 'Online');
+
+    expect(
+      screen.getByRole('radio', { name: 'Take site offline' }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole('radio', { name: 'Keep site online' }),
+    ).toBeVisible();
+  });
+
+  it('displays the correct status and radio button labels for offline site', async () => {
+    fetchSiteMock.mockResolvedValue(mockOfflineSite);
+    const jsx = await EditSiteStatusPage({
+      siteId: mockOfflineSite.id,
+    });
+    render(jsx);
+
+    verifySummaryListItem('Current site status', 'Offline');
+
+    expect(
+      screen.getByRole('radio', { name: 'Make site online' }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole('radio', { name: 'Keep site offline' }),
+    ).toBeVisible();
+  });
+});

--- a/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-page.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-page.tsx
@@ -1,0 +1,17 @@
+import NhsHeading from '@components/nhs-heading';
+import { fetchSite } from '@services/appointmentsService';
+
+type Props = {
+  siteId: string;
+};
+
+export const EditSiteStatusPage = async ({ siteId }: Props) => {
+  const siteDetails = await fetchSite(siteId);
+
+  return (
+    <>
+      <NhsHeading title="Manage site visibility" caption={siteDetails.name} />
+      <span>Hello world!</span>
+    </>
+  );
+};

--- a/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-page.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-page.tsx
@@ -1,5 +1,7 @@
 import NhsHeading from '@components/nhs-heading';
 import { fetchSite } from '@services/appointmentsService';
+import EditSiteStatusForm from './edit-site-status-form';
+import { SummaryList, SummaryListItem } from '@components/nhsuk-frontend';
 
 type Props = {
   siteId: string;
@@ -7,11 +9,28 @@ type Props = {
 
 export const EditSiteStatusPage = async ({ siteId }: Props) => {
   const siteDetails = await fetchSite(siteId);
+  const siteStatus = siteDetails.status;
+
+  const summaryList: SummaryListItem[] = [
+    {
+      title: 'Status',
+      value: siteDetails.status?.toString() ?? 'Online',
+      tag: {
+        colour:
+          siteStatus === 'Online' ||
+          siteStatus === null ||
+          siteStatus === undefined
+            ? 'green'
+            : 'red',
+      },
+    },
+  ];
 
   return (
     <>
       <NhsHeading title="Manage site visibility" caption={siteDetails.name} />
-      <span>Hello world!</span>
+      <SummaryList items={summaryList} />
+      <EditSiteStatusForm site={siteDetails} />
     </>
   );
 };

--- a/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-page.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-page.tsx
@@ -13,7 +13,7 @@ export const EditSiteStatusPage = async ({ siteId }: Props) => {
 
   const summaryList: SummaryListItem[] = [
     {
-      title: 'Status',
+      title: 'Current site status',
       value: siteDetails.status?.toString() ?? 'Online',
       tag: {
         colour:

--- a/src/client/src/app/site/[site]/details/edit-site-status/page.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/page.tsx
@@ -1,6 +1,9 @@
 import NhsPage from '@components/nhs-page';
 import { NavigationByHrefProps } from '@components/nhsuk-frontend/back-link';
-import { assertPermission } from '@services/appointmentsService';
+import {
+  assertFeatureEnabled,
+  assertPermission,
+} from '@services/appointmentsService';
 import { EditSiteStatusPage } from './edit-site-status-page';
 
 export type PageProps = {
@@ -12,8 +15,8 @@ export type PageProps = {
 const Page = async ({ params }: PageProps) => {
   const { site: siteFromPath } = { ...(await params) };
 
-  // TODO: Make sure navigation doesn't occur if feature is disabled
   await assertPermission(siteFromPath, 'site:manage');
+  await assertFeatureEnabled('SiteStatus');
 
   const backLink: NavigationByHrefProps = {
     renderingStrategy: 'server',

--- a/src/client/src/app/site/[site]/details/edit-site-status/page.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/page.tsx
@@ -1,0 +1,31 @@
+import NhsPage from '@components/nhs-page';
+import { NavigationByHrefProps } from '@components/nhsuk-frontend/back-link';
+import { assertPermission } from '@services/appointmentsService';
+import { EditSiteStatusPage } from './edit-site-status-page';
+
+export type PageProps = {
+  params: Promise<{
+    site: string;
+  }>;
+};
+
+const Page = async ({ params }: PageProps) => {
+  const { site: siteFromPath } = { ...(await params) };
+
+  // TODO: Make sure navigation doesn't occur if feature is disabled
+  await assertPermission(siteFromPath, 'site:manage');
+
+  const backLink: NavigationByHrefProps = {
+    renderingStrategy: 'server',
+    href: `/site/${siteFromPath}/details`,
+    text: 'Back',
+  };
+
+  return (
+    <NhsPage backLink={backLink} title="" originPage="edit">
+      <EditSiteStatusPage siteId={siteFromPath} />
+    </NhsPage>
+  );
+};
+
+export default Page;

--- a/src/client/src/app/site/[site]/details/site-details-page.tsx
+++ b/src/client/src/app/site/[site]/details/site-details-page.tsx
@@ -1,6 +1,7 @@
 import { Card, SummaryList } from '@components/nhsuk-frontend';
 import {
   fetchAccessibilityDefinitions,
+  fetchFeatureFlag,
   fetchSite,
 } from '@services/appointmentsService';
 import {
@@ -21,16 +22,17 @@ const SiteDetailsPage = async ({
   permissions,
   wellKnownOdsEntries,
 }: Props) => {
-  const [accessibilityDefinitions, site] = await Promise.all([
+  const [accessibilityDefinitions, site, siteStatus] = await Promise.all([
     fetchAccessibilityDefinitions(),
     fetchSite(siteId),
+    fetchFeatureFlag('SiteStatus'),
   ]);
 
   const siteReferenceSummaryData = mapSiteReferenceSummaryData(
     site,
     wellKnownOdsEntries,
   );
-  const siteCoreSummary = mapCoreSiteSummaryData(site);
+  const siteCoreSummary = mapCoreSiteSummaryData(site, siteStatus.enabled);
 
   return (
     <>

--- a/src/client/src/app/site/[site]/details/site-details-page.tsx
+++ b/src/client/src/app/site/[site]/details/site-details-page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@services/siteService';
 import { WellKnownOdsEntry } from '@types';
 import Link from 'next/link';
+import { ReactNode } from 'react';
 
 type Props = {
   siteId: string;
@@ -34,44 +35,75 @@ const SiteDetailsPage = async ({
   );
   const siteCoreSummary = mapCoreSiteSummaryData(site, siteStatus.enabled);
 
+  const siteDetailsActionLinks: ReactNode = permissions.includes(
+    'site:manage',
+  ) ? (
+    <>
+      <Link
+        href={`/site/${site.id}/details/edit-details`}
+        className="nhsuk-link"
+      >
+        Edit site details
+      </Link>
+      {siteStatus.enabled ? (
+        <>
+          &nbsp;|&nbsp;
+          <Link
+            href={`/site/${site.id}/details/edit-site-status`}
+            className="nhsuk-link"
+          >
+            Change site status
+          </Link>
+        </>
+      ) : null}
+    </>
+  ) : null;
+
+  const siteReferenceDetailsLink: ReactNode = permissions.includes(
+    'site:manage:admin',
+  ) ? (
+    <Link
+      href={`/site/${site.id}/details/edit-reference-details`}
+      className="nhsuk-link"
+    >
+      Edit site reference details
+    </Link>
+  ) : null;
+
+  const accessNeedsLink: ReactNode = permissions.includes('site:manage') ? (
+    <Link
+      href={`/site/${site.id}/details/edit-accessibilities`}
+      className="nhsuk-link"
+    >
+      Edit access needs
+    </Link>
+  ) : null;
+
+  const informationForCitizenLink: ReactNode = permissions.includes(
+    'site:manage',
+  ) ? (
+    <Link
+      href={`/site/${site.id}/details/edit-information-for-citizens`}
+      className="nhsuk-link"
+    >
+      Edit information for citizens
+    </Link>
+  ) : null;
+
   return (
     <>
-      <Card title="Site details">
+      <Card title="Site details" actionLinks={siteDetailsActionLinks}>
         {siteCoreSummary && <SummaryList {...siteCoreSummary} />}
-        {permissions.includes('site:manage') ? (
-          <>
-            <Link
-              href={`/site/${site.id}/details/edit-details`}
-              className="nhsuk-link"
-            >
-              Edit site details
-            </Link>
-            |
-            {siteStatus.enabled ? (
-              <Link
-                href={`/site/${site.id}/details/edit-site-status`}
-                className="nhsuk-link"
-              >
-                Edit Site Status
-              </Link>
-            ) : null}
-          </>
-        ) : null}
       </Card>
-      <Card title="Site reference details">
+      <Card
+        title="Site reference details"
+        actionLinks={siteReferenceDetailsLink}
+      >
         {siteReferenceSummaryData && (
           <SummaryList {...siteReferenceSummaryData}></SummaryList>
         )}
-        {permissions.includes('site:manage:admin') ? (
-          <Link
-            href={`/site/${site.id}/details/edit-reference-details`}
-            className="nhsuk-link"
-          >
-            Edit site reference details
-          </Link>
-        ) : null}
       </Card>
-      <Card title="Access needs">
+      <Card title="Access needs" actionLinks={accessNeedsLink}>
         <SummaryList
           borders={true}
           items={accessibilityDefinitions.map(definition => {
@@ -85,29 +117,16 @@ const SiteDetailsPage = async ({
             };
           })}
         />
-        {permissions.includes('site:manage') ? (
-          <Link
-            href={`/site/${site.id}/details/edit-accessibilities`}
-            className="nhsuk-link"
-          >
-            Edit access needs
-          </Link>
-        ) : null}
       </Card>
-      <Card title="Information for citizens">
+      <Card
+        title="Information for citizens"
+        actionLinks={informationForCitizenLink}
+      >
         {site.informationForCitizens ? (
           <p>{site.informationForCitizens}</p>
         ) : (
           <p>Information for people visiting the site</p>
         )}
-        {permissions.includes('site:manage') ? (
-          <Link
-            href={`/site/${site.id}/details/edit-information-for-citizens`}
-            className="nhsuk-link"
-          >
-            Edit information for citizens
-          </Link>
-        ) : null}
       </Card>
     </>
   );

--- a/src/client/src/app/site/[site]/details/site-details-page.tsx
+++ b/src/client/src/app/site/[site]/details/site-details-page.tsx
@@ -52,12 +52,21 @@ const SiteDetailsPage = async ({
       <Card title="Site details">
         {siteCoreSummary && <SummaryList {...siteCoreSummary} />}
         {permissions.includes('site:manage') ? (
-          <Link
-            href={`/site/${site.id}/details/edit-details`}
-            className="nhsuk-link"
-          >
-            Edit site details
-          </Link>
+          <>
+            <Link
+              href={`/site/${site.id}/details/edit-details`}
+              className="nhsuk-link"
+            >
+              Edit site details
+            </Link>
+            |
+            <Link
+              href={`/site/${site.id}/details/edit-site-status`}
+              className="nhsuk-link"
+            >
+              Edit Site Status
+            </Link>
+          </>
         ) : null}
       </Card>
       <Card title="Access needs">

--- a/src/client/src/app/site/[site]/details/site-details-page.tsx
+++ b/src/client/src/app/site/[site]/details/site-details-page.tsx
@@ -36,19 +36,6 @@ const SiteDetailsPage = async ({
 
   return (
     <>
-      <Card title="Site reference details">
-        {siteReferenceSummaryData && (
-          <SummaryList {...siteReferenceSummaryData}></SummaryList>
-        )}
-        {permissions.includes('site:manage:admin') ? (
-          <Link
-            href={`/site/${site.id}/details/edit-reference-details`}
-            className="nhsuk-link"
-          >
-            Edit site reference details
-          </Link>
-        ) : null}
-      </Card>
       <Card title="Site details">
         {siteCoreSummary && <SummaryList {...siteCoreSummary} />}
         {permissions.includes('site:manage') ? (
@@ -60,13 +47,28 @@ const SiteDetailsPage = async ({
               Edit site details
             </Link>
             |
-            <Link
-              href={`/site/${site.id}/details/edit-site-status`}
-              className="nhsuk-link"
-            >
-              Edit Site Status
-            </Link>
+            {siteStatus.enabled ? (
+              <Link
+                href={`/site/${site.id}/details/edit-site-status`}
+                className="nhsuk-link"
+              >
+                Edit Site Status
+              </Link>
+            ) : null}
           </>
+        ) : null}
+      </Card>
+      <Card title="Site reference details">
+        {siteReferenceSummaryData && (
+          <SummaryList {...siteReferenceSummaryData}></SummaryList>
+        )}
+        {permissions.includes('site:manage:admin') ? (
+          <Link
+            href={`/site/${site.id}/details/edit-reference-details`}
+            className="nhsuk-link"
+          >
+            Edit site reference details
+          </Link>
         ) : null}
       </Card>
       <Card title="Access needs">

--- a/src/client/src/app/site/[site]/page.tsx
+++ b/src/client/src/app/site/[site]/page.tsx
@@ -33,12 +33,14 @@ const Page = async ({ params }: PageProps) => {
     sitePermissions,
     permissionsAtAnySite,
     siteSummaryEnabled,
+    siteStatusFeature,
   ] = await Promise.all([
     fetchSite(siteFromPath),
     fetchWellKnownOdsCodeEntries(),
     fetchPermissions(siteFromPath),
     fetchPermissions('*'),
     fetchFeatureFlag('SiteSummaryReport'),
+    fetchFeatureFlag('SiteStatus'),
   ]);
 
   return (
@@ -49,6 +51,7 @@ const Page = async ({ params }: PageProps) => {
         permissionsAtAnySite={permissionsAtAnySite}
         wellKnownOdsCodeEntries={wellKnownOdsCodeEntries}
         siteSummaryEnabled={siteSummaryEnabled.enabled}
+        siteStatusEnabled={siteStatusFeature.enabled}
       />
     </NhsPage>
   );

--- a/src/client/src/app/site/[site]/site-page.tsx
+++ b/src/client/src/app/site/[site]/site-page.tsx
@@ -8,6 +8,7 @@ interface SitePageProps {
   permissionsAtAnySite: string[];
   wellKnownOdsCodeEntries: WellKnownOdsEntry[];
   siteSummaryEnabled: boolean;
+  siteStatusEnabled: boolean;
 }
 
 export const SitePage = ({
@@ -16,6 +17,7 @@ export const SitePage = ({
   permissionsAtAnySite,
   wellKnownOdsCodeEntries,
   siteSummaryEnabled,
+  siteStatusEnabled,
 }: SitePageProps) => {
   const permissionsRelevantToCards = permissions.filter(
     p =>
@@ -30,6 +32,7 @@ export const SitePage = ({
   const overviewData = mapSiteOverviewSummaryData(
     site,
     wellKnownOdsCodeEntries,
+    siteStatusEnabled,
   );
 
   return (

--- a/src/client/src/app/sites/sites-page.test.tsx
+++ b/src/client/src/app/sites/sites-page.test.tsx
@@ -19,7 +19,7 @@ describe('Sites Page', () => {
     const rows = screen.getAllByRole('row');
     const dataRows = rows.slice(1);
 
-    expect(dataRows).toHaveLength(4);
+    expect(dataRows).toHaveLength(5);
 
     const firstRow = dataRows[0];
     expect(within(firstRow).getByText('Site Alpha')).toBeInTheDocument();

--- a/src/client/src/app/styles/global.css
+++ b/src/client/src/app/styles/global.css
@@ -310,3 +310,16 @@
   line-height: 1.71429;
   padding: 4px 12px;
 }
+
+.card-title-wrapper {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+  padding: 15px 0;
+}
+
+.card-action-link {
+  text-align: right;
+  font-size: 1.1875rem;
+  font-weight: 700;
+}

--- a/src/client/src/app/testing/data.ts
+++ b/src/client/src/app/testing/data.ts
@@ -121,6 +121,7 @@ const mockSites: Site[] = [
       { id: 'accessibility/attr_1', value: 'true' },
     ],
     informationForCitizens: 'Test information 1',
+    status: 'Online',
   },
   {
     id: '95e4ca69-da15-45f5-9ec7-6b2ea50f07c8',
@@ -139,6 +140,7 @@ const mockSites: Site[] = [
       { id: 'accessibility/attr_2', value: 'true' },
     ],
     informationForCitizens: 'Test information 2',
+    status: 'Online',
   },
   {
     id: 'd79bec60-8968-4101-b553-67dec04e1019',
@@ -157,6 +159,7 @@ const mockSites: Site[] = [
       { id: 'accessibility/attr_3', value: 'true' },
     ],
     informationForCitizens: 'Test information 3',
+    status: 'Online',
   },
   {
     id: '90a9c1f2-83d0-4c40-9c7c-080d91c56e79',
@@ -175,10 +178,31 @@ const mockSites: Site[] = [
       { id: 'accessibility/attr_4', value: 'true' },
     ],
     informationForCitizens: 'Test information 4',
+    status: 'Online',
+  },
+  {
+    id: '5b1f2f76-36b4-41af-8a9d-82d2ce2230a6',
+    name: 'Site Lima',
+    phoneNumber: '0118 999 88199 9119 725 3',
+    address: 'Lima Street, London',
+    odsCode: '1005',
+    integratedCareBoard: 'ICB5',
+    region: 'R5',
+    location: {
+      type: 'Point',
+      coordinates: [0.5646, 56.76457],
+    },
+    accessibilities: [
+      { id: 'site_details/info_for_citizen', value: 'Test information' },
+      { id: 'accessibility/attr_4', value: 'true' },
+    ],
+    informationForCitizens: 'Test information 5',
+    status: 'Offline',
   },
 ];
 
 const mockSite = mockSites[0];
+const mockOfflineSite = mockSites[4];
 
 const mockWellKnownOdsCodeEntries: WellKnownOdsEntry[] = [
   {
@@ -765,4 +789,5 @@ export {
   mockWellKnownOdsCodeEntries,
   getMockOktaUserAssignments,
   mockClinicalServices,
+  mockOfflineSite,
 };

--- a/src/client/testing/fixtures.ts
+++ b/src/client/testing/fixtures.ts
@@ -2,7 +2,7 @@
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 import { test as baseTest, request, TestInfo } from '@playwright/test';
-import { Site } from '@types';
+import { Site, SiteStatus } from '@types';
 
 export * from '@playwright/test';
 
@@ -12,7 +12,10 @@ import testSite2DataRaw from '../../../data/CosmosDbSeeder/items/local/core_data
 
 const testUsersData: UserSeedDataRaw[] = testUsersDataRaw;
 const testSite1Data: Site = testSite1DataRaw;
-const testSite2Data: Site = testSite2DataRaw;
+const testSite2Data: Site = {
+  ...testSite2DataRaw,
+  status: testSite2DataRaw.status as SiteStatus,
+};
 
 interface UserSeedDataRaw {
   Username: string;

--- a/src/client/testing/page-objects/change-site-details-pages/edit-site-status.ts
+++ b/src/client/testing/page-objects/change-site-details-pages/edit-site-status.ts
@@ -24,7 +24,7 @@ export default class EditSiteStatusPage extends RootPage {
     this.saveAndContinueButton = page.getByRole('button', {
       name: 'Save and continue',
     });
-    this.backLink = page.getByRole('link').filter({ hasText: 'Back' });
+    this.backLink = page.getByRole('link', { name: 'Back', exact: true });
     this.takeSiteOffline = page.getByRole('radio', {
       name: 'Take site offline',
     });

--- a/src/client/testing/page-objects/change-site-details-pages/edit-site-status.ts
+++ b/src/client/testing/page-objects/change-site-details-pages/edit-site-status.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test';
 import { RootPage } from '@testing-page-objects';
+import { expect } from '../../fixtures';
 
 export default class EditSiteStatusPage extends RootPage {
   readonly title: Locator;
@@ -36,5 +37,17 @@ export default class EditSiteStatusPage extends RootPage {
     this.keepSiteOffline = page.getByRole('link', {
       name: 'Keep site offline',
     });
+  }
+
+  async verifySummaryListItemContentValue(title: string, value: string) {
+    const listitem = this.page.getByRole('listitem', {
+      name: `${title} summary`,
+    });
+    await expect(listitem).toBeVisible();
+
+    await expect(listitem.getByRole('term')).toBeVisible();
+    await expect(listitem.getByRole('term')).toHaveText(title);
+    await expect(listitem.getByRole('definition')).toBeVisible();
+    await expect(listitem.getByRole('definition')).toHaveText(value);
   }
 }

--- a/src/client/testing/page-objects/change-site-details-pages/edit-site-status.ts
+++ b/src/client/testing/page-objects/change-site-details-pages/edit-site-status.ts
@@ -1,0 +1,21 @@
+import { Locator, Page } from '@playwright/test';
+import { RootPage } from '@testing-page-objects';
+
+export default class EditSiteStatusPage extends RootPage {
+  readonly title: Locator;
+  readonly saveAndContinueButton: Locator;
+  readonly backLink: Locator;
+  readonly siteStatusLabel = 'Current site status';
+
+  constructor(page: Page) {
+    super(page);
+
+    this.title = page.getByRole('heading', {
+      name: 'Manage Site Visibility',
+    });
+    this.saveAndContinueButton = page.getByRole('button', {
+      name: 'Save and continue',
+    });
+    this.backLink = page.getByRole('link').filter({ hasText: 'Back' });
+  }
+}

--- a/src/client/testing/page-objects/change-site-details-pages/edit-site-status.ts
+++ b/src/client/testing/page-objects/change-site-details-pages/edit-site-status.ts
@@ -5,6 +5,13 @@ export default class EditSiteStatusPage extends RootPage {
   readonly title: Locator;
   readonly saveAndContinueButton: Locator;
   readonly backLink: Locator;
+  // Site online radio labels
+  readonly takeSiteOffline: Locator;
+  readonly keepSiteOnline: Locator;
+  // Site offline radio labels
+  readonly makeSiteOnline: Locator;
+  readonly keepSiteOffline: Locator;
+
   readonly siteStatusLabel = 'Current site status';
 
   constructor(page: Page) {
@@ -17,5 +24,17 @@ export default class EditSiteStatusPage extends RootPage {
       name: 'Save and continue',
     });
     this.backLink = page.getByRole('link').filter({ hasText: 'Back' });
+    this.takeSiteOffline = page.getByRole('radio', {
+      name: 'Take site offline',
+    });
+    this.keepSiteOnline = page.getByRole('link', {
+      name: 'Keep site online',
+    });
+    this.makeSiteOnline = page.getByRole('link', {
+      name: 'Make site online',
+    });
+    this.keepSiteOffline = page.getByRole('link', {
+      name: 'Keep site offline',
+    });
   }
 }

--- a/src/client/testing/page-objects/change-site-details-pages/site-details.ts
+++ b/src/client/testing/page-objects/change-site-details-pages/site-details.ts
@@ -1,7 +1,7 @@
 import { expect } from '../../fixtures';
 import { type Locator, type Page } from '@playwright/test';
 import RootPage from '../root';
-import { Site } from '@types';
+import { Site, SiteStatus } from '@types';
 
 export default class SiteDetailsPage extends RootPage {
   readonly title: Locator;
@@ -10,6 +10,7 @@ export default class SiteDetailsPage extends RootPage {
   readonly editSiteReferenceDetailsButton: Locator;
   readonly editInformationCitizenButton: Locator;
   readonly closeNotificationBannerButton: Locator;
+  readonly changeSiteStatusButton: Locator;
   readonly headerMsg = 'Manage Site';
   readonly siteDetailsheaderMsg = 'Site details';
   readonly referenceDetailsheaderMsg = 'Site reference details';
@@ -24,6 +25,7 @@ export default class SiteDetailsPage extends RootPage {
   readonly odsCodeLabel = 'ODS code';
   readonly icbLabel = 'ICB';
   readonly regionLabel = 'Region';
+  readonly siteStatusLabel = 'Status';
 
   readonly siteDetails: Site;
 
@@ -35,6 +37,12 @@ export default class SiteDetailsPage extends RootPage {
 
   readonly referenceDetailsSuccessBanner =
     'You have successfully updated the reference details for the current site.';
+
+  readonly siteStatusOnlineSuccessBanner =
+    'The site is now online and is available for appointments.';
+
+  readonly siteStatusOfflineSuccessBanner =
+    'The site is now offline and will not be available for appointments.';
 
   constructor(page: Page, siteDetails: Site) {
     super(page);
@@ -55,6 +63,9 @@ export default class SiteDetailsPage extends RootPage {
     });
     this.editInformationCitizenButton = page.getByRole('link', {
       name: 'Edit information for citizens',
+    });
+    this.changeSiteStatusButton = page.getByRole('link', {
+      name: 'Change site status',
     });
 
     this.closeNotificationBannerButton = page.getByRole('button', {
@@ -108,12 +119,29 @@ export default class SiteDetailsPage extends RootPage {
     }
   }
 
+  async verifySiteStatusNotificationVisibility(
+    shown: boolean,
+    expectedStatus: SiteStatus,
+  ) {
+    const banner =
+      expectedStatus === 'Online'
+        ? this.page.getByText(`${this.siteStatusOnlineSuccessBanner}`)
+        : this.page.getByText(`${this.siteStatusOfflineSuccessBanner}`);
+
+    if (!shown) {
+      await expect(banner).not.toBeVisible();
+    } else {
+      await expect(banner).toBeVisible();
+    }
+  }
+
   async verifyCoreDetailsContent(
     name: string,
     address: string,
     long: string,
     lat: string,
     phoneNumber: string,
+    siteStatus?: string,
   ) {
     await this.verifySummaryListItemContentValue(this.siteNameLabel, name);
     await this.verifySummaryListItemContentValue(this.addressLabel, address);
@@ -123,6 +151,13 @@ export default class SiteDetailsPage extends RootPage {
       this.phoneNumberLabel,
       phoneNumber,
     );
+
+    if (siteStatus !== undefined) {
+      await this.verifySummaryListItemContentValue(
+        this.siteStatusLabel,
+        siteStatus,
+      );
+    }
   }
 
   async verifyReferenceDetailsContent(

--- a/src/client/testing/page-objects/view-availability-appointment-pages/month-view-availability-page.ts
+++ b/src/client/testing/page-objects/view-availability-appointment-pages/month-view-availability-page.ts
@@ -40,7 +40,7 @@ export default class MonthViewAvailabilityPage extends RootPage {
       .getByRole('heading', {
         name: weekOverview.header,
       })
-      .locator('..');
+      .locator('../..');
 
     const header = cardDiv.getByRole('heading', {
       name: weekOverview.header,

--- a/src/client/testing/page-objects/view-availability-appointment-pages/week-view-availability-page.ts
+++ b/src/client/testing/page-objects/view-availability-appointment-pages/week-view-availability-page.ts
@@ -49,7 +49,7 @@ export default class WeekViewAvailabilityPage extends RootPage {
       .getByRole('heading', {
         name: dayOverview.header,
       })
-      .locator('..');
+      .locator('../..');
 
     const header = cardDiv.getByRole('heading', {
       name: dayOverview.header,
@@ -178,7 +178,7 @@ export default class WeekViewAvailabilityPage extends RootPage {
       .getByRole('heading', {
         name: dayOverview.header,
       })
-      .locator('..');
+      .locator('../..');
 
     const sessionTable = cardDiv.getByRole('table');
 

--- a/src/client/testing/tests/availability/availability.spec.ts
+++ b/src/client/testing/tests/availability/availability.spec.ts
@@ -1447,7 +1447,7 @@ test.describe.configure({ mode: 'serial' });
           .getByRole('heading', {
             name: 'Wednesday 20 August',
           })
-          .locator('..');
+          .locator('../..');
 
         //select the third session (flu only)
         const fluSessionRow = (
@@ -1570,7 +1570,7 @@ test.describe.configure({ mode: 'serial' });
                   .getByRole('heading', {
                     name: daySession.dayCardHeader,
                   })
-                  .locator('..')
+                  .locator('../..')
                   .getByRole('link', {
                     name: 'Change',
                   });
@@ -1652,7 +1652,7 @@ test.describe.configure({ mode: 'serial' });
                   .getByRole('heading', {
                     name: daySession.dayCardHeader,
                   })
-                  .locator('..')
+                  .locator('../..')
                   .getByRole('link', {
                     name: 'Change',
                   });
@@ -1710,7 +1710,7 @@ test.describe.configure({ mode: 'serial' });
                   .getByRole('heading', {
                     name: daySession.dayCardHeader,
                   })
-                  .locator('..')
+                  .locator('../..')
                   .getByRole('link', {
                     name: 'Change',
                   });
@@ -1813,7 +1813,7 @@ test.describe.configure({ mode: 'serial' });
                   .getByRole('heading', {
                     name: daySession.dayCardHeader,
                   })
-                  .locator('..')
+                  .locator('../..')
                   .getByRole('link', {
                     name: 'View daily appointments',
                   });

--- a/src/client/testing/tests/change-site-details/edit-site-status.spec.ts
+++ b/src/client/testing/tests/change-site-details/edit-site-status.spec.ts
@@ -1,0 +1,75 @@
+import {
+  RootPage,
+  OAuthLoginPage,
+  SiteSelectionPage,
+  SitePage,
+  SiteDetailsPage,
+} from '@testing-page-objects';
+import { Site } from '@types';
+import EditSiteStatusPage from '../../page-objects/change-site-details-pages/edit-site-status';
+import { test, overrideFeatureFlag } from '../../fixtures';
+import { verifySummaryListItem } from '@components/nhsuk-frontend/summary-list.test';
+
+let rootPage: RootPage;
+let oAuthPage: OAuthLoginPage;
+let siteSelectionPage: SiteSelectionPage;
+let sitePage: SitePage;
+let siteStatusPage: EditSiteStatusPage;
+let siteDetailsPage: SiteDetailsPage;
+
+let site: Site;
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async () => {
+  await overrideFeatureFlag('SiteStatus', true);
+});
+
+test.afterAll(async () => {
+  await overrideFeatureFlag('SiteStatus', false);
+});
+
+test.beforeEach(async ({ page, getTestSite }) => {
+  site = getTestSite(2);
+  rootPage = new RootPage(page);
+  oAuthPage = new OAuthLoginPage(page);
+  siteSelectionPage = new SiteSelectionPage(page);
+  sitePage = new SitePage(page);
+  siteStatusPage = new EditSiteStatusPage(page);
+  siteDetailsPage = new SiteDetailsPage(page, site);
+
+  await rootPage.goto();
+  await rootPage.pageContentLogInButton.click();
+  await oAuthPage.signIn();
+  await siteSelectionPage.selectSite(site);
+  await sitePage.siteManagementCard.click();
+  await page.waitForURL(`**/site/${site.id}/details`);
+  await siteDetailsPage.changeSiteStatusButton.click();
+  await page.waitForURL(`**/site/${site.id}/details/edit-site-status`);
+});
+
+test('Clicking back mid-form does not save the changes', async ({ page }) => {
+  verifySummaryListItem(siteStatusPage.siteStatusLabel, 'Online');
+  await siteStatusPage.takeSiteOffline.click();
+  await siteStatusPage.backLink.click();
+
+  await page.waitForURL(`**/site/${site.id}/details`);
+  await siteDetailsPage.verifySiteStatusNotificationVisibility(
+    false,
+    site.status ?? 'Online',
+  );
+
+  await siteDetailsPage.changeSiteStatusButton.click();
+  await page.waitForURL(`**/site/${site.id}/details/edit-site-status`);
+
+  verifySummaryListItem(siteStatusPage.siteStatusLabel, 'Online');
+});
+
+test('Update site status', async ({ page }) => {
+  verifySummaryListItem(siteStatusPage.siteStatusLabel, 'Online');
+  await siteStatusPage.takeSiteOffline.click();
+  await siteStatusPage.saveAndContinueButton.click();
+
+  await page.waitForURL(`**/site/${site.id}/details`);
+  await siteDetailsPage.verifySiteStatusNotificationVisibility(true, 'Offline');
+});

--- a/src/client/testing/tests/change-site-details/edit-site-status.spec.ts
+++ b/src/client/testing/tests/change-site-details/edit-site-status.spec.ts
@@ -8,7 +8,6 @@ import {
 import { Site } from '@types';
 import EditSiteStatusPage from '../../page-objects/change-site-details-pages/edit-site-status';
 import { test, overrideFeatureFlag } from '../../fixtures';
-import { verifySummaryListItem } from '@components/nhsuk-frontend/summary-list.test';
 
 let rootPage: RootPage;
 let oAuthPage: OAuthLoginPage;
@@ -49,7 +48,10 @@ test.beforeEach(async ({ page, getTestSite }) => {
 });
 
 test('Clicking back mid-form does not save the changes', async ({ page }) => {
-  verifySummaryListItem(siteStatusPage.siteStatusLabel, 'Online');
+  await siteStatusPage.verifySummaryListItemContentValue(
+    siteStatusPage.siteStatusLabel,
+    'Online',
+  );
   await siteStatusPage.takeSiteOffline.click();
   await siteStatusPage.backLink.click();
 
@@ -62,11 +64,17 @@ test('Clicking back mid-form does not save the changes', async ({ page }) => {
   await siteDetailsPage.changeSiteStatusButton.click();
   await page.waitForURL(`**/site/${site.id}/details/edit-site-status`);
 
-  verifySummaryListItem(siteStatusPage.siteStatusLabel, 'Online');
+  await siteStatusPage.verifySummaryListItemContentValue(
+    siteStatusPage.siteStatusLabel,
+    'Online',
+  );
 });
 
 test('Update site status', async ({ page }) => {
-  verifySummaryListItem(siteStatusPage.siteStatusLabel, 'Online');
+  await siteStatusPage.verifySummaryListItemContentValue(
+    siteStatusPage.siteStatusLabel,
+    'Online',
+  );
   await siteStatusPage.takeSiteOffline.click();
   await siteStatusPage.saveAndContinueButton.click();
 

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs
@@ -149,7 +149,6 @@ public sealed class SiteSearchFeatureSteps : SiteManagementBaseFeatureSteps, IDi
         var searchRadiusNumber = row.Cells.ElementAt(1).Value;
         var longitude = row.Cells.ElementAt(2).Value;
         var latitude = row.Cells.ElementAt(3).Value;
-
         _response = await Http.GetAsync(
             $"http://localhost:7071/api/sites?long={longitude}&lat={latitude}&searchRadius={searchRadiusNumber}&maxRecords={maxRecords}&ignoreCache=true");
         _statusCode = _response.StatusCode;


### PR DESCRIPTION
# Description

- Displaying the site status on the front end (assuming the feature toggle is enabled)
- New site status page to update the status (also behind feature toggle & site manage permission)
- Raises a notification on success for either update (online -> offline / offline -> online)
- Unit tests
- E2e tests
- Slight re-design of the buttons on the site edit details page
- Re-order of the site edit details page so site details is now at the top

<img width="1116" height="613" alt="image" src="https://github.com/user-attachments/assets/432b74ae-7430-4e88-9cf4-963cb5c00b8c" />
<img width="689" height="714" alt="image" src="https://github.com/user-attachments/assets/3085f3ab-fa4a-43b3-832e-e8bed871afc3" />
<img width="1138" height="735" alt="image" src="https://github.com/user-attachments/assets/bab29e46-7ad3-48aa-9910-11dea4bc452e" />
<img width="1126" height="713" alt="image" src="https://github.com/user-attachments/assets/f23c1fa7-bba8-4a4b-8f3f-70064c79fd9b" />


Fixes # (issue)

# Checklist:

- [x] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
