### PR TITLE
APPT-1236 - fix for cancellation not being added to aggregate, plus cancellation reason

### DIFF
--- a/src/api/Nhs.Appointments.Core/Reports/SiteSummary/DailySiteSummary.cs
+++ b/src/api/Nhs.Appointments.Core/Reports/SiteSummary/DailySiteSummary.cs
@@ -5,7 +5,7 @@ public class DailySiteSummary
     public string Site { get; set; }
     public DateOnly Date { get; set; }
     public Dictionary<string, int> Bookings { get; set; }
-    public int Cancelled { get; set; }
+    public Dictionary<string, int> Cancelled { get; set; }
     public Dictionary<string, int> Orphaned { set; get; }
     public Dictionary<string, int> RemainingCapacity { set; get; }
     public int MaximumCapacity { get; set; }

--- a/src/api/Nhs.Appointments.Core/SiteReport.cs
+++ b/src/api/Nhs.Appointments.Core/SiteReport.cs
@@ -6,6 +6,8 @@ public class SiteReport
 {
     public SiteReport(Site site, DailySiteSummary[] days, string[] clinicalServices)
     {
+        var cancellationReasons = days.SelectMany(x => x.Cancelled.Keys).Distinct();
+        
         SiteName = site.Name;
         ICB = site.IntegratedCareBoard;
         Region = site.Region;
@@ -15,7 +17,9 @@ public class SiteReport
         Bookings = clinicalServices.ToDictionary(
             service => service, 
             service => days.Sum(day => day.Bookings.GetValueOrDefault(service, 0)) + days.Sum(x => x.Orphaned.GetValueOrDefault(service, 0)));
-        Cancelled = days.Sum(day => day.Cancelled);
+        Cancelled = cancellationReasons.ToDictionary(
+            reason => reason,
+            reason => days.Sum(day => day.Cancelled.GetValueOrDefault(reason, 0)));
         RemainingCapacity = clinicalServices.ToDictionary(
             service => service, 
             service => days.Sum(day => day.RemainingCapacity.GetValueOrDefault(service, 0)));
@@ -30,7 +34,7 @@ public class SiteReport
     public double Latitude { get; }
     public Dictionary<string, int> Bookings { get; }
     public int TotalBookings => Bookings.Sum(x => x.Value);
-    public int Cancelled { get; }
+    public Dictionary<string, int> Cancelled { get; }
     public Dictionary<string, int> RemainingCapacity { get; }
     public int MaximumCapacity { get; }
 }

--- a/src/api/Nhs.Appointments.Core/WeekSummary.cs
+++ b/src/api/Nhs.Appointments.Core/WeekSummary.cs
@@ -10,7 +10,7 @@ namespace Nhs.Appointments.Core
     {
         public DateOnly Date { get; set; } = date;
         public readonly IEnumerable<SessionSummary> Sessions = sessions;
-        public int CancelledAppointments { get; set; }
+        public Dictionary<string, int> CancelledAppointments { get; set; }
     }
     
     public class SessionSummary

--- a/src/api/Nhs.Appointments.Persistance/DailySiteSummaryStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/DailySiteSummaryStore.cs
@@ -12,6 +12,7 @@ public class DailySiteSummaryStore(ITypedDocumentCosmosStore<DailySiteSummaryDoc
             Id = summary.Site,
             Date = summary.Date,
             Bookings = summary.Bookings,
+            Cancelled = summary.Cancelled,
             Orphaned = summary.Orphaned,
             RemainingCapacity = summary.RemainingCapacity,
             MaximumCapacity = summary.MaximumCapacity,

--- a/src/api/Nhs.Appointments.Persistance/Models/DailySiteSummaryDocument.cs
+++ b/src/api/Nhs.Appointments.Persistance/Models/DailySiteSummaryDocument.cs
@@ -8,7 +8,7 @@ public class DailySiteSummaryDocument : AggregatedDataCosmosDocument
     [JsonProperty("bookings")]
     public Dictionary<string, int> Bookings { get; set; }
     [JsonProperty("cancelled")]
-    public int Cancelled { get; }
+    public Dictionary<string, int> Cancelled { get; set; }
     [JsonProperty("orphaned")]
     public Dictionary<string, int> Orphaned { set; get; }
     [JsonProperty("remainingCapacity")]

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/WeekSummaryFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/WeekSummaryFeatureSteps.cs
@@ -71,7 +71,12 @@ namespace Nhs.Appointments.Api.Integration.Scenarios.Availability
                     RemainingCapacity = int.Parse(row.Cells.ElementAt(2).Value),
                     BookedAppointments = int.Parse(row.Cells.ElementAt(3).Value),
                     OrphanedAppointments = int.Parse(row.Cells.ElementAt(4).Value),
-                    CancelledAppointments = int.Parse(row.Cells.ElementAt(5).Value),
+                    CancelledAppointments = new Dictionary<string, int>
+                    {
+                        {
+                            "UNKNOWN", int.Parse(row.Cells.ElementAt(5).Value)
+                        }
+                    }
                 });
 
             _statusCode.Should().Be(HttpStatusCode.OK);

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingAvailabilityState/GetWeekSummaryTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingAvailabilityState/GetWeekSummaryTests.cs
@@ -94,7 +94,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 25,
                 BookedAppointments = 5,
                 OrphanedAppointments = 2,
