### PR TITLE
APPT-1274: r2.5 - Cherry-pick warning banner and flaky tests

### DIFF
--- a/src/client/src/app/lib/components/nhsuk-frontend/warning-callout.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/warning-callout.tsx
@@ -22,7 +22,7 @@ const WarningCallout = ({ title = 'Important', children }: Props) => {
           {title}
         </span>
       </h3>
-      {children}
+      <p>{children}</p>
     </div>
   );
 };

--- a/src/client/src/app/lib/components/refresh-button.tsx
+++ b/src/client/src/app/lib/components/refresh-button.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { Button } from '@components/nhsuk-frontend';
+
+const RefreshButton = () => {
+  const router = useRouter();
+
+  const handleRefresh = () => {
+    router.refresh();
+  };
+
+  return (
+    <Button onClick={handleRefresh} className="nhsuk-button">
+      Refresh the page
+    </Button>
+  );
+};
+
+export default RefreshButton;

--- a/src/client/src/app/login/page.tsx
+++ b/src/client/src/app/login/page.tsx
@@ -3,6 +3,7 @@ import LogInButton from './log-in-button';
 import NhsAnonymousPage from '@components/nhs-anonymous-page';
 import { fetchFeatureFlag } from '@services/appointmentsService';
 import LogInLink from './log-in-link';
+import { WarningCallout } from '@components/nhsuk-frontend';
 
 export type LoginPageProps = {
   searchParams?: Promise<{
@@ -21,6 +22,10 @@ const Page = async ({ searchParams }: LoginPageProps) => {
 
   return (
     <NhsAnonymousPage title="Manage your appointments" originPage="login">
+      <WarningCallout title="There is a known issue with signing in">
+        When signing in, you may be shown an error. If this happens, refresh the
+        page and you will see the sign-in screen.
+      </WarningCallout>
       <p>
         You are currently not signed in. You must sign in to access this
         service.

--- a/src/client/src/app/not-found.tsx
+++ b/src/client/src/app/not-found.tsx
@@ -1,5 +1,6 @@
 import ContactUs from '@components/contact-us';
 import NhsAnonymousPage from '@components/nhs-anonymous-page';
+import RefreshButton from '@components/refresh-button';
 import Link from 'next/link';
 
 // TODO: Update this page with approved copy
@@ -14,6 +15,13 @@ export default function NotFound() {
         You may have typed or pasted the web address incorrectly.{' '}
         <Link href="/sites">Go to the start page.</Link>
       </p>
+
+      <p>
+        There is a known issue with signing in. If this happens, please try
+        refreshing the page and you will see the login screen.
+      </p>
+
+      <RefreshButton />
 
       <ContactUs />
     </NhsAnonymousPage>

--- a/src/client/testing/tests/availability/availability.spec.ts
+++ b/src/client/testing/tests/availability/availability.spec.ts
@@ -1128,7 +1128,7 @@ test.describe.configure({ mode: 'serial' });
         test.describe(`Test in timezone: '${timezone}'`, () => {
           test.use({ timezoneId: timezone });
 
-          test('All the month page data is arranged in the week cards as expected - Oct 2025', async () => {
+          test.skip('All the month page data is arranged in the week cards as expected - Oct 2025', async () => {
             //go to a specific month page that has a daylight savings change
             await page.goto(
               `manage-your-appointments/site/${site.id}/view-availability?date=2025-10-20`,
@@ -1190,7 +1190,7 @@ test.describe.configure({ mode: 'serial' });
             }
           });
 
-          test('All the month page data is arranged in the week cards as expected - March 2026', async () => {
+          test.skip('All the month page data is arranged in the week cards as expected - March 2026', async () => {
             //go to a specific month page that has a daylight savings change
             await page.goto(
               `manage-your-appointments/site/${site.id}/view-availability?date=2026-03-01`,

--- a/tests/Nhs.Appointments.Api.UnitTests/Audit/FunctionMiddlewareTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Audit/FunctionMiddlewareTests.cs
@@ -83,7 +83,7 @@ public class FunctionMiddlewareTests
         _functionExecutionDelegate.Verify(x => x(_functionContext.Object), Times.Once);
     }
 
-    [Theory]
+    [Theory(Skip = "Flaky test")]
     [InlineData("test@test.com", typeof(ApplyAvailabilityTemplateFunction), "RunAsync")]
     [InlineData("user@test.com", typeof(SetAvailabilityFunction), "RunAsync")]
     public async Task Invoke_SiteFromBodyInspector_RecordFunction(string user, Type functionType, string method)


### PR DESCRIPTION
# Description

Cherry picks the temporary warning banner onto the 2.5 release branch. 
Also cherry picks several required test skips.

Cherry picked commits (from main): 
- https://github.com/NHSDigital/nbs-appointments-management-service/commit/89ed57733731c443c98bfdb9fb605bf85df2b5ad
- https://github.com/NHSDigital/nbs-appointments-management-service/commit/6a09ff52b4f850ba6960b9f565feb1f63e9b4e7c
- https://github.com/NHSDigital/nbs-appointments-management-service/commit/203b69ba8dba29bb64c6106f22d68040d061129d
- 
Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of
tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format
"APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran
automatically)
- [ ] My code generates no new .NET warnings (in the future these will
be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the
terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration
tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and
Jest tests

---------

Co-authored-by: Jonny Dyson <193929923+jsed-nhs@users.noreply.github.com>