### PR TITLE
APPT-1193: Part 2 Use Highload function app for availability and move host to akamai

### DIFF
--- a/infrastructure/environments/int/main.tf
+++ b/infrastructure/environments/int/main.tf
@@ -48,6 +48,7 @@ module "mya_application_int" {
   okta_private_key_kid                            = var.OKTA_PRIVATE_KEY_KID
   okta_pem                                        = var.OKTA_PEM
   auth_provider_challenge_phrase                  = var.AUTH_PROVIDER_CHALLENGE_PHRASE
+  nhs_host_url                                    = var.NHS_HOST_URL
   func_app_base_uri                               = var.FUNC_APP_BASE_URI
   web_app_base_uri                                = var.WEB_APP_BASE_URI
   gov_notify_base_uri                             = var.GOV_NOTIFY_BASE_URI

--- a/infrastructure/environments/int/main.tf
+++ b/infrastructure/environments/int/main.tf
@@ -60,7 +60,7 @@ module "mya_application_int" {
   site_summary_first_run_date                     = var.SITE_SUMMARY_FIRST_RUN_DATE
   splunk_hec_token                                = var.SPLUNK_HEC_TOKEN
   splunk_host_url                                 = var.SPLUNK_HOST_URL
-  disable_query_availability_function             = false
+  disable_query_availability_function             = true
   create_high_load_function_app                   = false
   create_app_slot                                 = false
   create_autoscale_settings                       = false

--- a/infrastructure/environments/int/variables.tf
+++ b/infrastructure/environments/int/variables.tf
@@ -1,3 +1,8 @@
+variable "NHS_HOST_URL" {
+  type      = string
+  sensitive = false
+}
+
 variable "FUNC_APP_BASE_URI" {
   type      = string
   sensitive = false

--- a/infrastructure/resources/locals.tf
+++ b/infrastructure/resources/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  mya_function_app_url     = var.environment == "dev" || var.environment == "int" ? var.func_app_base_uri : "${var.nhs_host_url}/manage-your-appointments"
-  auth_provider_return_uri = var.environment == "dev" || var.environment == "int" ? "${var.func_app_base_uri}/api/auth-return" : "${var.nhs_host_url}/manage-your-appointments/api/auth-return"
-  client_code_exchange_uri = var.environment == "dev" || var.environment == "int" ? "${var.web_app_base_uri}/manage-your-appointments/auth/set-cookie" : "${var.nhs_host_url}/manage-your-appointments/auth/set-cookie"
+  mya_function_app_url     = var.environment == "dev" ? var.func_app_base_uri : "${var.nhs_host_url}/manage-your-appointments"
+  auth_provider_return_uri = var.environment == "dev" ? "${var.func_app_base_uri}/api/auth-return" : "${var.nhs_host_url}/manage-your-appointments/api/auth-return"
+  client_code_exchange_uri = var.environment == "dev" ? "${var.web_app_base_uri}/manage-your-appointments/auth/set-cookie" : "${var.nhs_host_url}/manage-your-appointments/auth/set-cookie"
   resource_group_name = var.environment == "pen"  ? azurerm_resource_group.nbs_mya_resource_group[0].name : var.environment == "perf" ? "${var.application}perf-rg-stag-${var.loc}" : var.environment == "dev" ? "${var.application}dev-rg-int-${var.loc}" : "${var.application}-rg-${var.environment}-${var.loc}"
 }


### PR DESCRIPTION
# Description

This PR disables the query availability on the http function app, as it should always be going to the highload function app via the Frontdoor. It also makes INT use the new Akamai URL.

Before the this can be merged -

- [x] Part 1 must be merged and deployed to INT [Part 1](https://github.com/NHSDigital/nbs-appointments-management-service/pull/938)
- [x] Akamai should be set up on INT and tested (need to contact Infra with the Frontdoor info)
- [x] Validate NHS Mail is setup with the new URL
- [x] Validate Okta is setup with the new URL
- [x] TF_VAR_NHS_HOST_URL should be added to [Libary](https://dev.azure.com/nhsuk/covid19.vaccine-booking/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=1094&path=nbs-mya-int) and set.

Part 1 failed due to naming conflict of the endpoint on the frontdoor, resolved in [Part 1.1](https://github.com/NHSDigital/nbs-appointments-management-service/pull/941)

Frontdoor created and available [here ](https://portal.azure.com/#@nhschoices.net/resource/subscriptions/2cf44e0d-817d-4596-b471-0788f8a14ab2/resourceGroups/nbs-mya-rg-int-uks/providers/Microsoft.Cdn/profiles/nbs-mya-fd-int-uks/overview)@DACA16 to create infra ticket - REQ0274933

New URLs setup - 

[e.nhswebsite-integration.nhs.uk/manage-your-appointments/login](http://e.nhswebsite-integration.nhs.uk/manage-your-appointments/login)
[f.nhswebsite-integration.nhs.uk/manage-your-appointments/login](http://f.nhswebsite-integration.nhs.uk/manage-your-appointments/login)

Ticket raised with NHS Mail - INC46617870


Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
