### PR TITLE
APPT-1278: Update terraform to use nhs host url for all frontdoor environments

### DIFF
--- a/infrastructure/resources/locals.tf
+++ b/infrastructure/resources/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  mya_function_app_url     = var.environment == "stag" || var.environment == "prod" ? "${var.nhs_host_url}/manage-your-appointments" : var.func_app_base_uri
-  auth_provider_return_uri = var.environment == "stag" || var.environment == "prod" ? "${var.nhs_host_url}/manage-your-appointments/api/auth-return" : "${var.func_app_base_uri}/api/auth-return"
-  client_code_exchange_uri = var.environment == "stag" || var.environment == "prod" ? "${var.nhs_host_url}/manage-your-appointments/auth/set-cookie" : "${var.web_app_base_uri}/manage-your-appointments/auth/set-cookie"
+  mya_function_app_url     = var.environment == "dev" || var.environment == "int" ? var.func_app_base_uri : "${var.nhs_host_url}/manage-your-appointments"
+  auth_provider_return_uri = var.environment == "dev" || var.environment == "int" ? "${var.func_app_base_uri}/api/auth-return" : "${var.nhs_host_url}/manage-your-appointments/api/auth-return"
+  client_code_exchange_uri = var.environment == "dev" || var.environment == "int" ? "${var.web_app_base_uri}/manage-your-appointments/auth/set-cookie" : "${var.nhs_host_url}/manage-your-appointments/auth/set-cookie"
   resource_group_name = var.environment == "pen"  ? azurerm_resource_group.nbs_mya_resource_group[0].name : var.environment == "perf" ? "${var.application}perf-rg-stag-${var.loc}" : var.environment == "dev" ? "${var.application}dev-rg-int-${var.loc}" : "${var.application}-rg-${var.environment}-${var.loc}"
 }


### PR DESCRIPTION
# Description

All front door environments (pen, perf, stag and prod) should use NHS HOST. Otherwise none Frontdoor environments (dev and int) should use the resources directly

When frontdoor is added to int we'll need to update this to just be dev

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
