### PR TITLE
Appt 1178 - Cancel day page which is hooked up to the new endpoint

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
@@ -19,10 +19,10 @@ public class CancelDayFunction(
     IAvailabilityWriteService availabilityWriteService,
     IValidator<CancelDayRequest> validator,
     IUserContextProvider userContextProvider,
-    ILogger<CancelDayFunction> logger,
+    ILogger<CancelSessionFunction> logger,
     IMetricsRecorder metricsRecorder) : BaseApiFunction<CancelDayRequest, CancelDayResponse>(validator, userContextProvider, logger, metricsRecorder)
 {
-    [OpenApiOperation(operationId: "CancelDay", tags: ["Availability", "Booking"], Summary = "Cancel all sessions and bookings on a given day")]
+    [OpenApiOperation(operationId: "CancelSession", tags: ["Availability"], Summary = "Cancel a session")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, "application/json", typeof(CancelDayResponse),
         Description = "All Sessions and Bookings successfully cancelled for specified day")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, "application/json",
@@ -40,8 +40,8 @@ public class CancelDayFunction(
 
     protected override async Task<ApiResult<CancelDayResponse>> HandleRequest(CancelDayRequest request, ILogger logger)
     {
-        var (cancelledBookingCount, bookingsWithoutContactDetails) = await availabilityWriteService.CancelDayAsync(request.Site, request.Date);
+        var (cancelledBookingCount, bookingsWithouContactDetails) = await availabilityWriteService.CancelDayAsync(request.Site, request.Date);
 
-        return Success(new CancelDayResponse(cancelledBookingCount, bookingsWithoutContactDetails));
+        return Success(new CancelDayResponse(cancelledBookingCount, bookingsWithouContactDetails));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
@@ -40,8 +40,8 @@ public class CancelDayFunction(
 
     protected override async Task<ApiResult<CancelDayResponse>> HandleRequest(CancelDayRequest request, ILogger logger)
     {
-        var (cancelledBookingCount, bookingsWithouContactDetails) = await availabilityWriteService.CancelDayAsync(request.Site, request.Date);
+        var (cancelledBookingCount, bookingsWithoutContactDetails) = await availabilityWriteService.CancelDayAsync(request.Site, request.Date);
 
-        return Success(new CancelDayResponse(cancelledBookingCount, bookingsWithouContactDetails));
+        return Success(new CancelDayResponse(cancelledBookingCount, bookingsWithoutContactDetails));
     }
 }

--- a/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
@@ -22,7 +22,7 @@ public class CancelDayFunction(
     ILogger<CancelDayFunction> logger,
     IMetricsRecorder metricsRecorder) : BaseApiFunction<CancelDayRequest, CancelDayResponse>(validator, userContextProvider, logger, metricsRecorder)
 {
-    [OpenApiOperation(operationId: "CancelSession", tags: ["Availability"], Summary = "Cancel a session")]
+    [OpenApiOperation(operationId: "CancelDay", tags: ["Availability", "Booking"], Summary = "Cancel all sessions and bookings on a given day")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, "application/json", typeof(CancelDayResponse),
         Description = "All Sessions and Bookings successfully cancelled for specified day")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.BadRequest, "application/json",

--- a/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelDayFunction.cs
@@ -19,7 +19,7 @@ public class CancelDayFunction(
     IAvailabilityWriteService availabilityWriteService,
     IValidator<CancelDayRequest> validator,
     IUserContextProvider userContextProvider,
-    ILogger<CancelSessionFunction> logger,
+    ILogger<CancelDayFunction> logger,
     IMetricsRecorder metricsRecorder) : BaseApiFunction<CancelDayRequest, CancelDayResponse>(validator, userContextProvider, logger, metricsRecorder)
 {
     [OpenApiOperation(operationId: "CancelSession", tags: ["Availability"], Summary = "Cancel a session")]

--- a/src/client/src/app/lib/components/session-summary-table.test.tsx
+++ b/src/client/src/app/lib/components/session-summary-table.test.tsx
@@ -196,4 +196,38 @@ describe('Session summary table', () => {
       }),
     ).toBeInTheDocument();
   });
+
+  it('it does not render unbooked column', () => {
+    mockUkNow.mockReturnValue(
+      parseToUkDatetime('2024-06-09T23:59:59', dateTimeFormat),
+    );
+
+    render(
+      <SessionSummaryTable
+        sessionSummaries={mockWeekAvailability__Summary[0].sessions}
+        showChangeSessionLink={{
+          siteId: 'TEST01',
+          ukDate: mockWeekAvailability__Summary[0].ukDate.format(RFC3339Format),
+        }}
+        clinicalServices={clinicalServices}
+        showUnbooked={false}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('columnheader', { name: 'Unbooked' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a caption when tableCaption is provided', () => {
+    render(
+      <SessionSummaryTable
+        sessionSummaries={mockWeekAvailability__Summary[0].sessions}
+        clinicalServices={clinicalServices}
+        tableCaption="My custom caption"
+      />,
+    );
+
+    expect(screen.getByText('My custom caption')).toBeInTheDocument();
+  });
 });

--- a/src/client/src/app/lib/components/session-summary-table.tsx
+++ b/src/client/src/app/lib/components/session-summary-table.tsx
@@ -16,12 +16,16 @@ type SessionSummaryTableProps = {
     ukDate: string;
   };
   clinicalServices: ClinicalService[];
+  showUnbooked?: boolean;
+  tableCaption?: string;
 };
 
 export const SessionSummaryTable = ({
   sessionSummaries,
   showChangeSessionLink,
   clinicalServices,
+  showUnbooked = true,
+  tableCaption,
 }: SessionSummaryTableProps) => {
   return (
     <Table
@@ -29,7 +33,7 @@ export const SessionSummaryTable = ({
         'Time',
         'Services',
         'Booked',
-        'Unbooked',
+        ...(showUnbooked ? ['Unbooked'] : []),
         ...(showChangeSessionLink ? ['Action'] : []),
       ]}
       rows={getSessionSummaryRows(
@@ -37,6 +41,7 @@ export const SessionSummaryTable = ({
         clinicalServices,
         showChangeSessionLink,
       )}
+      caption={tableCaption}
     />
   );
 };

--- a/src/client/src/app/lib/components/session-summary-table.tsx
+++ b/src/client/src/app/lib/components/session-summary-table.tsx
@@ -39,6 +39,7 @@ export const SessionSummaryTable = ({
       rows={getSessionSummaryRows(
         sessionSummaries,
         clinicalServices,
+        showUnbooked,
         showChangeSessionLink,
       )}
       caption={tableCaption}
@@ -49,6 +50,7 @@ export const SessionSummaryTable = ({
 export const getSessionSummaryRows = (
   sessionSummaries: SessionSummary[],
   clinicalServices: ClinicalService[],
+  showUnbooked: boolean,
   showChangeSessionLinkProps?: {
     siteId: string;
     ukDate: string;
@@ -73,10 +75,14 @@ export const getSessionSummaryRows = (
         key={`session-${sessionIndex}-service-bookings`}
         sessionSummary={sessionSummary}
       />,
-      <SessionUnbookedCell
-        key={`session-${sessionIndex}-unbooked`}
-        sessionSummary={sessionSummary}
-      />,
+      ...(showUnbooked
+        ? [
+            <SessionUnbookedCell
+              key={`session-${sessionIndex}-unbooked`}
+              sessionSummary={sessionSummary}
+            />,
+          ]
+        : ['']),
       ...(showChangeSessionLinkProps &&
       isAfterCalendarDateUk(ukStartDatetime, ukNow())
         ? [

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -31,6 +31,7 @@ import {
   UpdateSiteStatusRequest,
   CancelDayRequest,
   CancelDayResponse,
+  DaySummaryV2,
 } from '@types';
 import { appointmentsApi } from '@services/api/appointmentsApi';
 import { ApiResponse, ClinicalService } from '@types';
@@ -255,10 +256,10 @@ export async function assertAllPermissions(
   }
 }
 
-async function handleBodyResponse<T>(
+async function handleBodyResponse<T, Y = T>(
   response: ApiResponse<T>,
-  transformData = (data: T) => data,
-): Promise<T> {
+  transformData = (data: T) => data as unknown as Y,
+): Promise<Y> {
   if (!response.success) {
     if (response.httpStatusCode === 404) {
       notFound();
@@ -471,12 +472,15 @@ export const fetchWeekSummaryV2 = async (site: string, from: string) => {
   return handleBodyResponse(response);
 };
 
-export const fetchDaySummary = async (site: string, from: string) => {
+export const fetchDaySummary = async (
+  site: string,
+  from: string,
+): Promise<DaySummaryV2> => {
   const response = await appointmentsApi.get<WeekSummaryV2>(
     `day-summary?site=${site}&from=${from}`,
   );
 
-  return handleBodyResponse(response);
+  return handleBodyResponse(response, data => data.daySummaries[0]);
 };
 
 export const fetchBooking = async (reference: string, site: string) => {

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -29,6 +29,8 @@ import {
   WeekSummaryV2,
   SiteStatus,
   UpdateSiteStatusRequest,
+  CancelDayRequest,
+  CancelDayResponse,
 } from '@types';
 import { appointmentsApi } from '@services/api/appointmentsApi';
 import { ApiResponse, ClinicalService } from '@types';
@@ -602,4 +604,13 @@ export const updateSiteStatus = async (site: string, status: SiteStatus) => {
 
   handleEmptyResponse(response);
   revalidatePath(`/site/${site}/details`);
+};
+
+export const cancelDay = async (payload: CancelDayRequest) => {
+  const response = await appointmentsApi.post<CancelDayResponse>(
+    'day/cancel',
+    JSON.stringify(payload),
+  );
+
+  return handleBodyResponse(response);
 };

--- a/src/client/src/app/lib/services/appointmentsService.ts
+++ b/src/client/src/app/lib/services/appointmentsService.ts
@@ -469,6 +469,14 @@ export const fetchWeekSummaryV2 = async (site: string, from: string) => {
   return handleBodyResponse(response);
 };
 
+export const fetchDaySummary = async (site: string, from: string) => {
+  const response = await appointmentsApi.get<WeekSummaryV2>(
+    `day-summary?site=${site}&from=${from}`,
+  );
+
+  return handleBodyResponse(response);
+};
+
 export const fetchBooking = async (reference: string, site: string) => {
   const response = await appointmentsApi.get<Booking>(
     `booking/${reference}?site=${site}`,

--- a/src/client/src/app/lib/types/index.tsx
+++ b/src/client/src/app/lib/types/index.tsx
@@ -385,6 +385,16 @@ type UpdateSiteStatusRequest = {
   status: SiteStatus;
 };
 
+type CancelDayRequest = {
+  site: string;
+  date: string;
+};
+
+type CancelDayResponse = {
+  cancelledBookingCount: number;
+  bookingsWithoutContactDetails: number;
+};
+
 export type {
   ApplyAvailabilityTemplateRequest,
   ApiErrorResponse,
@@ -439,6 +449,8 @@ export type {
   ClinicalService,
   SiteStatus,
   UpdateSiteStatusRequest,
+  CancelDayRequest,
+  CancelDayResponse,
 };
 
 export { MyaError, UnauthorizedError, daysOfTheWeek, clinicalServices };

--- a/src/client/src/app/site/[site]/cancel-day/cancel-day-form.test.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancel-day-form.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CancelDayForm from './cancel-day-form';
+import { useRouter } from 'next/navigation';
+import { parseToUkDatetime } from '@services/timeService';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@services/timeService', () => ({
+  parseToUkDatetime: jest.fn(),
+}));
+
+jest.mock('@components/session-summary-table', () => ({
+  SessionSummaryTable: ({ tableCaption }: { tableCaption: string }) => (
+    <div data-testid="session-summary">{tableCaption}</div>
+  ),
+}));
+
+const mockReplace = jest.fn();
+
+const defaultProps = {
+  date: '2025-01-01',
+  siteId: 'site-123',
+  daySummary: {
+    date: '2025-01-01',
+    maximumCapacity: 10,
+    remainingCapacity: 7,
+    bookedAppointments: 3,
+    orphanedAppointments: 0,
+    cancelledAppointments: 0,
+    sessions: [],
+  },
+  clinicalServices: [],
+};
+
+describe('CancelDayForm', () => {
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ replace: mockReplace });
+    (parseToUkDatetime as jest.Mock).mockReturnValue({
+      format: () => 'Wednesday 1 January',
+    });
+    jest.clearAllMocks();
+  });
+
+  it('renders the session summary and inset text', () => {
+    render(<CancelDayForm {...defaultProps} />);
+    expect(screen.getByTestId('session-summary')).toHaveTextContent(
+      'Sessions for Wednesday 1 January',
+    );
+    expect(
+      screen.getByText(/3 booked appointments will be cancelled/i),
+    ).toBeInTheDocument();
+  });
+
+  it('initially disables Continue until a choice is made', () => {
+    render(<CancelDayForm {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
+  });
+
+  it('allows selecting No and navigates back on Continue', () => {
+    render(<CancelDayForm {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText(/no, i don't want/i));
+    const continueBtn = screen.getByRole('button', { name: /continue/i });
+    expect(continueBtn).toBeEnabled();
+    fireEvent.click(continueBtn);
+    expect(mockReplace).toHaveBeenCalledWith(
+      `/site/site-123/view-availability/week?date=2025-01-01`,
+    );
+  });
+
+  it('allows selecting Yes and shows confirmation step', () => {
+    render(<CancelDayForm {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText(/yes, i want to cancel/i));
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    expect(
+      screen.getByRole('button', { name: /cancel day/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /no, go back/i })).toHaveAttribute(
+      'href',
+      '/site/site-123/view-availability/week?date=2025-01-01',
+    );
+  });
+
+  it('calls handleCancel when clicking Cancel day', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    render(<CancelDayForm {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText(/yes, i want to cancel/i));
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel day/i }));
+    expect(consoleSpy).toHaveBeenCalledWith('Day cancelled!');
+  });
+});

--- a/src/client/src/app/site/[site]/cancel-day/cancel-day-form.test.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancel-day-form.test.tsx
@@ -13,12 +13,6 @@ jest.mock('@services/timeService', () => ({
   parseToUkDatetime: jest.fn(),
 }));
 
-jest.mock('@components/session-summary-table', () => ({
-  SessionSummaryTable: ({ tableCaption }: { tableCaption: string }) => (
-    <div data-testid="session-summary">{tableCaption}</div>
-  ),
-}));
-
 jest.mock('@services/appointmentsService');
 const mockCancelDay = jest.spyOn(appointmentsService, 'cancelDay');
 

--- a/src/client/src/app/site/[site]/cancel-day/cancel-day-form.test.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancel-day-form.test.tsx
@@ -50,24 +50,25 @@ describe('CancelDayForm', () => {
 
   it('renders the session summary and inset text', () => {
     render(<CancelDayForm {...defaultProps} />);
-    expect(screen.getByTestId('session-summary')).toHaveTextContent(
-      'Sessions for Wednesday 1 January',
-    );
     expect(
-      screen.getByText(/3 booked appointments will be cancelled/i),
+      screen.getByText('Sessions for Wednesday 1 January'),
     ).toBeInTheDocument();
-  });
-
-  it('initially disables Continue until a choice is made', () => {
-    render(<CancelDayForm {...defaultProps} />);
-    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
+    expect(
+      screen.getByText(
+        "3 booked appointments will be cancelled. We'll notify people that their appointment has been cancelled",
+      ),
+    ).toBeInTheDocument();
   });
 
   it('allows selecting No and navigates back on Continue', async () => {
     const { user } = render(<CancelDayForm {...defaultProps} />);
 
-    await user.click(screen.getByLabelText(/no, i don't want/i));
-    const continueBtn = screen.getByRole('button', { name: /continue/i });
+    await user.click(
+      screen.getByRole('radio', {
+        name: "No, I don't want to cancel the appointments",
+      }),
+    );
+    const continueBtn = screen.getByRole('button', { name: 'Continue' });
 
     expect(continueBtn).toBeEnabled();
 
@@ -80,13 +81,17 @@ describe('CancelDayForm', () => {
   it('allows selecting Yes and shows confirmation step', async () => {
     const { user } = render(<CancelDayForm {...defaultProps} />);
 
-    await user.click(screen.getByLabelText(/yes, i want to cancel/i));
-    await user.click(screen.getByRole('button', { name: /continue/i }));
+    await user.click(
+      screen.getByRole('radio', {
+        name: 'Yes, I want to cancel the appointments',
+      }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
 
     expect(
-      screen.getByRole('button', { name: /cancel day/i }),
+      screen.getByRole('button', { name: 'Cancel day' }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /no, go back/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'No, go back' })).toHaveAttribute(
       'href',
       '/site/site-123/view-availability/week?date=2025-01-01',
     );
@@ -95,9 +100,13 @@ describe('CancelDayForm', () => {
   it('calls handleCancel when clicking Cancel day', async () => {
     const { user } = render(<CancelDayForm {...defaultProps} />);
 
-    await user.click(screen.getByLabelText(/yes, i want to cancel/i));
-    await user.click(screen.getByRole('button', { name: /continue/i }));
-    await user.click(screen.getByRole('button', { name: /cancel day/i }));
+    await user.click(
+      screen.getByRole('radio', {
+        name: 'Yes, I want to cancel the appointments',
+      }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel day' }));
 
     expect(mockCancelDay).toHaveBeenCalled();
   });

--- a/src/client/src/app/site/[site]/cancel-day/cancel-day-form.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancel-day-form.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  InsetText,
+  FormGroup,
+  RadioGroup,
+  Radio,
+  ButtonGroup,
+  Button,
+} from '@components/nhsuk-frontend';
+import { SessionSummaryTable } from '@components/session-summary-table';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { parseToUkDatetime } from '@services/timeService';
+import { DaySummaryV2, ClinicalService } from '@types';
+
+type Props = {
+  date: string;
+  siteId: string;
+  daySummary: DaySummaryV2;
+  clinicalServices: ClinicalService[];
+};
+
+export default function CancelDayForm({
+  date,
+  siteId,
+  daySummary,
+  clinicalServices,
+}: Props) {
+  const { replace } = useRouter();
+  const parsedDate = parseToUkDatetime(date);
+
+  // ✅ State to track yes/no radio
+  const [cancelChoice, setCancelChoice] = useState<boolean | undefined>(
+    undefined,
+  );
+
+  // ✅ State to track when user clicks "Continue"
+  const [confirmStep, setConfirmStep] = useState(false);
+
+  const handleContinue = () => {
+    if (cancelChoice === true) {
+      setConfirmStep(true); // show cancel day button
+    } else {
+      replace(`/site/${siteId}/view-availability/week?date=${date}`);
+    }
+  };
+
+  const handleCancel = () => {
+    // TODO: API call to cancel the day
+    console.log('Day cancelled!');
+  };
+
+  return (
+    <>
+      <SessionSummaryTable
+        sessionSummaries={daySummary.sessions}
+        clinicalServices={clinicalServices}
+        showUnbooked={false}
+        tableCaption={`Sessions for ${parsedDate.format('dddd D MMMM')}`}
+      />
+      <InsetText>
+        {daySummary.bookedAppointments} booked appointments will be cancelled.
+        We'll notify people that their appointment has been cancelled
+      </InsetText>
+
+      {!confirmStep ? (
+        <form onSubmit={e => e.preventDefault()}>
+          <FormGroup
+            legend="Are you sure you want to cancel this day?"
+            error=""
+          >
+            <RadioGroup>
+              <Radio
+                label="Yes, I want to cancel the appointments"
+                hint="Cancel day"
+                id="yes"
+                value="true"
+                checked={cancelChoice === true}
+                onChange={() => setCancelChoice(true)}
+              />
+              <Radio
+                label="No, I don't want to cancel the appointments"
+                hint="I want to keep my day, do not cancel"
+                id="no"
+                value="false"
+                checked={cancelChoice === false}
+                onChange={() => setCancelChoice(false)}
+              />
+            </RadioGroup>
+          </FormGroup>
+          <ButtonGroup>
+            <Button
+              type="button"
+              onClick={handleContinue}
+              disabled={cancelChoice === undefined}
+            >
+              Continue
+            </Button>
+          </ButtonGroup>
+        </form>
+      ) : (
+        <FormGroup legend="Are you sure you want to cancel this day?" error="">
+          <>
+            <ButtonGroup>
+              <Button type="button" styleType="warning" onClick={handleCancel}>
+                Cancel day
+              </Button>
+            </ButtonGroup>
+            <Link
+              href={`/site/${siteId}/view-availability/week?date=${date}`}
+              className="nhsuk-link"
+            >
+              No, go back
+            </Link>
+          </>
+        </FormGroup>
+      )}
+    </>
+  );
+}

--- a/src/client/src/app/site/[site]/cancel-day/cancel-day-form.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancel-day-form.tsx
@@ -12,8 +12,9 @@ import {
 import { SessionSummaryTable } from '@components/session-summary-table';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { parseToUkDatetime } from '@services/timeService';
-import { DaySummaryV2, ClinicalService } from '@types';
+import { parseToUkDatetime, RFC3339Format } from '@services/timeService';
+import { DaySummaryV2, ClinicalService, CancelDayRequest } from '@types';
+import { cancelDay } from '@services/appointmentsService';
 
 type Props = {
   date: string;
@@ -47,9 +48,14 @@ export default function CancelDayForm({
     }
   };
 
-  const handleCancel = () => {
-    // TODO: API call to cancel the day
-    console.log('Day cancelled!');
+  const handleCancel = async () => {
+    const payload: CancelDayRequest = {
+      site: siteId,
+      date: parsedDate.format(RFC3339Format),
+    };
+
+    await cancelDay(payload);
+    // TODO: APPT-1179 - use the response to the above & link to new page
   };
 
   return (

--- a/src/client/src/app/site/[site]/cancel-day/cancel-day-form.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancel-day-form.tsx
@@ -38,7 +38,6 @@ const CancelDayForm = ({
   const {
     register,
     handleSubmit,
-    watch,
     formState: { isSubmitting, isSubmitSuccessful, errors },
   } = useForm<FormFields>();
 
@@ -47,7 +46,6 @@ const CancelDayForm = ({
 
   // ✅ State to track when user clicks "Continue"
   const [confirmStep, setConfirmStep] = useState(false);
-  const choice = watch('cancelChoice');
 
   const handleContinue = (data: FormFields) => {
     if (data.cancelChoice === 'true') {
@@ -111,11 +109,7 @@ const CancelDayForm = ({
           {isSubmitting || isSubmitSuccessful ? (
             <SmallSpinnerWithText text="Working..." />
           ) : (
-            <Button
-              type="submit"
-              styleType="primary"
-              disabled={choice === undefined}
-            >
+            <Button type="submit" styleType="primary">
               Continue
             </Button>
           )}

--- a/src/client/src/app/site/[site]/cancel-day/page.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/page.tsx
@@ -1,9 +1,54 @@
 import NhsPage from '@components/nhs-page';
+import { notFound } from 'next/navigation';
+import {
+  fetchSite,
+  fetchDaySummary,
+  fetchClinicalServices,
+} from '@services/appointmentsService';
+import { parseToUkDatetime } from '@services/timeService';
+import CancelDayForm from './cancel-day-form';
+import { NavigationByHrefProps } from '@components/nhsuk-frontend/back-link';
 
-const Page = async () => {
+type PageProps = {
+  searchParams?: Promise<{
+    date: string;
+  }>;
+  params: Promise<{
+    site: string;
+  }>;
+};
+
+const Page = async ({ searchParams, params }: PageProps) => {
+  const { site: siteFromPath } = { ...(await params) };
+  const { date } = { ...(await searchParams) };
+
+  if (!date) return notFound();
+
+  const [daySummary, site, clinicalServices] = await Promise.all([
+    fetchDaySummary(siteFromPath, date),
+    fetchSite(siteFromPath),
+    fetchClinicalServices(),
+  ]);
+  const parsedDate = parseToUkDatetime(date);
+  const backLink: NavigationByHrefProps = {
+    renderingStrategy: 'server',
+    href: `/site/${site.id}/view-availability/week?date=${date}`,
+    text: 'Back',
+  };
+
   return (
-    <NhsPage title="Cancel [Date]" caption="Site Name" originPage="cancel-day">
-      <div>Cancel Day Page</div>
+    <NhsPage
+      title={`Cancel ${parsedDate.format('dddd D MMMM')}`}
+      caption={site.name}
+      originPage="cancel-day"
+      backLink={backLink}
+    >
+      <CancelDayForm
+        date={date}
+        siteId={site.id}
+        daySummary={daySummary.daySummaries[0]}
+        clinicalServices={clinicalServices}
+      />
     </NhsPage>
   );
 };

--- a/src/client/src/app/site/[site]/cancel-day/page.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/page.tsx
@@ -4,6 +4,8 @@ import {
   fetchSite,
   fetchDaySummary,
   fetchClinicalServices,
+  assertPermission,
+  assertFeatureEnabled,
 } from '@services/appointmentsService';
 import { parseToUkDatetime } from '@services/timeService';
 import CancelDayForm from './cancel-day-form';
@@ -22,6 +24,9 @@ const Page = async ({ searchParams, params }: PageProps) => {
   const { site: siteFromPath } = { ...(await params) };
   const { date } = { ...(await searchParams) };
 
+  await assertPermission(siteFromPath, 'availability:setup');
+  await assertFeatureEnabled('CancelDay');
+
   if (!date) return notFound();
 
   const [daySummary, site, clinicalServices] = await Promise.all([
@@ -29,6 +34,7 @@ const Page = async ({ searchParams, params }: PageProps) => {
     fetchSite(siteFromPath),
     fetchClinicalServices(),
   ]);
+
   const parsedDate = parseToUkDatetime(date);
   const backLink: NavigationByHrefProps = {
     renderingStrategy: 'server',
@@ -46,7 +52,7 @@ const Page = async ({ searchParams, params }: PageProps) => {
       <CancelDayForm
         date={date}
         siteId={site.id}
-        daySummary={daySummary.daySummaries[0]}
+        daySummary={daySummary}
         clinicalServices={clinicalServices}
       />
     </NhsPage>

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
@@ -7,11 +7,13 @@ import {
   isFutureCalendarDateUk,
   parseToUkDatetime,
   ukNow,
+  RFC3339Format,
 } from '@services/timeService';
 import { clinicalServices } from '@types';
 import { cookies } from 'next/headers';
 import { fetchFeatureFlag } from '@services/appointmentsService';
 import { FeatureFlag } from '@types';
+
 jest.mock('@services/timeService', () => {
   const originalModule = jest.requireActual('@services/timeService');
   return {
@@ -344,7 +346,7 @@ describe('Day Summary Card', () => {
       ).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'Cancel day' })).toHaveAttribute(
         'href',
-        '/site/mock-site/cancel-day',
+        `/site/mock-site/cancel-day?date=${mockDaySummaries[0].ukDate.format(RFC3339Format)}`,
       );
     });
 
@@ -404,7 +406,7 @@ describe('Day Summary Card', () => {
       ).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'Cancel day' })).toHaveAttribute(
         'href',
-        '/site/mock-site/cancel-day',
+        `/site/mock-site/cancel-day?date=${mockDaySummaries[0].ukDate.format(RFC3339Format)}`,
       );
     });
   });

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
@@ -73,7 +73,10 @@ export const DaySummaryCard = ({
 
   const futureCancelDayLink =
     cancelDayFlag && isFutureCalendarDate ? (
-      <Link className="nhsuk-link" href={`/site/${siteId}/cancel-day`}>
+      <Link
+        className="nhsuk-link"
+        href={`/site/${siteId}/cancel-day?date=${ukDate.format(RFC3339Format)}`}
+      >
         Cancel day
       </Link>
     ) : null;


### PR DESCRIPTION
# Description

This also includes the front end additions for APPT-1176

- Adding content to the cancel a day page
- Hooking it up to the new GetDaySummary and CancelDay endpoints
- Unit tests
- E2e tests will come later as further screens in the cancel day journey are yet to be developed

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
