### PR TITLE
APPT-XXX: allow us to deploy main line build to perf and pen if we need to

### DIFF
--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -12,7 +12,7 @@ variables:
 parameters:
   - name: environments
     type: object
-    default: ["dev"]
+    default: ["dev", "pen", "perf"]
     values: ["dev", "pen", "perf"]
 
 stages:


### PR DESCRIPTION
# Description

Starting to be a real bug bear of mine, we should be able to do one build to as many environments as possible. I don't want to have to spin up another build, especially with the standing E2E commit conflicts

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
