### PR TITLE
APPT-XXX: Improve handling of invalid requests in GetAuthToken

### DIFF
--- a/src/client/src/app/auth/set-cookie/route.ts
+++ b/src/client/src/app/auth/set-cookie/route.ts
@@ -13,11 +13,11 @@ export async function GET(request: NextRequest) {
   const provider = request.nextUrl.searchParams.get('provider');
   const cookieStore = await cookies();
 
-  if (code === null) {
+  if (code === null || code === '') {
     throw Error('No code found in request');
   }
 
-  if (provider === null) {
+  if (provider === null || provider === '') {
     throw Error('No provider found in request');
   }
 


### PR DESCRIPTION
# Description

We've seen some errors thrown from the `GetAuthTokenFunction` when it has been invoked with a correct query string parameter but no request body. 

Rather than mask this error, we should return a `BadRequest` object instead to correctly report that this is an error on the caller's behalf, not an issue in our service.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
