### PR TITLE
APPT-1249 RSV/FLU2:3 validation and memory caching (#895)

### DIFF
--- a/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using FluentValidation;
 using Nhs.Appointments.Api.Models;
 
@@ -47,8 +48,8 @@ public class GetSitesByAreaRequestValidator : AbstractValidator<GetSitesByAreaRe
                     () =>
                     {
                         RuleFor(x => x.Services)
-                            .Must(services => services.Length == 1)
-                            .WithMessage("'Services' currently only supports one service");
+                            .Must(services => services.Length == 1 && (services.Single() == "RSV:Adult" || services.Single() == "FLU:2_3"))
+                            .WithMessage("'Services' currently only supports: 'RSV:Adult or 'FLU:2_3'");
                         RuleFor(x => x)
                             .Cascade(CascadeMode.Stop)
                             .Must(x => DateOnly.TryParseExact(x.From, "yyyy-MM-dd", out _))

--- a/src/api/Nhs.Appointments.Core/SiteService.cs
+++ b/src/api/Nhs.Appointments.Core/SiteService.cs
@@ -28,6 +28,7 @@ public interface ISiteService
 public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilityStore, IMemoryCache memoryCache, ILogger<ISiteService> logger, TimeProvider time) : ISiteService
 {
     private const string CacheKey = "sites";
+    
     public async Task<IEnumerable<SiteWithDistance>> FindSitesByArea(double longitude, double latitude, int searchRadius, int maximumRecords, IEnumerable<string> accessNeeds, bool ignoreCache = false, SiteSupportsServiceFilter siteSupportsServiceFilter = null)
     {        
         var accessibilityIds = accessNeeds.Where(an => string.IsNullOrEmpty(an) == false).Select(an => $"accessibility/{an}").ToList();
@@ -65,17 +66,16 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
             siteSupportsServiceFilter.from,
             siteSupportsServiceFilter.until,
             maximumRecords,
-            maximumRecords * 2);
+            maximumRecords * 20);
     }
 
     private async Task<IEnumerable<SiteWithDistance>> GetSitesSupportingService(IEnumerable<SiteWithDistance> sites, string service, DateOnly from, DateOnly to,
-        int maxRecords = 50, int batchSize = 100)
+        int maxRecords = 50, int batchSize = 1000)
     {
         var orderedSites = sites.OrderBy(site => site.Distance).ToList();
         
         var results = new List<SiteWithDistance>();
 
-        var dateStringsInRange = GetDateStringsInRange(from, to);
         var iterations = 0;
         
         //while we are still short of the max, keep appending results
@@ -94,7 +94,7 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
 
             var siteOffersServiceDuringPeriodTasks = orderedSiteBatch.Select(async swd =>
             {
-                var siteOffersServiceDuringPeriod = await availabilityStore.SiteOffersServiceDuringPeriod(swd.Site.Id, service, dateStringsInRange);
+                var siteOffersServiceDuringPeriod = await GetSiteSupportingServiceInRange(swd.Site.Id, service, from, to);
                 if (siteOffersServiceDuringPeriod)
                 {
                     concurrentBatchResults.Add(swd);
@@ -113,7 +113,7 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
         return results;
     }
     
-       private static List<string> GetDateStringsInRange(DateOnly from, DateOnly to)
+    private static List<string> GetDateStringsInRange(DateOnly from, DateOnly to)
     {
         var result = new List<string>();
 
@@ -232,5 +232,27 @@ public class SiteService(ISiteStore siteStore, IAvailabilityStore availabilitySt
         memoryCache.Set(CacheKey, sites, time.GetUtcNow().AddMinutes(10));
 
         return sites;
+    }
+    
+    private async Task<bool> GetSiteSupportingServiceInRange(string siteId, string service, DateOnly from, DateOnly until)
+    {
+        var cacheKey = GetCacheSiteServiceSupportDateRangeKey(siteId, service, from, until);
+
+        if (memoryCache.TryGetValue(cacheKey, out bool siteSupportsService))
+        {
+            return siteSupportsService;
+        }
+        
+        var dateStringsInRange = GetDateStringsInRange(from, until);
+        var siteOffersServiceDuringPeriod = await availabilityStore.SiteOffersServiceDuringPeriod(siteId, service, dateStringsInRange);
+        
+        memoryCache.Set(cacheKey, siteOffersServiceDuringPeriod, time.GetUtcNow().AddMinutes(15));
+        return siteOffersServiceDuringPeriod;
+    }
+
+    private string GetCacheSiteServiceSupportDateRangeKey(string siteId, string service, DateOnly from, DateOnly until)
+    {
+        var dateRange = $"{from.ToString("yyyyMMdd")}_{until.ToString("yyyyMMdd")}";
+        return $"site_{siteId}_supports_{service}_in_{dateRange}";
     }
 }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearch.feature
@@ -49,14 +49,14 @@ Feature: Site search
       | a03982ab-f9a8-4d4b-97ca-419d1154896f | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
     And the following sessions exist for site 'a03982ab-f9a8-4d4b-97ca-419d1154896f'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
-      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+      | 3           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | a03982ab-f9a8-4d4b-97ca-419d1154896f | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
-
+    
   Scenario: Retrieve sites by service filter - multiple results limited to max records ordered by distance
     Given The following sites exist in the system
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  |
@@ -66,19 +66,19 @@ Feature: Site search
       | 156141af-89ab-4a30-83d4-a4d27a8322c2 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
     And the following sessions exist for site '156141af-89ab-4a30-83d4-a4d27a8322c2'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site 'f178d668-a8d7-4fa6-a4b1-b886feef29a6'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '3525af0d-9d89-4b32-ad6b-b85ae94589dc'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '3ac1981b-5d62-424a-b403-9d08a40739ce'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
-      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+      | 3           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | 156141af-89ab-4a30-83d4-a4d27a8322c2 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
@@ -86,7 +86,7 @@ Feature: Site search
       | 3ac1981b-5d62-424a-b403-9d08a40739ce | Site-2 | 2 Roadside | 0113 2222222 | K12     | R2     | ICB2 | Info 2                 | accessibility/attr_one=false | 0.14566747  | 51.482472 | 4819     |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
-      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+      | 4           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | 156141af-89ab-4a30-83d4-a4d27a8322c2 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
@@ -106,16 +106,16 @@ Feature: Site search
       | Tomorrow    | 09:00 | 17:00 | FLU:2-3    | 5           | 1        |
     And the following sessions exist for site '319eb942-1bcd-4d9b-b8b2-777f06d63320'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | RSV:Adult  | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | FLU:5-6    | 5           | 1        |
     And the following sessions exist for site '8f3259bf-e44e-43e6-9837-54a5c87198c7'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '55ad05a8-4fb5-47e1-a961-d18f4008862b'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
-      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+      | 4           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | 55ad05a8-4fb5-47e1-a961-d18f4008862b | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
@@ -133,10 +133,10 @@ Feature: Site search
       | Tomorrow    | 09:00 | 17:00 | FLU:2-3    | 5           | 1        |
     And the following sessions exist for site '4aeedaf7-48a8-4071-955c-93ccbcbc925c'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | RSV:Adult  | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | FLU:5-6    | 5           | 1        |
     And the following sessions exist for site '1950e7f1-356c-4017-ba62-62f3f973681f'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '78d28642-f429-4164-b758-f770b3dcd705'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
       | Tomorrow    | 09:00 | 17:00 | FLU:8-16   | 5           | 1        |
@@ -150,7 +150,7 @@ Feature: Site search
 #    Prove new endpoint returns a supported service site
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
-      | 1           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+      | 1           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | 1950e7f1-356c-4017-ba62-62f3f973681f | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 | 5677     |
@@ -167,16 +167,16 @@ Feature: Site search
       | Tomorrow    | 09:00 | 17:00 | FLU:2-3    | 5           | 1        |
     And the following sessions exist for site '4aeedaf7-48a8-4071-955c-93ccbcbc925c'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | RSV:Adult  | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | FLU:5-6    | 5           | 1        |
     And the following sessions exist for site '1950e7f1-356c-4017-ba62-62f3f973681f'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '78d28642-f429-4164-b758-f770b3dcd705'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
       | Tomorrow    | 09:00 | 17:00 | FLU:8-16   | 5           | 1        |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
-      | 1           | 5000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+      | 1           | 5000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow |
     Then no sites are returned
 
   Scenario: Retrieve sites by service filter - no results if no sessions
@@ -188,7 +188,7 @@ Feature: Site search
       | 10a54cc1-c052-4c7b-bfc8-de4e5ee7e193 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
-      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+      | 3           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow |
     Then no sites are returned
 
   Scenario: Retrieve sites by service filter - no results if no sessions for service exist
@@ -200,10 +200,10 @@ Feature: Site search
       | 7627459e-15b5-44e7-9318-1b1f3ca5c414 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     And the following sessions exist for site '355ca42f-586c-4f7a-a274-4d53844e3e0c'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | RSV:Adult  | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | FLU:5-6    | 5           | 1        |
     And the following sessions exist for site '8da01caa-f589-4914-9c4c-42d7adb185ae'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID-19   | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult-19   | 5           | 1        |
     And the following sessions exist for site '96f49dd3-f0cb-4b1b-826d-d07065e14c86'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
       | Tomorrow    | 09:00 | 17:00 | FLU:2-3    | 5           | 1        |
@@ -212,7 +212,7 @@ Feature: Site search
       | Tomorrow    | 09:00 | 17:00 | COV        | 5           | 1        |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    |
-      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow |
+      | 3           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow |
     Then no sites are returned
 
   Scenario: Retrieve sites by service filter - no results if no sessions for service exist in the date range required
@@ -224,19 +224,19 @@ Feature: Site search
       | 38d0905e-9395-4954-ba72-0ae5a81ff876 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     And the following sessions exist for site 'b37000df-f261-40ce-b86b-68b31540e804'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '6092852c-b454-4249-9e12-0c0152056708'
       | Date                 | From  | Until | Services   | Slot Length | Capacity |
-      | 4 days from today    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | 4 days from today    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '96e527f3-5791-4567-a6a7-6691f5dcecb5'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '38d0905e-9395-4954-ba72-0ae5a81ff876'
       | Date                 | From  | Until | Services     | Slot Length | Capacity |
-      | 4 days from today    | 09:00 | 17:00 | COVID        | 5           | 1        |
+      | 4 days from today    | 09:00 | 17:00 | RSV:Adult        | 5           | 1        |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From              | Until             |
-      | 3           | 6000          | 0.082     | 51.5     | COVID   | 2 days from today | 3 days from today |
+      | 3           | 6000          | 0.082     | 51.5     | RSV:Adult   | 2 days from today | 3 days from today |
     Then no sites are returned
     
   Scenario: Retrieve sites by service filter - results when service sessions are on different days
@@ -248,19 +248,19 @@ Feature: Site search
       | 61da1c54-0b24-470a-8978-bb7c66a15816 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     And the following sessions exist for site '9ac67f31-cc79-46c0-b0d2-e3be1d7b8caa'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site 'a1a30efa-9506-47aa-b6a6-fa0e74c848f4'
       | Date                 | From  | Until | Services   | Slot Length | Capacity |
-      | 2 days from today    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | 2 days from today    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '45a73a10-87c1-4826-a740-e1ebc4585618'
       | Date               | From  | Until | Services   | Slot Length | Capacity |
-      | 3 days from today  | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | 3 days from today  | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '61da1c54-0b24-470a-8978-bb7c66a15816'
       | Date                 | From  | Until | Services     | Slot Length | Capacity |
-      | 4 days from today    | 09:00 | 17:00 | COVID        | 5           | 1        |
+      | 4 days from today    | 09:00 | 17:00 | RSV:Adult        | 5           | 1        |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
-      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+      | 3           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow    | 4 days from today |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | 9ac67f31-cc79-46c0-b0d2-e3be1d7b8caa | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
@@ -275,20 +275,20 @@ Feature: Site search
       | 2ba498ab-42b5-4536-9f11-796077922ce1 | Site-3 | 3 Roadside | 0113 3333333 | L12     | R3     | ICB3 | Info 3                 | accessibility/attr_one=false | -0.13086317 | 51.583479 |
       | d2f9f101-b145-42ef-93e0-ae449efb9a78 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     And the following sessions exist for site '4dbaffc9-f476-494b-817a-37dc8aa151c9'
-      | Date        | From  | Until | Services          | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | RSV:Adult, COVID  | 5           | 1        |
+      | Date        | From  | Until | Services             | Slot Length | Capacity |
+      | Tomorrow    | 09:00 | 17:00 | COVID:19, RSV:Adult  | 5           | 1        |
     And the following sessions exist for site 'b06f4be6-16e3-40be-b373-b67a47301185'
       | Date                 | From  | Until | Services        | Slot Length | Capacity |
-      | 2 days from today    | 09:00 | 17:00 | COVID, FLU:2-3  | 5           | 1        |
+      | 2 days from today    | 09:00 | 17:00 | RSV:Adult, FLU:2-3  | 5           | 1        |
     And the following sessions exist for site '2ba498ab-42b5-4536-9f11-796077922ce1'
       | Date               | From  | Until | Services           | Slot Length | Capacity |
-      | 3 days from today  | 09:00 | 17:00 | COVID, COVID:5-18  | 5           | 1        |
+      | 3 days from today  | 09:00 | 17:00 | RSV:Adult, RSV:Adult:5-18  | 5           | 1        |
     And the following sessions exist for site 'd2f9f101-b145-42ef-93e0-ae449efb9a78'
       | Date                 | From  | Until | Services        | Slot Length | Capacity |
-      | 4 days from today    | 09:00 | 17:00 | COVID, FLU:2-3  | 5           | 1        |
+      | 4 days from today    | 09:00 | 17:00 | RSV:Adult, FLU:2-3  | 5           | 1        |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
-      | 3           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+      | 3           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow    | 4 days from today |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | 4dbaffc9-f476-494b-817a-37dc8aa151c9 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
@@ -305,51 +305,51 @@ Feature: Site search
       | a5f2f93e-26e8-45ac-a09b-2485517f1d9c | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     And the following sessions exist for site '2d1780ea-73cf-43c1-ad19-1f0cb288e35b'
       | Date        | From  | Until | Services  | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 09:10 | COVID     | 10           | 1       |
+      | Tomorrow    | 09:00 | 09:10 | RSV:Adult     | 10           | 1       |
     And the following bookings have been made for site '2d1780ea-73cf-43c1-ad19-1f0cb288e35b'
       | Date        | Time  | Duration | Service | Reference   |
-      | Tomorrow    | 09:00 | 10       | COVID   | 56345-11111 |
+      | Tomorrow    | 09:00 | 10       | RSV:Adult   | 56345-11111 |
     And the following sessions exist for site '586bc02d-310a-4b02-a117-d0d104de16bb'
       | Date                 | From  | Until | Services  | Slot Length | Capacity |
-      | 2 days from today    | 09:00 | 09:10 | COVID     | 10           | 1       |
+      | 2 days from today    | 09:00 | 09:10 | RSV:Adult     | 10           | 1       |
     And the following bookings have been made for site '586bc02d-310a-4b02-a117-d0d104de16bb'
       | Date                 | Time  | Duration | Service | Reference   |
-      | 2 days from today    | 09:00 | 10       | COVID   | 56345-22222 |
+      | 2 days from today    | 09:00 | 10       | RSV:Adult   | 56345-22222 |
     And the following sessions exist for site 'a01e7aec-4721-410b-853d-1bed6ade4c3c'
       | Date               | From  | Until | Services  | Slot Length | Capacity |
-      | 3 days from today  | 09:00 | 09:10 | COVID     | 10           | 1       |
+      | 3 days from today  | 09:00 | 09:10 | RSV:Adult     | 10           | 1       |
     And the following bookings have been made for site 'a01e7aec-4721-410b-853d-1bed6ade4c3c'
       | Date                 | Time  | Duration | Service | Reference   |
-      | 3 days from today    | 09:00 | 10       | COVID   | 56345-33333 |
+      | 3 days from today    | 09:00 | 10       | RSV:Adult   | 56345-33333 |
     And the following sessions exist for site 'a5f2f93e-26e8-45ac-a09b-2485517f1d9c'
       | Date                 | From  | Until | Services | Slot Length | Capacity |
-      | 4 days from today    | 09:00 | 09:10 | COVID    | 10           | 1       |
+      | 4 days from today    | 09:00 | 09:10 | RSV:Adult    | 10           | 1       |
     And the following bookings have been made for site 'a5f2f93e-26e8-45ac-a09b-2485517f1d9c'
       | Date                 | Time  | Duration | Service | Reference   |
-      | 4 days from today    | 09:00 | 10       | COVID   | 56345-44444 |
-    When I check daily availability for site '2d1780ea-73cf-43c1-ad19-1f0cb288e35b' for 'COVID' between 'Tomorrow' and '4 days from today'
+      | 4 days from today    | 09:00 | 10       | RSV:Adult   | 56345-44444 |
+    When I check daily availability for site '2d1780ea-73cf-43c1-ad19-1f0cb288e35b' for 'RSV:Adult' between 'Tomorrow' and '4 days from today'
     Then the following availability is returned for 'Tomorrow'
       | From  | Until | Count |
       | 00:00 | 12:00 | 0     |
       | 12:00 | 00:00 | 0     |
-    When I check daily availability for site '586bc02d-310a-4b02-a117-d0d104de16bb' for 'COVID' between 'Tomorrow' and '4 days from today'
+    When I check daily availability for site '586bc02d-310a-4b02-a117-d0d104de16bb' for 'RSV:Adult' between 'Tomorrow' and '4 days from today'
     Then the following availability is returned for '2 days from today'
       | From  | Until | Count |
       | 00:00 | 12:00 | 0     |
       | 12:00 | 00:00 | 0     |
-    When I check daily availability for site 'a01e7aec-4721-410b-853d-1bed6ade4c3c' for 'COVID' between 'Tomorrow' and '4 days from today'
+    When I check daily availability for site 'a01e7aec-4721-410b-853d-1bed6ade4c3c' for 'RSV:Adult' between 'Tomorrow' and '4 days from today'
     Then the following availability is returned for '3 days from today'
       | From  | Until | Count |
       | 00:00 | 12:00 | 0     |
       | 12:00 | 00:00 | 0     |
-    When I check daily availability for site 'a5f2f93e-26e8-45ac-a09b-2485517f1d9c' for 'COVID' between 'Tomorrow' and '4 days from today'
+    When I check daily availability for site 'a5f2f93e-26e8-45ac-a09b-2485517f1d9c' for 'RSV:Adult' between 'Tomorrow' and '4 days from today'
     Then the following availability is returned for '4 days from today'
       | From  | Until | Count |
       | 00:00 | 12:00 | 0     |
       | 12:00 | 00:00 | 0     |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
-      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+      | 4           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow    | 4 days from today |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | 2d1780ea-73cf-43c1-ad19-1f0cb288e35b | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
@@ -366,51 +366,51 @@ Feature: Site search
       | aa8ceff5-d152-4687-b8ea-030df7d5efb1 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     And the following sessions exist for site '20e7b709-83c6-416b-b5d8-27d03222e1bf'
       | Date        | From  | Until | Services  | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 09:20 | COVID     | 10           | 1       |
+      | Tomorrow    | 09:00 | 09:20 | RSV:Adult     | 10           | 1       |
     And the following bookings have been made for site '20e7b709-83c6-416b-b5d8-27d03222e1bf'
       | Date        | Time  | Duration | Service | Reference   |
-      | Tomorrow    | 09:00 | 10       | COVID   | 56345-11111 |
+      | Tomorrow    | 09:00 | 10       | RSV:Adult   | 56345-11111 |
     And the following sessions exist for site '9bf7f58b-ca1a-425a-869e-7a574e183a2c'
       | Date                 | From  | Until | Services  | Slot Length | Capacity |
-      | 2 days from today    | 09:00 | 09:20 | COVID     | 10           | 1       |
+      | 2 days from today    | 09:00 | 09:20 | RSV:Adult     | 10           | 1       |
     And the following bookings have been made for site '9bf7f58b-ca1a-425a-869e-7a574e183a2c'
       | Date                 | Time  | Duration | Service | Reference   |
-      | 2 days from today    | 09:00 | 10       | COVID   | 56345-22222 |
+      | 2 days from today    | 09:00 | 10       | RSV:Adult   | 56345-22222 |
     And the following sessions exist for site '6beadf23-2c8c-4080-8be6-896c73634efb'
       | Date               | From  | Until | Services  | Slot Length | Capacity |
-      | 3 days from today  | 09:00 | 09:20 | COVID     | 10           | 1       |
+      | 3 days from today  | 09:00 | 09:20 | RSV:Adult     | 10           | 1       |
     And the following bookings have been made for site '6beadf23-2c8c-4080-8be6-896c73634efb'
       | Date                 | Time  | Duration | Service | Reference   |
-      | 3 days from today    | 09:00 | 10       | COVID   | 56345-33333 |
+      | 3 days from today    | 09:00 | 10       | RSV:Adult   | 56345-33333 |
     And the following sessions exist for site 'aa8ceff5-d152-4687-b8ea-030df7d5efb1'
       | Date                 | From  | Until | Services | Slot Length | Capacity |
-      | 4 days from today    | 09:00 | 09:20 | COVID    | 10           | 1       |
+      | 4 days from today    | 09:00 | 09:20 | RSV:Adult    | 10           | 1       |
     And the following bookings have been made for site 'aa8ceff5-d152-4687-b8ea-030df7d5efb1'
       | Date                 | Time  | Duration | Service | Reference   |
-      | 4 days from today    | 09:00 | 10       | COVID   | 56345-44444 |
-    When I check daily availability for site '20e7b709-83c6-416b-b5d8-27d03222e1bf' for 'COVID' between 'Tomorrow' and '4 days from today'
+      | 4 days from today    | 09:00 | 10       | RSV:Adult   | 56345-44444 |
+    When I check daily availability for site '20e7b709-83c6-416b-b5d8-27d03222e1bf' for 'RSV:Adult' between 'Tomorrow' and '4 days from today'
     Then the following availability is returned for 'Tomorrow'
       | From  | Until | Count |
       | 00:00 | 12:00 | 1     |
       | 12:00 | 00:00 | 0     |
-    When I check daily availability for site '9bf7f58b-ca1a-425a-869e-7a574e183a2c' for 'COVID' between 'Tomorrow' and '4 days from today'
+    When I check daily availability for site '9bf7f58b-ca1a-425a-869e-7a574e183a2c' for 'RSV:Adult' between 'Tomorrow' and '4 days from today'
     Then the following availability is returned for '2 days from today'
       | From  | Until | Count |
       | 00:00 | 12:00 | 1     |
       | 12:00 | 00:00 | 0     |
-    When I check daily availability for site '6beadf23-2c8c-4080-8be6-896c73634efb' for 'COVID' between 'Tomorrow' and '4 days from today'
+    When I check daily availability for site '6beadf23-2c8c-4080-8be6-896c73634efb' for 'RSV:Adult' between 'Tomorrow' and '4 days from today'
     Then the following availability is returned for '3 days from today'
       | From  | Until | Count |
       | 00:00 | 12:00 | 1     |
       | 12:00 | 00:00 | 0     |
-    When I check daily availability for site 'aa8ceff5-d152-4687-b8ea-030df7d5efb1' for 'COVID' between 'Tomorrow' and '4 days from today'
+    When I check daily availability for site 'aa8ceff5-d152-4687-b8ea-030df7d5efb1' for 'RSV:Adult' between 'Tomorrow' and '4 days from today'
     Then the following availability is returned for '4 days from today'
       | From  | Until | Count |
       | 00:00 | 12:00 | 1     |
       | 12:00 | 00:00 | 0     |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
-      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+      | 4           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow    | 4 days from today |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | 20e7b709-83c6-416b-b5d8-27d03222e1bf | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
@@ -427,19 +427,19 @@ Feature: Site search
       | 6f2108ef-d1b3-4479-a5dc-cf2bb68dceb9 | Site-4 | 4 Roadside | 0113 4444444 | M12     | R4     | ICB4 | Info 4                 | accessibility/attr_one=true  | 0.040992272 | 51.455788 |
     And the following orphaned bookings exist for site 'dbd61ab0-281a-4df0-b1b7-6b6793f8e119'
       | Date        | Time  | Duration | Service | Reference   |
-      | Tomorrow    | 09:00 | 10       | COVID   | 56345-11111 |
+      | Tomorrow    | 09:00 | 10       | RSV:Adult   | 56345-11111 |
     And the following orphaned bookings exist for site 'dfd0ac4e-d5ae-4c63-87c9-c84a84c9a7d1'
       | Date                 | Time  | Duration | Service | Reference   |
-      | 2 days from today    | 09:00 | 10       | COVID   | 56345-22222 |
+      | 2 days from today    | 09:00 | 10       | RSV:Adult   | 56345-22222 |
     And the following orphaned bookings exist for site '5fdbbb82-45ee-4d0c-bbe0-57d25b55512a'
       | Date                 | Time  | Duration | Service | Reference   |
-      | 3 days from today    | 09:00 | 10       | COVID   | 56345-33333 |
+      | 3 days from today    | 09:00 | 10       | RSV:Adult   | 56345-33333 |
     And the following orphaned bookings exist for site '6f2108ef-d1b3-4479-a5dc-cf2bb68dceb9'
       | Date                 | Time  | Duration | Service | Reference   |
-      | 4 days from today    | 09:00 | 10       | COVID   | 56345-44444 |
+      | 4 days from today    | 09:00 | 10       | RSV:Adult   | 56345-44444 |
     When I make the following request with service filtering
       | Max Records | Search Radius | Longitude | Latitude | Service | From        | Until             |
-      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow    | 4 days from today |
+      | 4           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow    | 4 days from today |
     Then no sites are returned
 
   Scenario: Retrieve sites by service filter - only return sites with requested access needs
@@ -451,19 +451,19 @@ Feature: Site search
       | ad8ef3bd-cf15-47a6-8510-8bffcd52bd7b | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 |
     And the following sessions exist for site '9635bee5-895c-4368-a106-2d6bc1d74087'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '7e7bc5ed-a188-499d-9eab-1566d9e3b972'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '3558dad9-d0a6-49f4-942a-c951d07eb283'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | RSV:Adult  | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | FLU:2_3    | 5           | 1        |
     And the following sessions exist for site 'ad8ef3bd-cf15-47a6-8510-8bffcd52bd7b'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     When I make the following request with service filtering and with access needs
-      | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    | AccessNeeds  |
-      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow | attr_one     |
+      | Max Records | Search Radius | Longitude | Latitude | Service     | From     | Until    | AccessNeeds  |
+      | 4           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow | attr_one     |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities              | Longitude   | Latitude  | Distance |
       | ad8ef3bd-cf15-47a6-8510-8bffcd52bd7b | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true  | 0.082750916 | 51.494056 | 662      |
@@ -478,22 +478,22 @@ Feature: Site search
       | ae579504-1545-4fd9-a358-430a649e0354 | Site-5 | 5 Roadside | 0113 1111111 | N12     | R5     | ICB5 | Info 5                 | accessibility/attr_one=true,accessibility/attr_two=true    | 0.081750916 | 51.484056 |
     And the following sessions exist for site '6997851c-0bcd-462e-b1f5-b1c02f24d37d'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site '1efc8a32-ad71-4066-821e-e535317c309a'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site 'ab746a05-345f-4c06-829b-2d5d52ec341b'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | RSV:Adult  | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | FLU:2_3    | 5           | 1        |
     And the following sessions exist for site '8eb79504-1545-4fd9-a358-430a649e0352'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
-      | Tomorrow    | 09:00 | 17:00 | COVID      | 5           | 1        |
+      | Tomorrow    | 09:00 | 17:00 | RSV:Adult      | 5           | 1        |
     And the following sessions exist for site 'ae579504-1545-4fd9-a358-430a649e0354'
       | Date        | From  | Until | Services   | Slot Length | Capacity |
       | Tomorrow    | 09:00 | 17:00 | FLU:2-3    | 5           | 1        |
     When I make the following request with service filtering and with access needs
       | Max Records | Search Radius | Longitude | Latitude | Service | From     | Until    | AccessNeeds        |
-      | 4           | 6000          | 0.082     | 51.5     | COVID   | Tomorrow | Tomorrow | attr_one,attr_two  |
+      | 4           | 6000          | 0.082     | 51.5     | RSV:Adult   | Tomorrow | Tomorrow | attr_one,attr_two  |
     Then the following sites and distances are returned
       | Site                                 | Name   | Address    | PhoneNumber  | OdsCode | Region | ICB  | InformationForCitizens | Accessibilities                                          | Longitude   | Latitude  | Distance |
       | 8eb79504-1545-4fd9-a358-430a649e0352 | Site-1 | 1 Roadside | 0113 1111111 | J12     | R1     | ICB1 | Info 1                 | accessibility/attr_one=true,accessibility/attr_two=true  | 0.082750916 | 51.494056 | 662      |

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
@@ -124,8 +124,10 @@ public class GetSitesByAreaRequestValidatorTests
         result.Errors.Should().HaveCount(0);            
     }
     
-    [Fact]
-    public void Validate_ReturnsSuccess_WhenRequestIsValid_SiteSupportService()
+    [Theory]
+    [InlineData("RSV:Adult")]
+    [InlineData("FLU:2_3")]
+    public void Validate_ReturnsSuccess_WhenRequestIsValid_SiteSupportService(string service)
     {
         var request = new GetSitesByAreaRequest(
             180,
@@ -134,7 +136,7 @@ public class GetSitesByAreaRequestValidatorTests
             50,
             ["access_need_a", "access_need_b"],
             false,
-            ["RSV:Adult"],
+            [service],
             "2025-10-02",
             "2025-10-30"
         );
@@ -163,7 +165,34 @@ public class GetSitesByAreaRequestValidatorTests
         var result = _sut.Validate(request);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
-        result.Errors.Single().ErrorMessage.Should().Be("'Services' currently only supports one service");     
+        result.Errors.Single().ErrorMessage.Should().Be("'Services' currently only supports: 'RSV:Adult or 'FLU:2_3'");     
+    }
+    
+    [Theory]
+    [InlineData("COVID:5_11")]
+    [InlineData("COVID:12_17")]
+    [InlineData("COVID:18+")]
+    [InlineData("FLU:18_64")]
+    [InlineData("FLU:65+")]
+    [InlineData("COVID_FLU:18_64")]
+    [InlineData("COVID_FLU:65+")]
+    public void Validate_ReturnsError_SiteSupportService_UnsupportedServiceProvided(string service)
+    {
+        var request = new GetSitesByAreaRequest(
+            180,
+            90,
+            6000,
+            50,
+            ["access_need_a", "access_need_b"],
+            false,
+            [service],
+            "2025-10-02",
+            "2025-10-30"
+        );
+        var result = _sut.Validate(request);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors.Single().ErrorMessage.Should().Be("'Services' currently only supports: 'RSV:Adult or 'FLU:2_3'");     
     }
     
     [Fact]


### PR DESCRIPTION
# Description

Resolved conflicts against the Online/Offline status work. This needs verifying.

### Conflicts:

tests/Nhs.Appointments.Api.Integration/Scenarios/SiteManagement/SiteSearchFeatureSteps.cs tests/Nhs.Appointments.Core.UnitTests/SiteServiceTests.cs

(cherry picked from commit 8766f47e999b0682ab9a1711d2578ad099a41f19)

To ensure NBS do not use this potentially non-performant endpoint for busier services, the new optional parameters can only be used when 'RSV:Adult' and 'Flu:2_3' are provided (separately).

Additionally, I have realised a lot of the slowness will have come from the fact that we aren't caching these expensive operations, and this can be acheived by setting a key for the specific site, service and date range (with value of true/false whether the site supports that service). This should improve performance significantly.

Have also upped the batchSize in iterations as, when coupled with the new caching, should find results much faster.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests