### PR TITLE
APPT-1274: Create warning callout

### DIFF
--- a/src/client/src/app/lib/components/nhsuk-frontend/warning-callout.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/warning-callout.tsx
@@ -22,7 +22,7 @@ const WarningCallout = ({ title = 'Important', children }: Props) => {
           {title}
         </span>
       </h3>
-      {children}
+      <p>{children}</p>
     </div>
   );
 };

--- a/src/client/src/app/lib/components/refresh-button.tsx
+++ b/src/client/src/app/lib/components/refresh-button.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { Button } from '@components/nhsuk-frontend';
+
+const RefreshButton = () => {
+  const router = useRouter();
+
+  const handleRefresh = () => {
+    router.refresh();
+  };
+
+  return (
+    <Button onClick={handleRefresh} className="nhsuk-button">
+      Refresh the page
+    </Button>
+  );
+};
+
+export default RefreshButton;

--- a/src/client/src/app/login/page.tsx
+++ b/src/client/src/app/login/page.tsx
@@ -3,6 +3,7 @@ import LogInButton from './log-in-button';
 import NhsAnonymousPage from '@components/nhs-anonymous-page';
 import { fetchFeatureFlag } from '@services/appointmentsService';
 import LogInLink from './log-in-link';
+import { WarningCallout } from '@components/nhsuk-frontend';
 
 export type LoginPageProps = {
   searchParams?: Promise<{
@@ -21,6 +22,10 @@ const Page = async ({ searchParams }: LoginPageProps) => {
 
   return (
     <NhsAnonymousPage title="Manage your appointments" originPage="login">
+      <WarningCallout title="There is a known issue with signing in">
+        When signing in, you may be shown an error. If this happens, refresh the
+        page and you will see the sign-in screen.
+      </WarningCallout>
       <p>
         You are currently not signed in. You must sign in to access this
         service.

--- a/src/client/src/app/not-found.tsx
+++ b/src/client/src/app/not-found.tsx
@@ -1,5 +1,6 @@
 import ContactUs from '@components/contact-us';
 import NhsAnonymousPage from '@components/nhs-anonymous-page';
+import RefreshButton from '@components/refresh-button';
 import Link from 'next/link';
 
 // TODO: Update this page with approved copy
@@ -14,6 +15,13 @@ export default function NotFound() {
         You may have typed or pasted the web address incorrectly.{' '}
         <Link href="/sites">Go to the start page.</Link>
       </p>
+
+      <p>
+        There is a known issue with signing in. If this happens, please try
+        refreshing the page and you will see the login screen.
+      </p>
+
+      <RefreshButton />
 
       <ContactUs />
     </NhsAnonymousPage>


### PR DESCRIPTION
# Description

Adds a warning callout to the login page to warn users about the live issue. 

Also adds a refresh button to the 404 page to prompt users to try refreshing the page. 


Fixes # (issue)
<img width="896" height="573" alt="login" src="https://github.com/user-attachments/assets/7d47a946-6cbc-4678-8f3e-38d2f875ca54" />
<img width="891" height="500" alt="notfound" src="https://github.com/user-attachments/assets/3c1d5c26-1109-486f-97be-18607a8b612e" />

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
