### PR TITLE
Appt 1180 - New cancel all sessions and bookings in a day endpoint

### DIFF
--- a/infrastructure/resources/high_load_functions.tf
+++ b/infrastructure/resources/high_load_functions.tf
@@ -131,6 +131,7 @@ resource "azurerm_windows_function_app" "nbs_mya_high_load_func_app" {
     "AzureWebJobs.TriggerDailySitesSummary.Disabled"                       = true
     "AzureWebJobs.DailySiteSummaryAggregation.Disabled"                    = true
     "AzureWebJobs.UpdateSiteStatusFunction.Disabled"                       = true
+    "AzureWebJobs.CancelDayFunction.Disabled"                              = true
   }
 
   sticky_settings {
@@ -265,6 +266,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_high_load_func_app_preview
     "AzureWebJobs.TriggerDailySitesSummary.Disabled"                       = true
     "AzureWebJobs.DailySiteSummaryAggregation.Disabled"                    = true
     "AzureWebJobs.UpdateSiteStatusFunction.Disabled"                       = true
+    "AzureWebJobs.CancelDayFunction.Disabled"                              = true
   }
 
   identity {

--- a/infrastructure/resources/servicebus_functions.tf
+++ b/infrastructure/resources/servicebus_functions.tf
@@ -100,6 +100,7 @@ resource "azurerm_windows_function_app" "nbs_mya_service_bus_func_app" {
     "AzureWebJobs.TriggerDailySitesSummary.Disabled"                       = true
     "AzureWebJobs.DailySiteSummaryAggregation.Disabled"                    = true
     "AzureWebJobs.UpdateSiteStatusFunction.Disabled"                       = true
+    "AzureWebJobs.CancelDayFunction.Disabled"                              = true
   }
 
   sticky_settings {
@@ -211,6 +212,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_service_bus_func_app_previ
     "AzureWebJobs.TriggerDailySitesSummary.Disabled"                       = true
     "AzureWebJobs.DailySiteSummaryAggregation.Disabled"                    = true
     "AzureWebJobs.UpdateSiteStatusFunction.Disabled"                       = true
+    "AzureWebJobs.CancelDayFunction.Disabled"                              = true
   }
 
   identity {

--- a/infrastructure/resources/timer_functions.tf
+++ b/infrastructure/resources/timer_functions.tf
@@ -107,6 +107,7 @@ resource "azurerm_windows_function_app" "nbs_mya_timer_func_app" {
     "AzureWebJobs.AggregateDailySiteSummary.Disabled"                      = true
     "AzureWebJobs.TriggerDailySitesSummary.Disabled"                       = true
     "AzureWebJobs.UpdateSiteStatusFunction.Disabled"                       = true
+    "AzureWebJobs.CancelDayFunction.Disabled"                              = true
   }
 
   sticky_settings {
@@ -220,6 +221,7 @@ resource "azurerm_windows_function_app_slot" "nbs_mya_timer_func_app_preview" {
     "AzureWebJobs.AggregateDailySiteSummary.Disabled"                      = true
     "AzureWebJobs.TriggerDailySitesSummary.Disabled"                       = true
     "AzureWebJobs.UpdateSiteStatusFunction.Disabled"                       = true
+    "AzureWebJobs.CancelDayFunction.Disabled"                              = true
   }
 
   identity {

--- a/postman-collection/Appointment Service.postman_collection.json
+++ b/postman-collection/Appointment Service.postman_collection.json
@@ -1125,6 +1125,34 @@
         }
       },
       "response": []
+    },
+    {
+      "name": "cancel/day",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "ClientId",
+            "value": "{{clientId}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"site\": \"{{site}}\",\r\n    \"date\": \"2025-09-01\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}/api/day/cancel",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "day", "cancel"]
+        }
+      },
+      "response": []
     }
   ],
   "event": [

--- a/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
@@ -1,0 +1,47 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Extensions.Logging;
+using Nhs.Appointments.Api.Auth;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Core;
+using Nhs.Appointments.Core.Inspectors;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Nhs.Appointments.Api.Functions;
+
+public class CancelDayFunction(
+    IAvailabilityWriteService availabilityWriteService,
+    IValidator<CancelDayRequest> validator,
+    IUserContextProvider userContextProvider,
+    ILogger<CancelSessionFunction> logger,
+    IMetricsRecorder metricsRecorder) : BaseApiFunction<CancelDayRequest, CancelDayResponse>(validator, userContextProvider, logger, metricsRecorder)
+{
+    [OpenApiOperation(operationId: "CancelSession", tags: ["Availability"], Summary = "Cancel a session")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, "application/json", typeof(CancelDayResponse),
+        Description = "All Sessions and Bookings successfully cancelled for specified day")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, "application/json",
+        typeof(IEnumerable<ErrorMessageResponseItem>), Description = "The body of the request is invalid")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Unauthorized, "application/json",
+        typeof(ErrorMessageResponseItem), Description = "Unauthorized request to a protected API")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.Forbidden, "application/json", typeof(ErrorMessageResponseItem),
+        Description = "Request failed due to insufficient permissions")]
+    [RequiresPermission(Permissions.SetupAvailability, typeof(SiteFromBodyInspector))]
+    [Function("CancelDayFunction")]
+    public override Task<IActionResult> RunAsync([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "day/cancel")] HttpRequest req)
+    {
+        return base.RunAsync(req);
+    }
+
+    protected override async Task<ApiResult<CancelDayResponse>> HandleRequest(CancelDayRequest request, ILogger logger)
+    {
+        var (cancelledBookingCount, bookingsWithouContactDetails) = await availabilityWriteService.CancelDayAsync(request.Site, request.Date);
+
+        return Success(new CancelDayResponse(cancelledBookingCount, bookingsWithouContactDetails));
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
@@ -19,7 +19,7 @@ public class CancelDayFunction(
     IAvailabilityWriteService availabilityWriteService,
     IValidator<CancelDayRequest> validator,
     IUserContextProvider userContextProvider,
-    ILogger<CancelSessionFunction> logger,
+    ILogger<CancelDayFunction> logger,
     IMetricsRecorder metricsRecorder) : BaseApiFunction<CancelDayRequest, CancelDayResponse>(validator, userContextProvider, logger, metricsRecorder)
 {
     [OpenApiOperation(operationId: "CancelSession", tags: ["Availability"], Summary = "Cancel a session")]

--- a/src/api/Nhs.Appointments.Api/Models/CancelDayRequest.cs
+++ b/src/api/Nhs.Appointments.Api/Models/CancelDayRequest.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Nhs.Appointments.Api.Models;
+
+public record CancelDayRequest(
+    [property:JsonProperty("site", Required = Required.Always)]
+    string Site,
+    [property:JsonProperty("date", Required = Required.Always)]
+    DateOnly Date);

--- a/src/api/Nhs.Appointments.Api/Models/CancelDayResponse.cs
+++ b/src/api/Nhs.Appointments.Api/Models/CancelDayResponse.cs
@@ -1,0 +1,2 @@
+namespace Nhs.Appointments.Api.Models;
+public record CancelDayResponse(int CancelledBookingCount, int BookingsWithoutContactDetails);

--- a/src/api/Nhs.Appointments.Api/Validators/CancelDayRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/CancelDayRequestValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using Nhs.Appointments.Api.Models;
+using System;
+
+namespace Nhs.Appointments.Api.Validators;
+public class CancelDayRequestValidator : AbstractValidator<CancelDayRequest>
+{
+    public CancelDayRequestValidator(TimeProvider timeProvider)
+    {
+        RuleFor(x => x.Site)
+            .NotEmpty()
+            .WithMessage("Provide a valid site.");
+
+        RuleFor(x => x.Date)
+            .GreaterThanOrEqualTo(DateOnly.Parse(timeProvider.GetUtcNow().ToString("yyyy-MM-dd")))
+            .WithMessage("From date must be in the future.");
+    }
+}

--- a/src/api/Nhs.Appointments.Api/Validators/CancelDayRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/CancelDayRequestValidator.cs
@@ -12,7 +12,7 @@ public class CancelDayRequestValidator : AbstractValidator<CancelDayRequest>
             .WithMessage("Provide a valid site.");
 
         RuleFor(x => x.Date)
-            .GreaterThanOrEqualTo(DateOnly.Parse(timeProvider.GetUtcNow().ToString("yyyy-MM-dd")))
-            .WithMessage("From date must be in the future.");
+            .GreaterThan(DateOnly.Parse(timeProvider.GetUtcNow().ToString("yyyy-MM-dd")))
+            .WithMessage("Date must be in the future.");
     }
 }

