### PR TITLE
APPT-XXX Skip the month view tests until we can generate the data more consistently

### DIFF
--- a/src/client/testing/tests/availability/availability.spec.ts
+++ b/src/client/testing/tests/availability/availability.spec.ts
@@ -1128,7 +1128,7 @@ test.describe.configure({ mode: 'serial' });
         test.describe(`Test in timezone: '${timezone}'`, () => {
           test.use({ timezoneId: timezone });
 
-          test('All the month page data is arranged in the week cards as expected - Oct 2025', async () => {
+          test.skip('All the month page data is arranged in the week cards as expected - Oct 2025', async () => {
             //go to a specific month page that has a daylight savings change
             await page.goto(
               `manage-your-appointments/site/${site.id}/view-availability?date=2025-10-20`,
@@ -1190,7 +1190,7 @@ test.describe.configure({ mode: 'serial' });
             }
           });
 
-          test('All the month page data is arranged in the week cards as expected - March 2026', async () => {
+          test.skip('All the month page data is arranged in the week cards as expected - March 2026', async () => {
             //go to a specific month page that has a daylight savings change
             await page.goto(
               `manage-your-appointments/site/${site.id}/view-availability?date=2026-03-01`,


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
