### PR TITLE
APPT-XXX: Include int in the envs we deploy high load functions too

### DIFF
--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -278,7 +278,7 @@ stages:
           - DeployHttpFunctionApp
           - DeployServiceBusFunctionApp
           - DeployTimerFunctionApp
-          - ${{ if in(parameters.env, 'stag', 'pen', 'perf', 'prod') }}:
+          - ${{ if in(parameters.env, 'int', 'stag', 'pen', 'perf', 'prod') }}:
               - DeployHighLoadFunctionApp
         variables:
           environment: ${{parameters.env}}


### PR DESCRIPTION
# Description

We've enabled the high load function app on int, but forgotten to include it in the deploy step of the pipeline.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