-                CancelledAppointments = 2
+                CancelledAppointments = new Dictionary<string, int>() {{ "UNKNOWN", 2 }}
             });
 
         weekSummary.DaySummaries.AssertEmptySessionSummariesOnDate(new DateOnly(2025, 1, 7));
@@ -191,7 +191,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 26,
                 BookedAppointments = 6,
                 OrphanedAppointments = 0,
-                CancelledAppointments = 0
+                CancelledAppointments = new Dictionary<string, int>()
             });
 
         weekSummary.DaySummaries.AssertEmptySessionSummariesOnDate(new DateOnly(2025, 1, 14));
@@ -241,7 +241,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 26,
                 BookedAppointments = 6,
                 OrphanedAppointments = 0,
-                CancelledAppointments = 0
+                CancelledAppointments = new Dictionary<string, int>()
             });
     }
 
@@ -323,7 +323,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 26,
                 BookedAppointments = 6,
                 OrphanedAppointments = 0,
-                CancelledAppointments = 0
+                CancelledAppointments = new Dictionary<string, int>()
             });
 
         weekSummary.DaySummaries.AssertEmptySessionSummariesOnDate(new DateOnly(2025, 1, 14));
@@ -365,7 +365,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 26,
                 BookedAppointments = 6,
                 OrphanedAppointments = 0,
-                CancelledAppointments = 0
+                CancelledAppointments = new Dictionary<string, int>()
             });
     }
 
@@ -471,7 +471,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 32,
                 BookedAppointments = 3,
                 OrphanedAppointments = 3,
-                CancelledAppointments = 0
+                CancelledAppointments = new Dictionary<string, int>()
             });
 
         weekSummary.DaySummaries.AssertEmptySessionSummariesOnDate(new DateOnly(2025, 1, 13));
@@ -528,7 +528,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 61,
                 BookedAppointments = 3,
                 OrphanedAppointments = 3,
-                CancelledAppointments = 0
+                CancelledAppointments = new Dictionary<string, int>()
             });
         
         //extra padded data
@@ -555,7 +555,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 72,
                 BookedAppointments = 0,
                 OrphanedAppointments = 0,
-                CancelledAppointments = 0
+                CancelledAppointments = new Dictionary<string, int>()
             });
     }
 
@@ -641,7 +641,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 29,
                 BookedAppointments = 3,
                 OrphanedAppointments = 3,
-                CancelledAppointments = 0
+                CancelledAppointments = new Dictionary<string, int>()
             });
 
         weekSummary.DaySummaries.AssertEmptySessionSummariesOnDate(new DateOnly(2025, 1, 14));
@@ -683,7 +683,7 @@ public class GetWeekSummaryTests : BookingAvailabilityStateServiceTestBase
                 RemainingCapacity = 29,
                 BookedAppointments = 3,
                 OrphanedAppointments = 3,
-                CancelledAppointments = 0
+                CancelledAppointments = new Dictionary<string, int>()
             });
     }
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/Reports/SiteSummary/SiteSummaryAggregatorTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/Reports/SiteSummary/SiteSummaryAggregatorTests.cs
@@ -124,7 +124,7 @@ public class SiteSummaryAggregatorTests
                  }
              });
              
-             daySummary.CancelledAppointments = 1;
+             daySummary.CancelledAppointments = new Dictionary<string, int>() {{ "UNKNOWN", 1 }};
              
              _bookingAvailabilityStateService.Setup(x => x.GetDaySummary(It.IsAny<string>(), It.IsAny<DateOnly>())).ReturnsAsync(new Summary
              {


### PR DESCRIPTION
# Description

Fix for bug, plus missing logic for cancelation reason being added to the report

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
