### PR TITLE
APPT-1235: Fix bug in Download Report form

### DIFF
--- a/src/client/src/app/reports/download-report-form-schema.ts
+++ b/src/client/src/app/reports/download-report-form-schema.ts
@@ -50,10 +50,17 @@ export const downloadReportFormSchema: yup.ObjectSchema<DownloadReportFormValues
         if (!values.startDate || !values.endDate) {
           return true; // Validation will fail on required fields first
         }
+
         return occurInOrder([
           parseToUkDatetime(values.startDate, RFC3339Format),
           parseToUkDatetime(values.endDate, RFC3339Format),
-        ]);
+        ])
+          ? true
+          : new yup.ValidationError(
+              'End date must be equal to or after start date',
+              values.endDate,
+              'endDate',
+            );
       },
     )
     .required();

--- a/src/client/src/app/reports/download-report-form.tsx
+++ b/src/client/src/app/reports/download-report-form.tsx
@@ -1,10 +1,12 @@
 'use client';
 import { RFC3339Format, ukNow } from '@services/timeService';
 import {
+  downloadReportFormSchema,
   DownloadReportFormValues,
   REPORT_DATE_EARLIEST_ALLOWED,
 } from './download-report-form-schema';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
 import { BackLink, Button, ButtonGroup } from '@components/nhsuk-frontend';
 import NhsHeading from '@components/nhs-heading';
 import Datepicker from '@components/nhsuk-frontend/custom/datepicker';
@@ -28,6 +30,7 @@ const DownloadReportForm = ({
       startDate: today.format(RFC3339Format),
       endDate: today.format(RFC3339Format),
     },
+    resolver: yupResolver(downloadReportFormSchema),
   });
 
   const submitForm: SubmitHandler<DownloadReportFormValues> = async (


### PR DESCRIPTION
# Description

So I created a form schema and wrote lots of unit tests for a form schema. 

... then I forgot to tell the form to USE the schema 🤦 

Also snuck in a minor improvement to the schema as I've found a way to give an object-level test a property-level error path
Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
