### PR TITLE
APPT-1319: enabling Site Status feature flag

### DIFF
--- a/features/dev.feature.flags.json
+++ b/features/dev.feature.flags.json
@@ -4,7 +4,7 @@
     "TestFeatureEnabled": true,
     "JointBookings": false,
     "SiteSummaryReport": true,
-    "SiteStatus": false,
+    "SiteStatus": true,
     "CancelDay": false,
     "TestFeaturePercentageEnabled": {
       "EnabledFor": [

--- a/features/int.feature.flags.json
+++ b/features/int.feature.flags.json
@@ -3,7 +3,7 @@
     "OktaEnabled": true,
     "JointBookings": false,
     "SiteSummaryReport": true,
-    "SiteStatus": false,
+    "SiteStatus": true,
     "CancelDay": false
   }
 }

--- a/features/pen.feature.flags.json
+++ b/features/pen.feature.flags.json
@@ -4,7 +4,7 @@
     "JointBookings": false,
     "BulkImport": true,
     "SiteSummaryReport": true,
-    "SiteStatus": false,
+    "SiteStatus": true,
     "CancelDay": false
   }
 }

--- a/features/perf.feature.flags.json
+++ b/features/perf.feature.flags.json
@@ -4,7 +4,7 @@
     "JointBookings": false,
     "BulkImport": true,
     "SiteSummaryReport": true,
-    "SiteStatus": false,
+    "SiteStatus": true,
     "CancelDay": false
   }
 }

--- a/features/prod.feature.flags.json
+++ b/features/prod.feature.flags.json
@@ -3,7 +3,7 @@
     "OktaEnabled": true,
     "JointBookings": false,
     "SiteSummaryReport": true,
-    "SiteStatus": false,
+    "SiteStatus": true,
     "CancelDay": false
   }
 }

--- a/features/stag.feature.flags.json
+++ b/features/stag.feature.flags.json
@@ -3,7 +3,7 @@
     "OktaEnabled": true,
     "JointBookings": false,
     "SiteSummaryReport": true,
-    "SiteStatus": false,
+    "SiteStatus": true,
     "CancelDay": false
   }
 }


### PR DESCRIPTION
# Description

Enables the SiteStatus feature flag across all environments

# Checklist:

- [ - ] My work is behind a feature toggle (if appropriate)
- [ - ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ YES ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [  - ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ - ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ - ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ - ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ - ] If I've made UI changes, I've added appropriate Playwright and Jest tests
