### PR TITLE
APPT-767: Consecutive count bug

### DIFF
--- a/tests/Nhs.Appointments.Api.Integration/JointBookingsSerialToggleCollection.cs
+++ b/tests/Nhs.Appointments.Api.Integration/JointBookingsSerialToggleCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Nhs.Appointments.Api.Integration;
+
+[CollectionDefinition("JointBookingsSerialToggle")]
+public class JointBookingsSerialToggleCollection : ICollectionFixture<object>
+{
+}

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/JointBookings/JointBookingsAvailabilityFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/JointBookings/JointBookingsAvailabilityFeatureSteps.cs
@@ -1,0 +1,15 @@
+﻿using Nhs.Appointments.Core.Features;
+using Xunit;
+using Xunit.Gherkin.Quick;
+
+namespace Nhs.Appointments.Api.Integration.Scenarios.Availability.JointBookings;
+
+[Collection("JointBookingsSerialToggle")]
+[FeatureFile("./Scenarios/Availability/JointBookings/JointBookings_Enabled.feature")]
+public class JointBookings_Enabled()
+    : AvailabilityBaseFeatureSteps(Flags.JointBookings, true);
+
+[Collection("JointBookingsSerialToggle")]
+[FeatureFile("./Scenarios/Availability/JointBookings/JointBookings_Disabled.feature")]
+public class JointBookings_Disabled()
+    : AvailabilityBaseFeatureSteps(Flags.JointBookings, false);

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/JointBookings/JointBookings_Disabled.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/JointBookings/JointBookings_Disabled.feature
@@ -1,0 +1,43 @@
+Feature: Joint Bookings (Disabled)
+
+  Scenario: APPT-767 scenario one
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | RSV      | 5           | 1        |
+      | Tomorrow | 09:00 | 10:00 | RSV      | 5           | 1        |
+    When I check consecutive slot availability for 'RSV' between 'Tomorrow' and 'Tomorrow' with consecutive '2'
+    Then the following availability is returned for 'Tomorrow'
+      | From  | Until | Count |
+      | 09:00 | 09:05 | 2     |
+      | 09:05 | 09:10 | 2     |
+      | 09:10 | 09:15 | 2     |
+      | 09:15 | 09:20 | 2     |
+      | 09:20 | 09:25 | 2     |
+      | 09:25 | 09:30 | 2     |
+      | 09:30 | 09:35 | 2     |
+      | 09:35 | 09:40 | 2     |
+      | 09:40 | 09:45 | 2     |
+      | 09:45 | 09:50 | 2     |
+      | 09:50 | 09:55 | 2     |
+      | 09:55 | 10:00 | 2     |
+
+  Scenario: APPT-767 scenario two
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | RSV      | 5           | 1        |
+      | Tomorrow | 09:00 | 10:00 | RSV      | 5           | 2        |
+    When I check consecutive slot availability for 'RSV' between 'Tomorrow' and 'Tomorrow' with consecutive '2'
+    Then the following availability is returned for 'Tomorrow'
+      | From  | Until | Count |
+      | 09:00 | 09:05 | 3     |
+      | 09:05 | 09:10 | 3     |
+      | 09:10 | 09:15 | 3     |
+      | 09:15 | 09:20 | 3     |
+      | 09:20 | 09:25 | 3     |
+      | 09:25 | 09:30 | 3     |
+      | 09:30 | 09:35 | 3     |
+      | 09:35 | 09:40 | 3     |
+      | 09:40 | 09:45 | 3     |
+      | 09:45 | 09:50 | 3     |
+      | 09:50 | 09:55 | 3     |
+      | 09:55 | 10:00 | 3     |

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/JointBookings/JointBookings_Enabled.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/JointBookings/JointBookings_Enabled.feature
@@ -1,0 +1,43 @@
+Feature: Joint Bookings (Enabled)
+
+  Scenario: APPT-767 scenario one
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | RSV      | 5           | 1        |
+      | Tomorrow | 09:00 | 10:00 | RSV      | 5           | 1        |
+    When I check consecutive slot availability for 'RSV' between 'Tomorrow' and 'Tomorrow' with consecutive '2'
+    Then the following availability is returned for 'Tomorrow'
+      | From  | Until | Count |
+      | 09:00 | 09:05 | 2     |
+      | 09:05 | 09:10 | 2     |
+      | 09:10 | 09:15 | 2     |
+      | 09:15 | 09:20 | 2     |
+      | 09:20 | 09:25 | 2     |
+      | 09:25 | 09:30 | 2     |
+      | 09:30 | 09:35 | 2     |
+      | 09:35 | 09:40 | 2     |
+      | 09:40 | 09:45 | 2     |
+      | 09:45 | 09:50 | 2     |
+      | 09:50 | 09:55 | 2     |
+      | 09:55 | 10:00 | 0     |
+
+  Scenario: APPT-767 scenario two
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | RSV      | 5           | 1        |
+      | Tomorrow | 09:00 | 10:00 | RSV      | 5           | 2        |
+    When I check consecutive slot availability for 'RSV' between 'Tomorrow' and 'Tomorrow' with consecutive '2'
+    Then the following availability is returned for 'Tomorrow'
+      | From  | Until | Count |
+      | 09:00 | 09:05 | 3     |
+      | 09:05 | 09:10 | 3     |
+      | 09:10 | 09:15 | 3     |
+      | 09:15 | 09:20 | 3     |
+      | 09:20 | 09:25 | 3     |
+      | 09:25 | 09:30 | 3     |
+      | 09:30 | 09:35 | 3     |
+      | 09:35 | 09:40 | 3     |
+      | 09:40 | 09:45 | 3     |
+      | 09:45 | 09:50 | 3     |
+      | 09:50 | 09:55 | 3     |
+      | 09:55 | 10:00 | 0     |

