### PR TITLE
APPT-1144: Zone redundancy removed from perf-ukw

### DIFF
--- a/infrastructure/environments/perf-ukw/main.tf
+++ b/infrastructure/environments/perf-ukw/main.tf
@@ -76,7 +76,7 @@ module "mya_application_perf" {
   create_app_config                               = false
   web_app_service_sku                             = "P1v3"
   web_app_service_plan_default_worker_count       = 3
-  app_service_plan_zone_redundancy_enabled        = true
+  app_service_plan_zone_redundancy_enabled        = false
   web_app_service_plan_min_worker_count           = 1
   web_app_service_plan_max_worker_count           = 20
   web_app_service_plan_scale_out_worker_count     = 1


### PR DESCRIPTION
# Description

Removed zone redundancy from perf-ukw as it's a disaster recovery environment

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
