### PR TITLE
APPT-1235 - Ensuring the date picker contains a valid date before trying to parse to uk time

### DIFF
--- a/src/client/src/app/lib/services/timeService.test.ts
+++ b/src/client/src/app/lib/services/timeService.test.ts
@@ -17,6 +17,7 @@ import {
   DayJsType,
   RFC3339Format,
   occurInOrder,
+  stringIsValidDate,
 } from '@services/timeService';
 import { TimeComponents } from '@types';
 
@@ -508,4 +509,17 @@ describe('Time Service', () => {
       },
     );
   });
+
+  it.each([
+    ['2025-03-10', true],
+    ['2025-05-25', true],
+    ['invalid', false],
+  ])(
+    'checks if a string is a valid date',
+    (dateStringToCheck: string, expectedOutcome: boolean) => {
+      const result = stringIsValidDate(dateStringToCheck, RFC3339Format);
+
+      expect(result).toBe(expectedOutcome);
+    },
+  );
 });

--- a/src/client/src/app/lib/services/timeService.ts
+++ b/src/client/src/app/lib/services/timeService.ts
@@ -246,6 +246,10 @@ export const isValidDate = (
   return potentialDate.isValid();
 };
 
+export const stringIsValidDate = (input: string, format: string) => {
+  return dayjs(input, format, true).isValid();
+};
+
 export const getUkWeeksOfTheMonth = (ukDate: dayjs.Dayjs): dayjs.Dayjs[][] => {
   const startOfFirstWeekInMonth = startOfUkWeek(ukDate.startOf('month'));
   const endOfLastWeekInMonth = endOfUkWeek(ukDate.endOf('month'));

--- a/src/client/src/app/reports/download-report-form-schema.test.ts
+++ b/src/client/src/app/reports/download-report-form-schema.test.ts
@@ -46,6 +46,16 @@ describe('Download Report Form Schema', () => {
       '2026-02-01',
       'Select a date on or after 1 March 2025 and within 3 months from today',
     ],
+    [
+      'invalid-start-date',
+      '2025-03-31',
+      'Select a date on or after 1 March 2025 and within 3 months from today',
+    ],
+    [
+      '2025-03-01',
+      'invalid-end-date',
+      'Select a date on or after 1 March 2025 and within 3 months from today',
+    ],
   ])(
     'validates the schema',
     async (

--- a/src/client/src/app/reports/download-report-form-schema.ts
+++ b/src/client/src/app/reports/download-report-form-schema.ts
@@ -2,6 +2,7 @@ import {
   occurInOrder,
   parseToUkDatetime,
   RFC3339Format,
+  stringIsValidDate,
   ukNow,
 } from '@services/timeService';
 import * as yup from 'yup';
@@ -22,12 +23,15 @@ export const downloadReportFormSchema: yup.ObjectSchema<DownloadReportFormValues
         .test(
           'is-after-february-2025-and-not-more-than-3-months-in-the-future',
           'Select a date on or after 1 March 2025 and within 3 months from today',
-          value =>
-            occurInOrder([
+          value => {
+            if (!stringIsValidDate(value, RFC3339Format)) return false;
+
+            return occurInOrder([
               parseToUkDatetime(REPORT_DATE_EARLIEST_ALLOWED, RFC3339Format),
               parseToUkDatetime(value, RFC3339Format),
               ukNow().add(3, 'month'),
-            ]),
+            ]);
+          },
         ),
       endDate: yup
         .string()
@@ -35,12 +39,15 @@ export const downloadReportFormSchema: yup.ObjectSchema<DownloadReportFormValues
         .test(
           'is-after-february-2025-and-not-more-than-3-months-in-the-future',
           'Select a date on or after 1 March 2025 and within 3 months from today',
-          value =>
-            occurInOrder([
+          value => {
+            if (!stringIsValidDate(value, RFC3339Format)) return false;
+
+            return occurInOrder([
               parseToUkDatetime(REPORT_DATE_EARLIEST_ALLOWED, RFC3339Format),
               parseToUkDatetime(value, RFC3339Format),
               ukNow().add(3, 'month'),
-            ]),
+            ]);
+          },
         ),
     })
     .test(
@@ -49,6 +56,13 @@ export const downloadReportFormSchema: yup.ObjectSchema<DownloadReportFormValues
       values => {
         if (!values.startDate || !values.endDate) {
           return true; // Validation will fail on required fields first
+        }
+
+        if (
+          !stringIsValidDate(values.startDate, RFC3339Format) ||
+          !stringIsValidDate(values.endDate, RFC3339Format)
+        ) {
+          return true;
         }
 
         return occurInOrder([


### PR DESCRIPTION
# Description

Ensuring the string in the date picker can be parsed into a date before parsing it to UK time which was preventing an error from showing on the screen.
<img width="731" height="550" alt="image" src="https://github.com/user-attachments/assets/ccb20f0d-9286-4012-85c1-1087495caba0" />

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
