### PR TITLE
APPT-XXX: Include int in the envs we deploy high load functions too

### DIFF
--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -278,7 +278,7 @@ stages:
           - DeployHttpFunctionApp
           - DeployServiceBusFunctionApp
           - DeployTimerFunctionApp
-          - ${{ if in(parameters.env, 'stag', 'pen', 'perf', 'prod') }}:
+          - ${{ if in(parameters.env, 'int', 'stag', 'pen', 'perf', 'prod') }}:
               - DeployHighLoadFunctionApp
         variables:
           environment: ${{parameters.env}}


### PR DESCRIPTION
# Description

We've enabled the high load function app on int, but forgotten to include it in the deploy step of the pipeline.
(cherry picked from commit 71b0e354c4178332db61344c5da6544d2773c6b2)