--- a/src/api/Nhs.Appointments.Core/BookingWriteService.cs
+++ b/src/api/Nhs.Appointments.Core/BookingWriteService.cs
@@ -25,6 +25,8 @@ public interface IBookingWriteService
     Task<IEnumerable<string>> RemoveUnconfirmedProvisionalBookings();
 
     Task RecalculateAppointmentStatuses(string site, DateOnly day);
+
+    Task<(int cancelledBookingsCount, int bookingsWithoutContactDetailsCount)> CancelAllBookingsInDayAsync(string site, DateOnly day);
 }
 
 public class BookingWriteService(
@@ -121,6 +123,9 @@ public class BookingWriteService(
 
         await RecalculateAppointmentStatuses_SingleService(site, day);
     }
+
+    public async Task<(int cancelledBookingsCount, int bookingsWithoutContactDetailsCount)> CancelAllBookingsInDayAsync(string site, DateOnly day)
+        => await bookingDocumentStore.CancelAllBookingsInDay(site, day);
 
     private async Task<(bool Success, string Reference)> MakeBooking_SingleService(Booking booking)
     {

--- a/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
+++ b/src/api/Nhs.Appointments.Core/IAvailabilityStore.cs
@@ -10,4 +10,5 @@ public interface IAvailabilityStore
 
    Task<bool> SiteOffersServiceDuringPeriod(string siteId, string service,
        List<string> datesInPeriod);
+    Task CancelDayAsync(string site, DateOnly date);
 }

--- a/src/api/Nhs.Appointments.Core/IAvailabilityWriteService.cs
+++ b/src/api/Nhs.Appointments.Core/IAvailabilityWriteService.cs
@@ -7,4 +7,5 @@ public interface IAvailabilityWriteService
     Task ApplySingleDateSessionAsync(DateOnly date, string site, Session[] sessions, ApplyAvailabilityMode mode,
         string user, Session sessionToEdit = null);
     Task CancelSession(string site, DateOnly date, string from, string until, string[] services, int slotLength, int capacity);
+    Task<(int cancelledBookingsCount, int bookingsWithoutContactDetailsCount)> CancelDayAsync(string site, DateOnly date);
 }

