### PR TITLE
APPT-XXXX: Stop prefetching external links

### DIFF
--- a/src/client/src/app/eula/page.tsx
+++ b/src/client/src/app/eula/page.tsx
@@ -22,6 +22,7 @@ const Page = async () => {
         <Link
           href="https://digital.nhs.uk/services/vaccinations-national-booking-service/terms-of-use"
           target="_blank"
+          prefetch={false}
         >
           Read the full terms of use for Manage Your Appointments
         </Link>

--- a/src/client/src/app/lib/components/contact-us.tsx
+++ b/src/client/src/app/lib/components/contact-us.tsx
@@ -9,7 +9,7 @@ const ContactUs = () =>
 
     //     <p>
     //       <strong>By email</strong> <br />
-    //       <Link href="enquiries@nhsdigital.nhs.uk">
+    //       <Link href="enquiries@nhsdigital.nhs.uk" prefetch={false}>
     //         enquiries@nhsdigital.nhs.uk
     //       </Link>
     //     </p>

--- a/src/client/src/app/lib/components/nhs-footer.tsx
+++ b/src/client/src/app/lib/components/nhs-footer.tsx
@@ -13,25 +13,30 @@ const NhsFooter = ({ buildNumber }: NhsFooterProps) => {
           text: 'User guidance',
           href: 'http://www.digital.nhs.uk/services/vaccinations-national-booking-service/manage-your-appointments-guidance',
           target: '_blank',
+          internal: false,
         },
         {
           text: 'Terms of Use',
           href: 'https://digital.nhs.uk/services/vaccinations-national-booking-service/terms-of-use',
           target: '_blank',
+          internal: false,
         },
         {
           text: 'Privacy Policy',
           href: 'https://www.nhs.uk/our-policies/manage-your-appointments-privacy-policy/',
           target: '_blank',
+          internal: false,
         },
         {
           text: 'Cookies Policy',
           href: '/cookies-policy',
+          internal: true,
         },
         {
           text: 'Accessibility Statement',
           href: 'https://www.nhs.uk/our-policies/manage-your-appointment-accessibility-statement',
           target: '_blank',
+          internal: false,
         },
       ]}
     >

