### PR TITLE
APPT-1293 - Adding missing site status label onto the site status form page

### DIFF
--- a/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.test.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.test.tsx
@@ -30,6 +30,11 @@ describe('Edit Site Status Form', () => {
     render(<EditSiteStatusForm site={mockSite} />);
 
     expect(
+      screen.queryByText(
+        'Patients can currently book appointments at this site',
+      ),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('group', { name: 'What do you want to do?' }),
     ).toBeInTheDocument();
     expect(

--- a/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.tsx
+++ b/src/client/src/app/site/[site]/details/edit-site-status/edit-site-status-form.tsx
@@ -35,6 +35,10 @@ const EditSiteStatusForm = ({ site }: { site: Site }) => {
       : 'Make site online';
   const offlineLabel =
     site.status === 'Offline' ? 'Keep site offline' : 'Take site offline';
+  const statusLabel =
+    site.status === 'Online' || undefined
+      ? 'Patients can currently book appointments at this site'
+      : 'Patients can not currently book appointments at this site';
 
   const submitForm: SubmitHandler<FormFields> = async (form: FormFields) => {
     await updateSiteStatus(site.id, form.siteStatus);
@@ -44,6 +48,7 @@ const EditSiteStatusForm = ({ site }: { site: Site }) => {
 
   return (
     <form onSubmit={handleSubmit(submitForm)}>
+      <p>{statusLabel}</p>
       <FormGroup
         legend="What do you want to do?"
         error={errors.siteStatus?.message}


### PR DESCRIPTION
# Description

Adding missing text on change site status screen

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
