### PR TITLE
Appt 1319: cherry pick to release 2.5

### DIFF
--- a/features/dev.feature.flags.json
+++ b/features/dev.feature.flags.json
@@ -5,7 +5,7 @@
     "JointBookings": false,
     "MultipleServices": true,
     "SiteSummaryReport": true,
-    "SiteStatus": false,
+    "SiteStatus": true,
     "TestFeaturePercentageEnabled": {
       "EnabledFor": [
         {

--- a/features/int.feature.flags.json
+++ b/features/int.feature.flags.json
@@ -4,6 +4,6 @@
     "JointBookings": false,
     "MultipleServices": true,
     "SiteSummaryReport": true,
-    "SiteStatus": false
+    "SiteStatus": true
   }
 }

--- a/features/pen.feature.flags.json
+++ b/features/pen.feature.flags.json
@@ -5,6 +5,6 @@
     "BulkImport": true,
     "MultipleServices": true,
     "SiteSummaryReport": true,
-    "SiteStatus": false
+    "SiteStatus": true
   }
 }

--- a/features/perf.feature.flags.json
+++ b/features/perf.feature.flags.json
@@ -5,6 +5,6 @@
     "BulkImport": true,
     "MultipleServices": true,
     "SiteSummaryReport": true,
-    "SiteStatus": false
+    "SiteStatus": true
   }
 }

--- a/features/prod.feature.flags.json
+++ b/features/prod.feature.flags.json
@@ -4,6 +4,6 @@
     "JointBookings": false,
     "MultipleServices": true,
     "SiteSummaryReport": true,
-    "SiteStatus": false
+    "SiteStatus": true
   }
 }

--- a/features/stag.feature.flags.json
+++ b/features/stag.feature.flags.json
@@ -4,6 +4,6 @@
     "JointBookings": false,
     "MultipleServices": true,
     "SiteSummaryReport": true,
-    "SiteStatus": false
+    "SiteStatus": true
   }
 }


### PR DESCRIPTION
**(cherry picked from commit a18d47a68818331783c161b3b92adf7169afe18f)**

Enable Site Status filter on all environments

Fixes # (issue)

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
