### PR TITLE
APPT-1259 Make release pipeline INT dependency optional.

### DIFF
--- a/azure-pipelines-hotfix.yml
+++ b/azure-pipelines-hotfix.yml
@@ -34,4 +34,4 @@ stages:
           resourceGroup: nbs-mya-rg-${{env}}-uks
           serviceConnectionName: nbs-mya-rg-${{env}}
           buildNumber: "$(Build.BuildNumber)"
-          isHotfix: true
+          ignoreIntDeployDependency: true

--- a/azure-pipelines-main.yml
+++ b/azure-pipelines-main.yml
@@ -44,4 +44,4 @@ stages:
             resourceGroup: nbs-mya-rg-${{env}}-uks
             serviceConnectionName: nbs-mya-rg-${{env}}
           buildNumber: "$(Build.BuildNumber)"
-          isHotfix: false
+          ignoreIntDeployDependency: false

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -14,6 +14,9 @@ parameters:
     type: object
     default: ["int", "stag", "prod"]
     values: ["int", "stag", "prod", "pen", "perf"]
+  - name: ignoreIntDeployDependency
+    type: boolean
+    default: false
 
 stages:
   - template: scripts/pipeline-templates/build.yml
@@ -41,4 +44,4 @@ stages:
             resourceGroup: nbs-mya-rg-${{env}}-uks
             serviceConnectionName: nbs-mya-rg-${{env}}
           buildNumber: "$(Build.BuildNumber)"
-          isHotfix: false
+          ignoreIntDeployDependency: ${{ parameters.ignoreIntDeployDependency }}

--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -22,7 +22,7 @@ parameters:
     type: string
   - name: buildNumber
     type: string
-  - name: isHotfix
+  - name: ignoreIntDeployDependency
     type: boolean
 
 stages:
@@ -30,7 +30,7 @@ stages:
     displayName: Deploy ${{parameters.env}}
     dependsOn:
       - Build
-      - ${{ if and(eq(parameters.env, 'stag'), not(parameters.isHotfix)) }}:
+      - ${{ if and(eq(parameters.env, 'stag'), not(parameters.ignoreIntDeployDependency)) }}:
           - DeployInt
       - ${{ if eq(parameters.env, 'prod') }}:
           - DeployStag


### PR DESCRIPTION
# Description

Rename isHotfix -> ignoreIntDeployDependency and make it an optional param in the release pipeline alone. Defaulted to false. Can be overridden to be true if required in release pipeline for updated releases (due to cherry-picked hotfixes) that need deploying straight to Stag without Int (as Int has moved on since...)

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