--- a/src/client/src/app/lib/components/nhsuk-frontend/back-link.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/back-link.tsx
@@ -24,7 +24,12 @@ const BackLink = (props: Props) => {
   if (props.renderingStrategy === 'server') {
     return (
       <div className="nhsuk-back-link">
-        <Link role="link" className="nhsuk-back-link__link" href={props.href}>
+        <Link
+          role="link"
+          className="nhsuk-back-link__link"
+          href={props.href}
+          prefetch={false}
+        >
           <LeftChevron />
           {props.text}
         </Link>

--- a/src/client/src/app/lib/components/nhsuk-frontend/footer.test.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/footer.test.tsx
@@ -5,7 +5,11 @@ import render from '@testing/render';
 describe('Footer', () => {
   it('renders', () => {
     render(
-      <Footer supportLinks={[{ text: 'Contact us', href: '/contact-us' }]} />,
+      <Footer
+        supportLinks={[
+          { text: 'Contact us', href: '/contact-us', internal: true },
+        ]}
+      />,
     );
 
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();

--- a/src/client/src/app/lib/components/nhsuk-frontend/footer.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/footer.tsx
@@ -5,6 +5,7 @@ type supportLink = {
   text: string;
   href: string;
   target?: HTMLAttributeAnchorTarget;
+  internal: boolean;
 };
 
 type FooterProps = {
@@ -35,6 +36,7 @@ const Footer = ({ supportLinks = [], children }: FooterProps) => {
                     href={link.href}
                     target={link.target ?? '_self'}
                     rel="noopener noreferrer"
+                    prefetch={link.internal}
                   >
                     {link.text}
                   </Link>

--- a/src/client/src/app/lib/components/nhsuk-frontend/summary-list.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/summary-list.tsx
@@ -77,7 +77,9 @@ const SummaryList = ({ items, borders = true }: Props) => {
                 aria-label={`${item.action.text}`}
               >
                 {item.action.renderingStrategy === 'server' ? (
-                  <Link href={item.action.href}>{item.action.text}</Link>
+                  <Link href={item.action.href} prefetch={false}>
+                    {item.action.text}
+                  </Link>
                 ) : (
                   <Link href={''} onClick={item.action.onClick} role="button">
                     {item.action.text}

--- a/src/client/src/app/lib/components/nhsuk-frontend/tabs.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/tabs.tsx
@@ -68,6 +68,7 @@ const Tabs = ({
                   }
                   window.history.pushState(null, '', `?${params.toString()}`);
                 }}
+                prefetch={false}
               >
                 {tab.props.title}
               </Link>

--- a/src/client/src/app/login/log-in-link.tsx
+++ b/src/client/src/app/login/log-in-link.tsx
@@ -15,6 +15,7 @@ const LogInLink = ({
     <Link
       href={`auth/login/${provider}?redirectUrl=${redirectUrl}`}
       aria-label={`Sign in to service with ${friendlyName}`}
+      prefetch={false}
     >
       Sign in to service with {friendlyName}
     </Link>

--- a/src/client/src/app/reports/download-report-confirmation.tsx
+++ b/src/client/src/app/reports/download-report-confirmation.tsx
@@ -39,6 +39,7 @@ const DownloadReportConfirmation = ({
             },
           }}
           download
+          prefetch={false}
         >
           <Button styleType="secondary">Export data</Button>
         </Link>

--- a/src/client/src/app/site/[site]/site-page.test.tsx
+++ b/src/client/src/app/site/[site]/site-page.test.tsx
@@ -18,7 +18,8 @@ describe('Site Page', () => {
         permissions={mockAllPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteSummaryEnabled={true}
+        siteSummaryEnabled
+        siteStatusEnabled
       />,
     );
 
@@ -34,7 +35,8 @@ describe('Site Page', () => {
         permissions={mockAllPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteSummaryEnabled={true}
+        siteSummaryEnabled
+        siteStatusEnabled
       />,
     );
 
@@ -56,7 +58,8 @@ describe('Site Page', () => {
         permissions={mockAllPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteSummaryEnabled={true}
+        siteSummaryEnabled
+        siteStatusEnabled
       />,
     );
     verifySummaryListItem('Region', mockSite.region);
@@ -77,7 +80,8 @@ describe('Site Page', () => {
         permissions={mockNonManagerPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteSummaryEnabled={true}
+        siteSummaryEnabled
+        siteStatusEnabled
       />,
     );
 
@@ -93,7 +97,8 @@ describe('Site Page', () => {
         permissions={mockNonManagerPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteSummaryEnabled={true}
+        siteSummaryEnabled
+        siteStatusEnabled
       />,
     );
 
@@ -133,7 +138,8 @@ describe('Site Page', () => {
             permission === 'reports:sitesummary' ? ['reports:sitesummary'] : []
           }
           wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-          siteSummaryEnabled={true}
+          siteSummaryEnabled
+          siteStatusEnabled
         />,
       );
 
@@ -176,7 +182,8 @@ describe('Site Page', () => {
           permissions={mockAllPermissions.filter(p => !permissions.includes(p))}
           permissionsAtAnySite={[]}
           wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-          siteSummaryEnabled={true}
+          siteSummaryEnabled
+          siteStatusEnabled
         />,
       );
 


### PR DESCRIPTION
# Description

When using the NextJS `<Link>` component, routes are prefetched by default to speed up page transitions. This behaviour can be read about here https://nextjs.org/docs/app/guides/prefetching. 

This is undesirable behaviour for external routes, such as the Okta login link, so this PR disables those. 

(it also fixes some tsc errors in some tests)

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
