### PR TITLE
Appt 1240 - Fixing the link on the back to week link on edit session confirmation page

### DIFF
--- a/src/client/src/app/site/[site]/availability/edit-services/confirmed/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit-services/confirmed/page.tsx
@@ -47,7 +47,7 @@ const Page = async ({ searchParams, params }: PageProps) => {
       title={`Services removed for ${parsedDate.format('DD MMMM YYYY')}`}
       caption={site.name}
       backLink={{
-        href: `/site/${site.id}/view-availability/week/?date=${parsedDate.date}`,
+        href: `/site/${site.id}/view-availability/week/?date=${date}`,
         renderingStrategy: 'server',
         text: 'Back to week view',
       }}


### PR DESCRIPTION
(cherry picked from commit e8039bc4c347c1510d7b0ad0284649c490b72553)

(#891)

# Description

Updating the date parameter on the edit session back to week view back link to the correct date

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
