### PR TITLE
APPT-764: Improve ConfirmBookingRequest validator

### DIFF
--- a/src/api/Nhs.Appointments.Api/Validators/ConfirmBookingRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/ConfirmBookingRequestValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System.Linq;
+using FluentValidation;
 using Nhs.Appointments.Api.Models;
 
 namespace Nhs.Appointments.Api.Validators;
@@ -9,7 +10,26 @@ public class ConfirmBookingRequestValidator : AbstractValidator<ConfirmBookingRe
     public ConfirmBookingRequestValidator()
     {
         RuleFor(x => x.bookingReference)
-            .NotEmpty().WithMessage("Provide a valid booking reference");        
+            .NotEmpty().WithMessage("Provide a valid booking reference");
+        When(x => x.relatedBookings is not null, () =>
+        {
+            RuleForEach(x => x.relatedBookings)
+                .NotEmpty()
+                .WithMessage("Each related booking must be a valid booking reference")
+                .NotEqual(x => x.bookingReference)
+                .WithMessage("Related bookings must not include the primary booking reference")
+                .NotEqual(x => x.bookingToReschedule)
+                .WithMessage("Related bookings must not include the booking to reschedule");
+            RuleFor(x => x.relatedBookings)
+                .Must(x => x.Distinct().Count() == x.Length)
+                .WithMessage("Related bookings must not include the same booking more than once");
+        });
+        When(x => x.bookingToReschedule is not null, () =>
+        {
+            RuleFor(x => x.bookingToReschedule)
+                .NotEqual(x => x.bookingReference)
+                .WithMessage("The booking to reschedule cannot be the primary booking reference");
+        });
     }
 }
 

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/ConfirmBookingRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/ConfirmBookingRequestValidatorTests.cs
@@ -8,11 +8,12 @@ namespace Nhs.Appointments.Api.Tests.Validators;
 public class ConfirmBookingRequestValidatorTests
 {
     private readonly ConfirmBookingRequestValidator _sut = new();
+    private readonly ContactItem _mockContactInfo = new() { Type = ContactItemType.Email, Value = "test@tempuri.org" };
 
     [Fact]
     public void Validate_ReturnError_WhenReferenceIsBlank()
     {
-        var testRequest = new ConfirmBookingRequest(string.Empty, [new ContactItem { Type = ContactItemType.Email, Value = "test@tempuri.org" }], null, string.Empty);
+        var testRequest = new ConfirmBookingRequest(string.Empty, [_mockContactInfo], null, null);
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeFalse();
         result.Errors.Should().HaveCount(1);
@@ -22,9 +23,96 @@ public class ConfirmBookingRequestValidatorTests
     [Fact]
     public void Validate_ReturnsSuccess_WhenRequestIsValid()
     {
-        var testRequest = new ConfirmBookingRequest("my-ref", [new ContactItem{Type = ContactItemType.Email, Value = "test@tempuri.org"}], null, string.Empty);
+        var testRequest = new ConfirmBookingRequest("my-ref", [_mockContactInfo], null, null);
         var result = _sut.Validate(testRequest);
         result.IsValid.Should().BeTrue();
         result.Errors.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public void Validate_ReturnsSuccess_WhenRequestIsValidWithRelatedBookings()
+    {
+        var testRequest =
+            new ConfirmBookingRequest("my-ref", [_mockContactInfo], ["some-ref", "some-other-ref"], null);
+        var result = _sut.Validate(testRequest);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public void Validate_ReturnsSuccess_WhenRequestIsValidWithBookingToReschedule()
+    {
+        var testRequest =
+            new ConfirmBookingRequest("my-ref", [_mockContactInfo], ["some-ref", "some-other-ref"],
+                "some-ref-to-reschedule");
+        var result = _sut.Validate(testRequest);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().HaveCount(0);
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenRelatedBookingsIncludesThePrimaryBooking()
+    {
+        var testRequest = new ConfirmBookingRequest("my-ref",
+            [_mockContactInfo], ["some-ref", "my-ref", "some-other-ref"], null);
+
+        var result = _sut.Validate(testRequest);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Single().ErrorMessage.Should()
+            .Be("Related bookings must not include the primary booking reference");
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenRelatedBookingsIncludesTheBookingToReschedule()
+    {
+        var testRequest = new ConfirmBookingRequest("my-ref",
+            [_mockContactInfo], ["some-ref", "some-other-ref", "some-ref-to-reschedule"],
+            "some-ref-to-reschedule");
+
+        var result = _sut.Validate(testRequest);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Single().ErrorMessage.Should()
+            .Be("Related bookings must not include the booking to reschedule");
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenRelatedBookingsIncludesAnEmptyBooking()
+    {
+        var testRequest = new ConfirmBookingRequest("my-ref",
+            [_mockContactInfo], [""], null);
+
+        var result = _sut.Validate(testRequest);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Single().ErrorMessage.Should()
+            .Be("Each related booking must be a valid booking reference");
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenRelatedBookingsIncludesANullBooking()
+    {
+        var testRequest = new ConfirmBookingRequest("my-ref",
+            [_mockContactInfo], [""], null);
+
+        var result = _sut.Validate(testRequest);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Single().ErrorMessage.Should()
+            .Be("Each related booking must be a valid booking reference");
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenRelatedBookingsIncludesDuplicateBookings()
+    {
+        var testRequest = new ConfirmBookingRequest("my-ref",
+            [_mockContactInfo], ["some-ref", "some-ref"], null);
+
+        var result = _sut.Validate(testRequest);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Single().ErrorMessage.Should()
+            .Be("Related bookings must not include the same booking more than once");
     }
 }


### PR DESCRIPTION
# Description

The ConfirmBookingRequest validator is not currently checking that the related (joint) bookings don't include the primary booking reference. This PR adds that check in, but I've also taken the liberty of adding some others: 

- Related bookings is now checked for duplicates
- Related bookings is now checked for null / empty items
- Related bookings is now checked to not include the primary reference (actual goal of ticket)
- Booking to reschedule is now checked to not be the primary reference
- Related bookings is now checked to not include the booking to reschedule

Fixes # (APPT-764)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
