### PR TITLE
APPT-1268 Only change the name of the Frontdoor endpoint in the perf or pen envs

### DIFF
--- a/infrastructure/resources/frontdoor.tf
+++ b/infrastructure/resources/frontdoor.tf
@@ -8,7 +8,7 @@ resource "azurerm_cdn_frontdoor_profile" "nbs_mya_frontdoor_profile" {
 
 resource "azurerm_cdn_frontdoor_endpoint" "nbs_mya_endpoint" {
   count                    = var.create_frontdoor ? 1 : 0
-  name                     = "nbs-mya-${var.environment}"
+  name                     = var.environment == "perf" || var.environment == "pen" ? "nbs-mya-${var.environment}" : "nbs-mya"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.nbs_mya_frontdoor_profile[0].id
 }
 


### PR DESCRIPTION
**(cherry picked from commit 16a77b3ad2db2b9e355051371dd5571497be6f3f)**

# Description

The name of the endpoint used by Frontdoor has changed in all environments from `nbs-mya` to `nbs-mya-{env}` to avoid conflicts when creating the perf and pen environment. This has had undesired and unintended consequences in staging/production, and needs reverting.

Instead, we will only use the environment tag in the endpoint name for the pen and perf environments.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