--- a/tests/Nhs.Appointments.Core.UnitTests/HasConsecutiveCapacityFilterTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/HasConsecutiveCapacityFilterTests.cs
@@ -305,7 +305,7 @@ public class HasConsecutiveCapacityFilterTests
                 Capacity = 2,
                 Services = ["test"]
             },
-            new (new TimePeriod(new DateTime(2025, 1, 1, 9, 15, 0), TimeSpan.FromMinutes(5)))
+            new(new TimePeriod(new DateTime(2025, 1, 1, 9, 20, 0), TimeSpan.FromMinutes(5)))
             {
                 Capacity = 4,
                 Services = ["test"]

--- a/tests/Nhs.Appointments.Core.UnitTests/HasConsecutiveCapacityFilterTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/HasConsecutiveCapacityFilterTests.cs
@@ -1,5 +1,3 @@
-using Nhs.Appointments.Api.Availability;
-
 namespace Nhs.Appointments.Core.UnitTests;
 public class HasConsecutiveCapacityFilterTests
 {
@@ -69,13 +67,9 @@ public class HasConsecutiveCapacityFilterTests
 
         var slotsAfterFilteringByConsecutive = _sut.SessionHasConsecutiveSessions(sessions, 2);
 
-        var availabilityGrouper = new SlotAvailabilityGrouper();
-        var groupedBlocks = availabilityGrouper.GroupAvailability(slotsAfterFilteringByConsecutive);
-
-        var nineFiftyFiveBlock = groupedBlocks.Single(block => block.from.Hour is 9 & block.from.Minute is 55);
-
-        // The final block should have capacity 0, because there are no slots after it to support a consecutive booking
-        nineFiftyFiveBlock.count.Should().Be(0);
+        slotsAfterFilteringByConsecutive
+            .Single(slot => slot.From.Hour is 9 & slot.From.Minute is 55)
+            .Capacity.Should().Be(0);
     }
 
     [Fact]
@@ -125,14 +119,14 @@ public class HasConsecutiveCapacityFilterTests
             new(new TimePeriod(AtTime("09:55"), WithLength(5))) { Capacity = 2, Services = ["RSV:Adult"] }
         };
 
-        var slotsAfterFilteringByConsecutive = _sut.SessionHasConsecutiveSessions(sessions, 2);
+        var slotsAfterFilteringByConsecutive = _sut.SessionHasConsecutiveSessions(sessions, 2).ToList();
 
-        var availabilityGrouper = new SlotAvailabilityGrouper();
-        var groupedBlocks = availabilityGrouper.GroupAvailability(slotsAfterFilteringByConsecutive).ToList();
+        slotsAfterFilteringByConsecutive.Count.Should().Be(12);
+        slotsAfterFilteringByConsecutive.Count(blocks => blocks.Capacity == 3).Should().Be(11);
 
-        groupedBlocks.Count.Should().Be(12);
-        groupedBlocks.Count(blocks => blocks.count == 3).Should().Be(11);
-        groupedBlocks.Count(blocks => blocks.count == 0).Should().Be(1);
+        slotsAfterFilteringByConsecutive
+            .Single(slot => slot.From.Hour is 9 & slot.From.Minute is 55)
+            .Capacity.Should().Be(0);
     }
 
     [Fact]

--- a/tests/Nhs.Appointments.Core.UnitTests/Nhs.Appointments.Core.UnitTests.csproj
+++ b/tests/Nhs.Appointments.Core.UnitTests/Nhs.Appointments.Core.UnitTests.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\api\Nhs.Appointments.Api\Nhs.Appointments.Api.csproj"/>
     <ProjectReference Include="..\..\src\api\Nhs.Appointments.Core\Nhs.Appointments.Core.csproj" />
   </ItemGroup>
 

--- a/tests/Nhs.Appointments.Core.UnitTests/Nhs.Appointments.Core.UnitTests.csproj
+++ b/tests/Nhs.Appointments.Core.UnitTests/Nhs.Appointments.Core.UnitTests.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\api\Nhs.Appointments.Api\Nhs.Appointments.Api.csproj"/>
     <ProjectReference Include="..\..\src\api\Nhs.Appointments.Core\Nhs.Appointments.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Description

The Joint Bookings code was not correctly handling the case where two slots occur in parallel, causing the wrong capacity to be reporting and also causing the final slot in the list to incorrectly report capacity where there is in fact none.

Khurram did a fantastic job providing specific test cases for this, so I've reproduced the bug by replicating those in the unit tests.

Fixes # (APPT-767)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
