### PR TITLE
APPT-XXX: Deploy the high load funcs to int

### DIFF
--- a/scripts/pipeline-templates/deploy.yml
+++ b/scripts/pipeline-templates/deploy.yml
@@ -203,7 +203,7 @@ stages:
                 slotName: "preview"
       - job: DeployHighLoadFunctionApp
         dependsOn: ApplyTerraform
-        condition: and(succeeded(), ${{ in(parameters.env, 'stag', 'pen', 'perf', 'prod') }})
+        condition: and(succeeded(), ${{ in(parameters.env, 'int', 'stag', 'pen', 'perf', 'prod') }})
         displayName: "Deploy high load function app"
         steps:
           - checkout: none


### PR DESCRIPTION
# Description

We now create the high load functions in INT but forgot to actually deploy them in the pipeline.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
