### PR TITLE
APPT-1144: support disaster recovery on perf

### DIFF
--- a/disaster-recovery.yml
+++ b/disaster-recovery.yml
@@ -6,7 +6,7 @@ parameters:
     displayName: "The environment the disaster recovery should be ran for."
     type: string
     default: "stag"
-    values: ["stag", "prod"]
+    values: ["perf", "stag", "prod"]
 
 trigger: none
 pr: none
@@ -19,11 +19,20 @@ variables:
   - name: env
     value: ${{parameters.env}}
   - name: uksResourceGroup
-    value: "nbs-mya-rg-$(env)-uks"
+    ${{ if eq(parameters.env, 'perf') }}: 
+      value: "nbs-mya$(env)-rg-stag-uks"
+    ${{ if ne(parameters.env, 'perf') }}: 
+      value: "nbs-mya-rg-$(env)-uks"
   - name: ukwResourceGroup
-    value: "nbs-mya-rg-$(env)-ukw"
+    ${{ if eq(parameters.env, 'perf') }}: 
+      value: "nbs-mya$(env)-rg-stag-ukw"
+    ${{ if ne(parameters.env, 'perf') }}: 
+      value: "nbs-mya-rg-$(env)-ukw"
   - name: serviceConnection
-    value: "nbs-mya-rg-$(env)"
+    ${{ if eq(parameters.env, 'perf') }}: 
+      value: "nbs-mya$(env)-rg-stag"
+    ${{ if ne(parameters.env, 'perf') }}: 
+      value: "nbs-mya-rg-$(env)"
   - name: frontdoorProfileName
     value: "nbs-mya-fd-$(env)-uks"
   - name: frontdoorRuleSetNameUkw

--- a/infrastructure/environments/perf-ukw/main.tf
+++ b/infrastructure/environments/perf-ukw/main.tf
@@ -1,0 +1,103 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.37.0"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "nbs-myaperf-rg-stag-ukw"
+    storage_account_name = "myaperftfstagukw"
+    container_name       = "tfstate"
+    key                  = "perf.tfstate"
+  }
+
+  required_version = ">= 1.6.5"
+}
+
+provider "azurerm" {
+  features {
+    app_configuration {
+      purge_soft_delete_on_destroy = false
+      recover_soft_deleted         = false
+    }
+  }
+}
+
+module "mya_application_perf" {
+  environment                                     = "perf"
+  location                                        = "ukwest"
+  loc                                             = "ukw"
+  build_number                                    = var.BUILD_NUMBER
+  source                                          = "../../resources"
+  nhs_mail_issuer                                 = var.NHS_MAIL_ISSUER
+  nhs_mail_authorize_uri                          = var.NHS_MAIL_AUTHORIZE_URI
+  nhs_mail_token_uri                              = var.NHS_MAIL_TOKEN_URI
+  nhs_mail_jwks_uri                               = var.NHS_MAIL_JWKS_URI
+  nhs_mail_client_id                              = var.NHS_MAIL_CLIENT_ID
+  nhs_mail_client_secret                          = var.NHS_MAIL_CLIENT_SECRET
+  okta_issuer                                     = var.OKTA_ISSUER
+  okta_authorize_uri                              = var.OKTA_AUTHORIZE_URI
+  okta_token_uri                                  = var.OKTA_TOKEN_URI
+  okta_jwks_uri                                   = var.OKTA_JWKS_URI
+  okta_client_id                                  = var.OKTA_CLIENT_ID
+  okta_client_secret                              = var.OKTA_CLIENT_SECRET
+  okta_domain                                     = var.OKTA_ISSUER
+  okta_management_id                              = var.OKTA_MANAGEMENT_ID
+  okta_private_key_kid                            = var.OKTA_PRIVATE_KEY_KID
+  okta_pem                                        = var.OKTA_PEM
+  auth_provider_challenge_phrase                  = var.AUTH_PROVIDER_CHALLENGE_PHRASE
+  nhs_host_url                                    = var.NHS_HOST_URL
+  func_app_base_uri                               = var.FUNC_APP_BASE_URI
+  func_app_slot_base_uri                          = var.FUNC_APP_SLOT_BASE_URI
+  web_app_base_uri                                = var.WEB_APP_BASE_URI
+  web_app_slot_base_uri                           = var.WEB_APP_SLOT_BASE_URI
+  gov_notify_base_uri                             = var.GOV_NOTIFY_BASE_URI
+  gov_notify_api_key                              = var.GOV_NOTIFY_API_KEY
+  booking_reminders_cron_schedule                 = var.BOOKING_REMINDERS_CRON_SCHEDULE
+  unconfirmed_provisional_bookings_cron_schedule  = var.UNCONFIRMED_PROVISIONAL_BOOKINGS_CRON_SCHEDULE
+  daily_site_summary_aggregation_cron_schedule    = var.DAILY_SITE_SUMMARY_AGGREGATION_CRON_SCHEDULE
+  site_summary_days_forward                       = var.SITE_SUMMARY_DAYS_FORWARD
+  site_summary_days_chunk_size                    = var.SITE_SUMMARY_DAYS_CHUNK_SIZE
+  site_summary_first_run_date                     = var.SITE_SUMMARY_FIRST_RUN_DATE
+  splunk_hec_token                                = var.SPLUNK_HEC_TOKEN
+  splunk_host_url                                 = var.SPLUNK_HOST_URL
+  autoscale_notification_email_address            = var.AUTOSCALE_NOTIFICATION_EMAIL_ADDRESS
+  cosmos_endpoint                                 = var.COSMOS_ENDPOINT
+  cosmos_token                                    = var.COSMOS_TOKEN
+  app_config_connection                           = var.APP_CONFIG_CONNECTION
+  disable_query_availability_function             = false
+  create_high_load_function_app                   = true
+  create_app_slot                                 = false
+  create_autoscale_settings                       = false
+  create_frontdoor                                = false
+  create_cosmos_db                                = false
+  create_app_config                               = false
+  web_app_service_sku                             = "P1v3"
+  web_app_service_plan_default_worker_count       = 3
+  app_service_plan_zone_redundancy_enabled        = true
+  web_app_service_plan_min_worker_count           = 1
+  web_app_service_plan_max_worker_count           = 20
+  web_app_service_plan_scale_out_worker_count     = 1
+  web_app_service_plan_scale_in_worker_count      = 1
+  app_insights_sampling_percentage                = 12.5
+  storage_account_replication_type                = "LRS"
+  cosmos_automatic_failover_enabled               = true
+  disable_bulk_import_function                    = true
+  cosmos_booking_autoscale_settings = [{
+    max_throughput = 60000
+  }]
+  cosmos_aggregation_autoscale_settings = [{
+    max_throughput = 10000
+  }]
+  cosmos_core_autoscale_settings = [{
+    max_throughput = 25000
+  }]
+  cosmos_index_autoscale_settings = [{
+    max_throughput = 4000
+  }]
+  cosmos_audit_autoscale_settings = [{
+    max_throughput = 2000
+  }]
+}

