### PR TITLE
Appt 1211 - Site status bulk import

### DIFF
--- a/src/api/Nhs.Appointments.Core/BulkImport/SiteDataImporterHandler.cs
+++ b/src/api/Nhs.Appointments.Core/BulkImport/SiteDataImporterHandler.cs
@@ -1,8 +1,9 @@
 using Microsoft.AspNetCore.Http;
+using Nhs.Appointments.Core.Features;
 
 namespace Nhs.Appointments.Core.BulkImport;
 
-public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodesService wellKnowOdsCodesService) : ISiteDataImportHandler
+public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodesService wellKnowOdsCodesService, IFeatureToggleHelper featureToggleHelper) : ISiteDataImportHandler
 {
     public async Task<IEnumerable<ReportItem>> ProcessFile(IFormFile inputFile)
     {
@@ -24,6 +25,9 @@ public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodes
             return report.Where(r => !r.Success);
         }
 
+		SiteStatus? siteStatus = await featureToggleHelper.IsFeatureEnabled(Flags.SiteStatus)
+			? SiteStatus.Online : null;
+
         foreach (var site in siteRows)
         {
             try
@@ -38,7 +42,8 @@ public class SiteDataImporterHandler(ISiteService siteService, IWellKnowOdsCodes
                     site.Region,
                     site.Location,
                     site.Accessibilities,
-                    site.Type);
+                    site.Type,
+					siteStatus);
             }
             catch (Exception ex)
             {

--- a/src/api/Nhs.Appointments.Core/ISiteStore.cs
+++ b/src/api/Nhs.Appointments.Core/ISiteStore.cs
@@ -17,7 +17,7 @@ public interface ISiteStore
     Task<IEnumerable<Site>> GetAllSites();
 
     Task<OperationResult> SaveSiteAsync(string siteId, string odsCode, string name, string address, string phoneNumber,
-        string icb, string region, Location location, IEnumerable<Accessibility> accessibilities, string type);
+        string icb, string region, Location location, IEnumerable<Accessibility> accessibilities, string type, SiteStatus? siteStatus = null);
 
     Task<IEnumerable<Site>> GetSitesInRegionAsync(string region);
 

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -22,7 +22,7 @@ public interface ISiteService
     Task<OperationResult> UpdateSiteReferenceDetailsAsync(string siteId, string odsCode, string icb, string region);
 
     Task<OperationResult> SaveSiteAsync(string siteId, string odsCode, string name, string address, string phoneNumber,
-        string icb, string region, Location location, IEnumerable<Accessibility> accessibilities, string type);
+        string icb, string region, Location location, IEnumerable<Accessibility> accessibilities, string type, SiteStatus? siteStatus = null);
     Task<IEnumerable<Site>> GetSitesInRegion(string region);
     Task<OperationResult> SetSiteStatus(string siteId, SiteStatus status);
 }
@@ -175,7 +175,7 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
     }
 
     public async Task<OperationResult> SaveSiteAsync(string siteId, string odsCode, string name, string address, string phoneNumber, string icb,
-        string region, Location location, IEnumerable<Accessibility> accessibilities, string type)
+        string region, Location location, IEnumerable<Accessibility> accessibilities, string type, SiteStatus? siteStatus = null)
             => await siteStore.SaveSiteAsync(
                 siteId,
                 odsCode,
@@ -186,7 +186,8 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
                 region,
                 location,
                 accessibilities,
-                type);
+                type,
+                siteStatus);
 
     public Task<OperationResult> UpdateAccessibilities(string siteId, IEnumerable<Accessibility> accessibilities) 
     {

--- a/src/api/Nhs.Appointments.Persistance/SiteStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/SiteStore.cs
@@ -111,7 +111,7 @@ public class SiteStore(ITypedDocumentCosmosStore<SiteDocument> cosmosStore) : IS
     }
 
     public async Task<OperationResult> SaveSiteAsync(string siteId, string odsCode, string name, string address, string phoneNumber,
-        string icb, string region, Location location, IEnumerable<Accessibility> accessibilities, string type)
+        string icb, string region, Location location, IEnumerable<Accessibility> accessibilities, string type, SiteStatus? siteStatus = null)
     {
         var originalDocument = await GetOrDefault(siteId);
         if (originalDocument is null)
@@ -129,7 +129,8 @@ public class SiteStore(ITypedDocumentCosmosStore<SiteDocument> cosmosStore) : IS
                 IntegratedCareBoard = icb,
                 Location = location,
                 Region = region,
-                Type = type
+                Type = type,
+                Status = siteStatus
             };
             var document = cosmosStore.ConvertToDocument(site);
             await cosmosStore.WriteAsync(document);

--- a/tests/Nhs.Appointments.Core.UnitTests/BulkImport/SiteDataImporterHandlerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BulkImport/SiteDataImporterHandlerTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Nhs.Appointments.Core.BulkImport;
+using Nhs.Appointments.Core.Features;
 using System.Runtime.Intrinsics.Arm;
 using System.Text;
 
@@ -8,6 +9,7 @@ public class SiteDataImporterHandlerTests
 {
     private readonly Mock<ISiteService> _siteServiceMock = new();
     private readonly Mock<IWellKnowOdsCodesService> _wellKnownOdsCodesServiceMock = new();
+    private readonly Mock<IFeatureToggleHelper> _featureToggleHelperMock = new();
 
     private readonly SiteDataImporterHandler _sut;
 
@@ -16,7 +18,7 @@ public class SiteDataImporterHandlerTests
 
     public SiteDataImporterHandlerTests()
     {
-        _sut = new SiteDataImporterHandler(_siteServiceMock.Object, _wellKnownOdsCodesServiceMock.Object);
+        _sut = new SiteDataImporterHandler(_siteServiceMock.Object, _wellKnownOdsCodesServiceMock.Object, _featureToggleHelperMock.Object);
     }
 
     [Fact]
@@ -342,7 +344,8 @@ public class SiteDataImporterHandlerTests
             It.IsAny<string>(),
             It.IsAny<Location>(),
             It.IsAny<List<Accessibility>>(),
-            It.IsAny<string>()), Times.Never);
+            It.IsAny<string>(),
+            null), Times.Never);
     }
 
     [Fact]
@@ -388,6 +391,82 @@ public class SiteDataImporterHandlerTests
 
         report.Count().Should().Be(1);
         report.First().Message.Should().Be($"OdsCode: '{odsCode}' is invalid. OdsCode's must be a maximum of 10 characters long and only contain numbers and capital letters.");
+    }
+
+    [Fact]
+    public async Task SavesSiteStatusAsOnline_WhenSiteStatusFeatureToggleEnabled()
+    {
+        var input = CsvFileBuilder.BuildInputCsv(SitesHeader, ValidInputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        _wellKnownOdsCodesServiceMock.Setup(x => x.GetWellKnownOdsCodeEntries())
+            .ReturnsAsync(new List<WellKnownOdsEntry>
+            {
+                new("site1", "Site 1", "Test1"),
+                new("site2", "Site 2", "Test2"),
+                new("site3", "Site 3", "Test3"),
+                new("Yorkshire", "Site 4", "Region"),
+                new("test icb", "Site 5", "ICB")
+            });
+        _featureToggleHelperMock.Setup(x => x.IsFeatureEnabled(Flags.SiteStatus)).ReturnsAsync(true);
+
+        var report = await _sut.ProcessFile(file);
+
+        report.Count().Should().Be(3);
+        report.All(r => r.Success).Should().BeTrue();
+
+        _siteServiceMock.Verify(s => s.SaveSiteAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<Location>(),
+            It.IsAny<Accessibility[]>(),
+            It.IsAny<string>(),
+            SiteStatus.Online), Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task SaveSitesStatusAsNull_WhenSiteStatusFeatureToggleDisabled()
+    {
+        var input = CsvFileBuilder.BuildInputCsv(SitesHeader, ValidInputRows);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+        var file = new FormFile(stream, 0, stream.Length, "Test", "test.csv");
+
+        _wellKnownOdsCodesServiceMock.Setup(x => x.GetWellKnownOdsCodeEntries())
+            .ReturnsAsync(new List<WellKnownOdsEntry>
+            {
+                new("site1", "Site 1", "Test1"),
+                new("site2", "Site 2", "Test2"),
+                new("site3", "Site 3", "Test3"),
+                new("Yorkshire", "Site 4", "Region"),
+                new("test icb", "Site 5", "ICB")
+            });
+        _featureToggleHelperMock.Setup(x => x.IsFeatureEnabled(Flags.SiteStatus)).ReturnsAsync(false);
+
+        var report = await _sut.ProcessFile(file);
+
+        report.Count().Should().Be(3);
+        report.All(r => r.Success).Should().BeTrue();
+
+        _siteServiceMock.Verify(s => s.SaveSiteAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<Location>(),
+            It.IsAny<Accessibility[]>(),
+            It.IsAny<string>(),
+            null), Times.Exactly(3));
     }
 
     private readonly string[] ValidInputRows =


### PR DESCRIPTION
# Description

If the site status feature toggle is enabled, set the site status to Online by default. If the feature is disabled, store as null

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