--- a/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
@@ -17,6 +17,7 @@ public interface IBookingsDocumentStore
     Task<IEnumerable<string>> RemoveUnconfirmedProvisionalBookings();
     Task DeleteBooking(string reference, string site);
     Task<bool> UpdateAvailabilityStatus(string bookingReference, AvailabilityStatus status);
+    Task<(int cancelledBookingsCount, int bookingsWithoutContactDetailsCount)> CancelAllBookingsInDay(string site, DateOnly date);
 }
 
 public interface IRolesStore

--- a/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
@@ -121,7 +121,7 @@ public class AvailabilityDocumentStore(
         var document = await GetOrDefaultAsync(documentId, site)
             ?? throw new InvalidOperationException($"The requested Availability for site {site} could not be found on date: {date}.");
 
-        await documentStore.DeleteDocument(documentId, site);
+        await PatchAvailabilityDocument(documentId, [], site, document, false);
     }
 
     private async Task EditExistingSession(string documentId, string site, Session newSession, Session sessionToEdit)

--- a/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/AvailabilityDocumentStore.cs
@@ -115,6 +115,15 @@ public class AvailabilityDocumentStore(
         }
     }
 
+    public async Task CancelDayAsync(string site, DateOnly date)
+    {
+        var documentId = date.ToString("yyyyMMdd");
+        var document = await GetOrDefaultAsync(documentId, site)
+            ?? throw new InvalidOperationException($"The requested Availability for site {site} could not be found on date: {date}.");
+
+        await documentStore.DeleteDocument(documentId, site);
+    }
+
     private async Task EditExistingSession(string documentId, string site, Session newSession, Session sessionToEdit)
     {
         var dayDocument = await GetOrDefaultAsync(documentId, site);

--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -301,4 +301,33 @@ public class BookingCosmosDocumentStore(
         indexStore.DeleteDocument(reference, "booking_index"),
         bookingStore.DeleteDocument(reference, site)
     );
+
+    public async Task<(int cancelledBookingsCount, int bookingsWithoutContactDetailsCount)> CancelAllBookingsInDay(string site, DateOnly date)
+    {
+        using (metricsRecorder.BeginScope("CancelAllBookingsInDay"))
+        {
+            var startOfDay = date.ToDateTime(TimeOnly.MinValue);
+            var endOfDay = date.AddDays(1).ToDateTime(TimeOnly.MinValue);
+
+            var bookings = await GetInDateRangeAsync(startOfDay, endOfDay, site);
+
+            var successfulCancellations = 0;
+            var bookingsWithoutContactDetailsCount = 0;
+
+            foreach (var booking in bookings)
+            {
+                if (await UpdateStatus(booking.Reference, AppointmentStatus.Cancelled, AvailabilityStatus.Unknown, CancellationReason.CancelledBySite))
+                {
+                    successfulCancellations++;
+                }
+
+                if (booking.ContactDetails is null || booking.ContactDetails.Length == 0)
+                {
+                    bookingsWithoutContactDetailsCount++;
+                }
+            }
+
+            return (successfulCancellations, bookingsWithoutContactDetailsCount);
+        }
+    }
 }    

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/CancelDay.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/CancelDay.feature
@@ -1,0 +1,12 @@
+Feature: Cancel All Availability And Bookings On A Given Day
+
+    Scenario: Dates and sessions are returned within date range
+        Given the following sessions
+          | Date              | From  | Until | Services | Slot Length | Capacity |
+          | Tomorrow          | 09:00 | 17:00 | COVID    | 5           | 1        |
+        And the following bookings have been made
+          | Date     | Time  | Duration | Service | Reference   |
+          | Tomorrow | 09:20 | 5        | COVID   | 12345-54321 |
+        When I cancel the day 'Tomorrow'
+        Then the booking with reference '12345-54321' has been 'Cancelled'
+        And there are no sessions for 'Tomorrow'

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/CancelDayFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Availability/CancelDayFeatureSteps.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using Nhs.Appointments.Persistance.Models;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit.Gherkin.Quick;
+
+namespace Nhs.Appointments.Api.Integration.Scenarios.Availability;
+
+[FeatureFile("./Scenarios/Availability/CancelDay.feature")]
+public class CancelDayFeatureSteps : BaseFeatureSteps
+{
+    private HttpResponseMessage Response { get; set; }
+
+    [When("I cancel the day '(.+)'")]
+    public async Task CancelDay(string dateString)
+    {
+        var date = ParseNaturalLanguageDateOnly(dateString);
+        var site = GetSiteId();
+
+        var payload = new
+        {
+            site,
+            date
+        };
+        var jsonPayload = JsonSerializer.Serialize(payload);
+        var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+        Response = await Http.PostAsync("http://localhost:7071/api/day/cancel", content);
+        Response.EnsureSuccessStatusCode();
+    }
+
+    [And("there are no sessions for '(.+)'")]
+    public async Task AssertSessionNoLongerExists(string dateString)
+    {
+        var date = ParseNaturalLanguageDateOnly(dateString);
+        var documentId = date.ToString("yyyyMMdd");
+
+        var dayAvailabilityDocument = await Client.GetContainer("appts", "booking_data")
+            .ReadItemAsync<DailyAvailabilityDocument>(documentId, new PartitionKey(GetSiteId()));
+
+        dayAvailabilityDocument.Resource.Sessions.Length.Should().Be(0);
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelDayFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelDayFunctionTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Nhs.Appointments.Api.Functions;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Core;
+using System.Text;
+
+namespace Nhs.Appointments.Api.Tests.Functions;
+public class CancelDayFunctionTests
+{
+
+    private readonly Mock<ILogger<CancelDayFunction>> _logger = new();
+    private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
+    private readonly Mock<IUserContextProvider> _userContextProvider = new();
+    private readonly Mock<IValidator<CancelDayRequest>> _validator = new();
+    private readonly Mock<IAvailabilityWriteService> _availabilityWriteService = new();
+
+    private readonly CancelDayFunction _sut;
+
+    public CancelDayFunctionTests()
+    {
+        _sut = new CancelDayFunction(
+            _availabilityWriteService.Object,
+            _validator.Object,
+            _userContextProvider.Object,
+            _logger.Object,
+            _metricsRecorder.Object);
+        _validator.Setup(x => x.ValidateAsync(It.IsAny<CancelDayRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnSuccessfulResponse_WhenDayCancelled()
+    {
+        _availabilityWriteService.Setup(x => x.CancelDayAsync(It.IsAny<string>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync((5, 1));
+
+        var request = BuildRequest();
+
+        var response = await _sut.RunAsync(request) as ContentResult;
+
+        response.StatusCode.Should().Be(200);
+
+        var body = await new StringReader(response.Content).ReadToEndAsync();
+        var deserialisedResponse = JsonConvert.DeserializeObject<CancelDayResponse>(body);
+
+        deserialisedResponse.BookingsWithoutContactDetails.Should().Be(1);
+        deserialisedResponse.CancelledBookingCount.Should().Be(5);
+
+        _availabilityWriteService.Verify(x => x.CancelDayAsync(It.IsAny<string>(), It.IsAny<DateOnly>()), Times.Once);
+    }
+
+    private static HttpRequest BuildRequest()
+    {
+        var requestBody = new
+        {
+            site = Guid.NewGuid().ToString(),
+            date = new DateOnly(2025, 09, 09)
+        };
+        var body = JsonConvert.SerializeObject(requestBody);
+        var context = new DefaultHttpContext();
+        var request = context.Request;
+        request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        request.Headers.Append("Authorization", "Test 123");
+
+        return request;
+    }
+}

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/CancelDayRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/CancelDayRequestValidatorTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Moq;
+using Nhs.Appointments.Api.Models;
+using Nhs.Appointments.Api.Validators;
+
+namespace Nhs.Appointments.Api.Tests.Validators;
+public class CancelDayRequestValidatorTests
+{
+    private readonly Mock<TimeProvider> _timeProvider = new();
+    private readonly CancelDayRequestValidator _sut;
+
+    public CancelDayRequestValidatorTests()
+    {
+        _timeProvider
+            .Setup(x => x.GetUtcNow())
+            .Returns(new DateTimeOffset(DateTime.Parse("2076-12-31T00:00:00Z")));
+
+        _sut = new CancelDayRequestValidator(_timeProvider.Object);
+    }
+
+    [Fact]
+    public void ReturnsValidResult_WhenAllFieldsAreValid()
+    {
+        var request = new CancelDayRequest(Guid.NewGuid().ToString(), new DateOnly(2077, 01, 01));
+
+        var result = _sut.Validate(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ReturnsInvalid_WhenSiteIsInvalid(string siteId)
+    {
+        var request = new CancelDayRequest(siteId, new DateOnly(2077, 01, 01));
+
+        var result = _sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Count.Should().Be(1);
+        result.Errors.First().ErrorMessage.Should().Be("Provide a valid site.");
+    }
+
+    [Fact]
+    public void Validate_ReturnsError_WhenFromDateIsTodayOrEarlier()
+    {
+        var request = new CancelDayRequest(Guid.NewGuid().ToString(), new DateOnly(2076, 12, 31));
+
+        var result = _sut.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Count.Should().Be(1);
+        result.Errors.First().ErrorMessage.Should().Be("Date must be in the future.");
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/AvailabilityWriteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/AvailabilityWriteServiceTests.cs
@@ -389,4 +389,18 @@ public class AvailabilityWriteServiceTests : FeatureToggledTests
         _availabilityStore.Verify(x => x.CancelSession(site, date, It.IsAny<Session>()), Times.Once());
         _bookingsWriteService.Verify(x => x.RecalculateAppointmentStatuses(site, date), Times.Once());
     }
+
+    [Fact]
+    public async Task CancelDayAsync_CallsAvailabilityStore_AndBookingWriteService()
+    {
+        var date = new DateOnly(2025, 1, 1);
+        _bookingsWriteService.Setup(x => x.CancelAllBookingsInDayAsync(It.IsAny<string>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync((5, 1));
+
+        var result = await _sut.CancelDayAsync("TEST_SITE_123", date);
+
+        result.Should().Be((5, 1));
+
+        _bookingsWriteService.Verify(x => x.CancelAllBookingsInDayAsync("TEST_SITE_123", date), Times.Once);
+    }
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
@@ -1182,6 +1182,20 @@ namespace Nhs.Appointments.Core.UnitTests
                     MockSite, It.IsAny<DateOnly>(), It.IsAny<DateOnly>()),
                 Times.Never);
         }
+
+        [Fact]
+        public async Task CancelAllBookingsInDayAsync_CallsBookingStore()
+        {
+            var date = new DateOnly(2025, 1, 1);
+            _bookingsDocumentStore.Setup(x => x.CancelAllBookingsInDay(It.IsAny<string>(), It.IsAny<DateOnly>()))
+                .ReturnsAsync((5, 1));
+
+            var result = await _sut.CancelAllBookingsInDayAsync("TEST_SITE_123", date);
+
+            result.Should().Be((5, 1));
+
+            _bookingsDocumentStore.Verify(x => x.CancelAllBookingsInDay("TEST_SITE_123", date), Times.Once);
+        }
     }
 
     public class FakeLeaseManager : ISiteLeaseManager

--- a/tests/Nhs.Appointments.Persistance.UnitTests/AvailabilityDocumentStoreTests.cs
+++ b/tests/Nhs.Appointments.Persistance.UnitTests/AvailabilityDocumentStoreTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Azure.Cosmos;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Persistance.Models;
 
@@ -24,7 +25,7 @@ public class AvailabilityDocumentStoreTests
     }
 
     [Fact]
-    public async Task CancelDayAsync_DeletesAvailabilityForTheDay()
+    public async Task CancelDayAsync_RemovesSessionsForTheDay()
     {
         var date = new DateOnly(2025, 1, 1);
         _documentStore.Setup(x => x.GetByIdOrDefaultAsync<DailyAvailabilityDocument>(It.IsAny<string>(), It.IsAny<string>()))
@@ -48,6 +49,6 @@ public class AvailabilityDocumentStoreTests
 
         await _sut.CancelDayAsync("TEST_SITE_123", date);
 
-        _documentStore.Verify(x => x.DeleteDocument(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _documentStore.Verify(x => x.PatchDocument("TEST_SITE_123", "20250101", It.IsAny<PatchOperation[]>()), Times.Once);
     }
 }

--- a/tests/Nhs.Appointments.Persistance.UnitTests/AvailabilityDocumentStoreTests.cs
+++ b/tests/Nhs.Appointments.Persistance.UnitTests/AvailabilityDocumentStoreTests.cs
@@ -1,0 +1,53 @@
+using Nhs.Appointments.Core;
+using Nhs.Appointments.Persistance.Models;
+
+namespace Nhs.Appointments.Persistance.UnitTests;
+public class AvailabilityDocumentStoreTests
+{
+    private readonly Mock<ITypedDocumentCosmosStore<DailyAvailabilityDocument>> _documentStore = new();
+    private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
+
+    private readonly AvailabilityDocumentStore _sut;
+
+    public AvailabilityDocumentStoreTests()
+    {
+        _sut = new AvailabilityDocumentStore(_documentStore.Object, _metricsRecorder.Object);
+    }
+
+    [Fact]
+    public async Task CancelDayAsync_ThrowsException_WhenAvailabilityNotFoundAtSite()
+    {
+        _documentStore.Setup(x => x.GetByIdOrDefaultAsync<DailyAvailabilityDocument>(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(null as DailyAvailabilityDocument);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await _sut.CancelDayAsync("TEST_SITE_123", new DateOnly(2025, 1, 1)));
+    }
+
+    [Fact]
+    public async Task CancelDayAsync_DeletesAvailabilityForTheDay()
+    {
+        var date = new DateOnly(2025, 1, 1);
+        _documentStore.Setup(x => x.GetByIdOrDefaultAsync<DailyAvailabilityDocument>(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new DailyAvailabilityDocument
+            {
+                Date = date,
+                DocumentType = "availability",
+                Id =  "20250101",
+                Site = "TEST_SITE_123",
+                Sessions = [
+                    new()
+                    {
+                        Capacity = 2,
+                        From = new TimeOnly(12, 00),
+                        Services = ["RSV:Adult"],
+                        Until = new TimeOnly(18, 00),
+                        SlotLength = 5
+                    }
+                ]
+            });
+
+        await _sut.CancelDayAsync("TEST_SITE_123", date);
+
+        _documentStore.Verify(x => x.DeleteDocument(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+}


### PR DESCRIPTION
# Description

- New endpoint to cancel all sessions for a single site on a given day
- Returns the cancelled booking count as well as the bookings without contact details count as these are needed for the front end
- Tests for the above
- Updated postman collection with the new endpoint
- Disabling the new function in the appropriate resources

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [x] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [x] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