--- a/infrastructure/environments/perf-ukw/variables.tf
+++ b/infrastructure/environments/perf-ukw/variables.tf
@@ -1,0 +1,176 @@
+variable "NHS_HOST_URL" {
+  type      = string
+  sensitive = false
+}
+
+variable "FUNC_APP_BASE_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "WEB_APP_BASE_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "FUNC_APP_SLOT_BASE_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "WEB_APP_SLOT_BASE_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "NHS_MAIL_ISSUER" {
+  type      = string
+  sensitive = false
+}
+
+variable "NHS_MAIL_AUTHORIZE_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "NHS_MAIL_TOKEN_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "NHS_MAIL_JWKS_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "NHS_MAIL_CLIENT_ID" {
+  type      = string
+  sensitive = false
+}
+
+variable "NHS_MAIL_CLIENT_SECRET" {
+  type      = string
+  sensitive = true
+}
+
+variable "OKTA_ISSUER" {
+  type      = string
+  sensitive = false
+}
+
+variable "OKTA_AUTHORIZE_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "OKTA_TOKEN_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "OKTA_JWKS_URI" {
+  type      = string
+  sensitive = false
+}
+
+variable "OKTA_CLIENT_ID" {
+  type      = string
+  sensitive = false
+}
+
+variable "OKTA_CLIENT_SECRET" {
+  type      = string
+  sensitive = true
+}
+
+variable "OKTA_MANAGEMENT_ID" {
+  type      = string
+  sensitive = false
+}
+
+variable "OKTA_PRIVATE_KEY_KID" {
+  type      = string
+  sensitive = true
+}
+
+variable "OKTA_PEM" {
+  type      = string
+  sensitive = true
+}
+
+variable "AUTH_PROVIDER_CHALLENGE_PHRASE" {
+  type      = string
+  sensitive = false
+}
+
+variable "GOV_NOTIFY_BASE_URI" {
+  type = string
+}
+
+variable "GOV_NOTIFY_API_KEY" {
+  type      = string
+  sensitive = true
+}
+
+variable "BOOKING_REMINDERS_CRON_SCHEDULE" {
+  type      = string
+  sensitive = false
+}
+
+variable "UNCONFIRMED_PROVISIONAL_BOOKINGS_CRON_SCHEDULE" {
+  type      = string
+  sensitive = false
+}
+
+variable "DAILY_SITE_SUMMARY_AGGREGATION_CRON_SCHEDULE" {
+  type      = string
+  sensitive = false
+}
+
+variable "SITE_SUMMARY_DAYS_FORWARD" {
+  type      = string
+  sensitive = false
+}
+
+variable "SITE_SUMMARY_DAYS_CHUNK_SIZE" {
+  type      = string
+  sensitive = false
+}
+
+variable "SITE_SUMMARY_FIRST_RUN_DATE" {
+  type      = string
+  sensitive = false
+}
+
+variable "SPLUNK_HOST_URL" {
+  type      = string
+  sensitive = false
+}
+
+variable "SPLUNK_HEC_TOKEN" {
+  type      = string
+  sensitive = true
+}
+
+variable "AUTOSCALE_NOTIFICATION_EMAIL_ADDRESS" {
+  type = string
+}
+
+variable "BUILD_NUMBER" {
+  type = string
+}
+
+variable "COSMOS_ENDPOINT" {
+  type      = string
+  sensitive = true
+}
+
+variable "COSMOS_TOKEN" {
+  type      = string
+  sensitive = true
+}
+
+variable "APP_CONFIG_CONNECTION" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
# Description

Add Disaster Recovery for Perf environment

Updates to disaster recovery YAML to reflect wonky resource group naming
Add new environment to Terraform

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
