### PR TITLE
Appt 1239/lower days 60

### DIFF
--- a/data/CapacityDataExtract/CapacityDataExtract.cs
+++ b/data/CapacityDataExtract/CapacityDataExtract.cs
@@ -15,7 +15,8 @@ public class CapacityDataExtract(
         var availabilityTask = availabilityStore.RunQueryAsync(
             b => b.DocumentType == "daily_availability"
                 && b.Date >= DateOnly.FromDateTime(timeProvider.GetUtcNow().Date)
-                && b.Date <= DateOnly.FromDateTime(timeProvider.GetUtcNow().Date.AddDays(90)),
+                //&& b.Date <= DateOnly.FromDateTime(timeProvider.GetUtcNow().Date.AddDays(90))
+                && b.Date <= DateOnly.FromDateTime(timeProvider.GetUtcNow().Date.AddDays(60)),
             b => b
         );
 

--- a/data/DataExtract/DataExtractWorker.cs
+++ b/data/DataExtract/DataExtractWorker.cs
@@ -25,8 +25,8 @@ public class DataExtractWorker<TExtractor>(
             {
                 WriteFileLocally(outputFile);
             }
-
-            await SendViaMesh(outputFile);
+            Console.WriteLine($"Data extract completed. Output file Not going to mesh: {outputFile.FullName}");
+            //await SendViaMesh(outputFile);
         }
         catch (Exception ex)
         {

--- a/data/DataExtract/DataExtractWorker.cs
+++ b/data/DataExtract/DataExtractWorker.cs
@@ -25,8 +25,8 @@ public class DataExtractWorker<TExtractor>(
             {
                 WriteFileLocally(outputFile);
             }
-            Console.WriteLine($"Data extract completed. Output file Not going to mesh: {outputFile.FullName}");
-            //await SendViaMesh(outputFile);
+
+            await SendViaMesh(outputFile);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
# Description

Lowering days from 90 to 60 temporarily to stop time out of capacity report. This will need rolling back once the the extracts are stable again

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
