### PR TITLE
Appt 1193: Part 1 Create Frontdoor on INT (#938)

### DIFF
--- a/infrastructure/environments/int/main.tf
+++ b/infrastructure/environments/int/main.tf
@@ -61,10 +61,10 @@ module "mya_application_int" {
   splunk_hec_token                                = var.SPLUNK_HEC_TOKEN
   splunk_host_url                                 = var.SPLUNK_HOST_URL
   disable_query_availability_function             = false
-  create_high_load_function_app                   = false
+  create_high_load_function_app                   = true
   create_app_slot                                 = false
   create_autoscale_settings                       = false
-  create_frontdoor                                = false
+  create_frontdoor                                = true
   create_cosmos_db                                = true
   create_app_config                               = true
   web_app_service_sku                             = "B1"


### PR DESCRIPTION
**(cherry picked from commit e5aca1355478b9ec1fb153c7b51937e8bd0fa215)**

# Description

This is to create the Front door on INT. This does not mean we are using the Frontdoor or Akamai. But it allows infra to create akamai definition in INT. Part 2 of this will move INT fully over to the new Akamai URL.

It will also create the highload function app.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests