### PR TITLE
Appt 1282 - Change session start time validation

### DIFF
--- a/src/client/src/app/lib/services/timeService.ts
+++ b/src/client/src/app/lib/services/timeService.ts
@@ -388,7 +388,7 @@ export const getNearestAlignedTimes = (
   return [floor, ceil];
 };
 
-// Checks if the session start time is divisible by the slot length
+// Checks if the new session length is divisible by the slot length
 export const isValidStartTime = (
   sesionStart: Dayjs,
   sessionEnd: Dayjs,

--- a/src/client/src/app/lib/services/timeService.ts
+++ b/src/client/src/app/lib/services/timeService.ts
@@ -128,11 +128,11 @@ export const parseDateAndTimeComponentsToUkDateTime = (
   date: string,
   time: TimeComponents,
 ): DayJsType => {
-  return dayjs(date)
+  return dayjs
+    .tz(date, ukTimezone)
     .hour(Number(time.hour))
     .minute(Number(time.minute))
-    .second(0)
-    .tz(ukTimezone);
+    .second(0);
 };
 
 //#endregion

--- a/src/client/src/app/lib/services/timeService.ts
+++ b/src/client/src/app/lib/services/timeService.ts
@@ -1,5 +1,5 @@
 import { DateComponents, TimeComponents } from '@types';
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
@@ -122,6 +122,17 @@ export const parseDateComponentsToUkDatetime = ({
   }
   const inputString = `${toTwoDigitFormat(day)}-${toTwoDigitFormat(month)}-${year}`;
   return parseToUkDatetime(inputString, 'DD-MM-YYYY');
+};
+
+export const parseDateAndTimeComponentsToUkDateTime = (
+  date: string,
+  time: TimeComponents,
+): DayJsType => {
+  return dayjs(date)
+    .hour(Number(time.hour))
+    .minute(Number(time.minute))
+    .second(0)
+    .tz(ukTimezone);
 };
 
 //#endregion
@@ -360,4 +371,21 @@ export const addHoursAndMinutesToUkDatetime = (
   //as simply doing .add() in daysjs maintains the original timezone info (even if the operation crosses a DST)
   const newHour = addToUkDatetime(ukDatetime, hours, 'hour', dateTimeFormat);
   return addToUkDatetime(newHour, minutes, 'minute', dateTimeFormat);
+};
+
+export const getNearestAlignedTimes = (
+  requested: Dayjs,
+  slotLengthMinutes: number,
+): Dayjs[] => {
+  const minutes = requested.hour() * 60 + requested.minute();
+  const remainder = minutes % slotLengthMinutes;
+
+  if (remainder === 0) {
+    return [requested];
+  }
+
+  const floor = requested.subtract(remainder, 'minute');
+  const ceil = floor.add(slotLengthMinutes, 'minute');
+
+  return [floor, ceil];
 };

--- a/src/client/src/app/lib/services/timeService.ts
+++ b/src/client/src/app/lib/services/timeService.ts
@@ -373,15 +373,27 @@ export const addHoursAndMinutesToUkDatetime = (
   return addToUkDatetime(newHour, minutes, 'minute', dateTimeFormat);
 };
 
+// Get nearest possible start times that align with slot length in a session that contains bookings
+// when the requested start time does not align with the slot length in the session
 export const getNearestAlignedTimes = (
   requested: Dayjs,
-  slotLengthMinutes: number,
+  slotLength: number,
 ): Dayjs[] => {
   const minutes = requested.hour() * 60 + requested.minute();
-  const remainder = minutes % slotLengthMinutes;
+  const remainder = minutes % slotLength;
 
   const floor = requested.subtract(remainder, 'minute');
-  const ceil = floor.add(slotLengthMinutes, 'minute');
+  const ceil = floor.add(slotLength, 'minute');
 
   return [floor, ceil];
+};
+
+// Checks if the session start time is divisible by the slot length
+export const isValidStartTime = (
+  sesionStart: Dayjs,
+  sessionEnd: Dayjs,
+  slotLength: number,
+): boolean => {
+  const duration = sessionEnd.diff(sesionStart, 'minute');
+  return duration % slotLength === 0;
 };

--- a/src/client/src/app/lib/services/timeService.ts
+++ b/src/client/src/app/lib/services/timeService.ts
@@ -380,10 +380,6 @@ export const getNearestAlignedTimes = (
   const minutes = requested.hour() * 60 + requested.minute();
   const remainder = minutes % slotLengthMinutes;
 
-  if (remainder === 0) {
-    return [requested];
-  }
-
   const floor = requested.subtract(remainder, 'minute');
   const ceil = floor.add(slotLengthMinutes, 'minute');
 

--- a/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.test.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.test.tsx
@@ -269,4 +269,43 @@ describe('Edit Session Time And Capacity Form', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('navigates to the edit start time page when there are bookings and the requested start time is not valid', async () => {
+    const { user } = render(
+      <EditSessionTimeAndCapacityForm
+        date={'2024-06-10 07:00:00'}
+        site={mockSite}
+        existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+      />,
+    );
+
+    const startTimeHourInput = screen.getByRole('textbox', {
+      name: 'Session start time - hour',
+    });
+    const startTimeMinuteInput = screen.getByRole('textbox', {
+      name: 'Session start time - minute',
+    });
+    const endTimeHourInput = screen.getByRole('textbox', {
+      name: 'Session end time - hour',
+    });
+    const endTimeMinuteInput = screen.getByRole('textbox', {
+      name: 'Session end time - minute',
+    });
+
+    await user.clear(startTimeHourInput);
+    await user.type(startTimeHourInput, '10');
+
+    await user.clear(startTimeMinuteInput);
+    await user.type(startTimeMinuteInput, '27');
+
+    await user.clear(endTimeHourInput);
+    await user.type(endTimeHourInput, '12');
+
+    await user.clear(endTimeMinuteInput);
+    await user.type(endTimeMinuteInput, '00');
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(editSessionMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
@@ -88,13 +88,7 @@ const EditSessionTimeAndCapacityForm = ({
   const submitForm: SubmitHandler<EditSessionFormValues> = async (
     form: EditSessionFormValues,
   ) => {
-    const updatedSession: AvailabilitySession = {
-      from: toTimeFormat(form.newSession.startTime) ?? '',
-      until: toTimeFormat(form.newSession.endTime) ?? '',
-      slotLength: form.newSession.slotLength,
-      capacity: form.newSession.capacity,
-      services: form.newSession.services,
-    };
+    const updatedSession = toAvailabilitySession(form.newSession);
 
     const sessionStart = parseDateAndTimeComponentsToUkDateTime(
       date,
@@ -135,19 +129,21 @@ const EditSessionTimeAndCapacityForm = ({
       site: site.id,
       mode: 'Edit',
       sessions: [updatedSession],
-      sessionToEdit: {
-        from: toTimeFormat(form.sessionToEdit.startTime) ?? '',
-        until: toTimeFormat(form.sessionToEdit.endTime) ?? '',
-        slotLength: form.sessionToEdit.slotLength,
-        capacity: form.sessionToEdit.capacity,
-        services: form.sessionToEdit.services,
-      },
+      sessionToEdit: toAvailabilitySession(form.sessionToEdit),
     });
 
     router.push(
       `edit/confirmed?updatedSession=${btoa(JSON.stringify(updatedSession))}&date=${date}`,
     );
   };
+
+  const toAvailabilitySession = (session: Session): AvailabilitySession => ({
+    from: toTimeFormat(session.startTime) ?? '',
+    until: toTimeFormat(session.endTime) ?? '',
+    slotLength: session.slotLength,
+    capacity: session.capacity,
+    services: session.services,
+  });
 
   const handleTwoDigitPositiveBoundedNumberInput = (
     e: ChangeEvent<HTMLInputElement>,

--- a/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
@@ -108,9 +108,16 @@ const EditSessionTimeAndCapacityForm = ({
       },
     });
 
+    const updatedString = btoa(JSON.stringify(updatedSession));
+    const existingString = btoa(JSON.stringify(existingSession));
+
     router.push(
-      `edit/confirmed?updatedSession=${btoa(JSON.stringify(updatedSession))}&date=${date}`,
+      `edit/edit-start-time?date=${date}&existingSession=${existingString}&updatedSession=${updatedString}`,
     );
+
+    // router.push(
+    //   `edit/confirmed?updatedSession=${btoa(JSON.stringify(updatedSession))}&date=${date}`,
+    // );
   };
 
   const handleTwoDigitPositiveBoundedNumberInput = (

--- a/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
@@ -17,6 +17,8 @@ import {
   parseToUkDatetime,
   parseToTimeComponents,
   toTimeFormat,
+  isValidStartTime,
+  parseDateAndTimeComponentsToUkDateTime,
 } from '@services/timeService';
 import { ChangeEvent } from 'react';
 import { sessionLengthInMinutes } from '@services/availabilityCalculatorService';
@@ -94,6 +96,40 @@ const EditSessionTimeAndCapacityForm = ({
       services: form.newSession.services,
     };
 
+    const sessionStart = parseDateAndTimeComponentsToUkDateTime(
+      date,
+      form.newSession.startTime,
+    );
+    const sessionEnd = parseDateAndTimeComponentsToUkDateTime(
+      date,
+      form.newSession.endTime,
+    );
+
+    const validSessionStartTime = isValidStartTime(
+      sessionStart,
+      sessionEnd,
+      form.newSession.slotLength,
+    );
+
+    if (
+      existingSession.totalSupportedAppointments === 0 ||
+      validSessionStartTime
+    ) {
+      return await updateSession(form, updatedSession);
+    }
+
+    const updatedString = btoa(JSON.stringify(updatedSession));
+    const existingString = btoa(JSON.stringify(existingSession));
+
+    router.push(
+      `edit/edit-start-time?date=${date}&existingSession=${existingString}&updatedSession=${updatedString}`,
+    );
+  };
+
+  const updateSession = async (
+    form: EditSessionFormValues,
+    updatedSession: AvailabilitySession,
+  ) => {
     await editSession({
       date,
       site: site.id,
@@ -108,16 +144,9 @@ const EditSessionTimeAndCapacityForm = ({
       },
     });
 
-    const updatedString = btoa(JSON.stringify(updatedSession));
-    const existingString = btoa(JSON.stringify(existingSession));
-
     router.push(
-      `edit/edit-start-time?date=${date}&existingSession=${existingString}&updatedSession=${updatedString}`,
+      `edit/confirmed?updatedSession=${btoa(JSON.stringify(updatedSession))}&date=${date}`,
     );
-
-    // router.push(
-    //   `edit/confirmed?updatedSession=${btoa(JSON.stringify(updatedSession))}&date=${date}`,
-    // );
   };
 
   const handleTwoDigitPositiveBoundedNumberInput = (

--- a/src/client/src/app/site/[site]/availability/edit/edit-start-time/edit-session-start-time-form.test.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-start-time/edit-session-start-time-form.test.tsx
@@ -1,0 +1,121 @@
+import { editSession } from '@services/appointmentsService';
+import render from '@testing/render';
+import { useRouter } from 'next/navigation';
+import EditSessionStartTimeForm from './edit-session-start-time-form';
+import { mockSession1, mockSite } from '@testing/data';
+import { screen } from '@testing-library/react';
+import { mockWeekAvailability__Summary } from '@testing/availability-and-bookings-mock-data';
+
+jest.mock('next/navigation');
+const mockUseRouter = useRouter as jest.Mock;
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+
+jest.mock('@services/appointmentsService');
+const editSessionMock = editSession as jest.Mock;
+
+describe('Edit Session Start Time Form', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockUseRouter.mockReturnValue({
+      replace: mockReplace,
+      push: mockPush,
+    });
+  });
+
+  it('renders', () => {
+    render(
+      <EditSessionStartTimeForm
+        date="2025-09-10"
+        site={mockSite}
+        existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        updatedSession={mockSession1}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'What time do you want the session to start?',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the correct nearest aligned start times', () => {
+    render(
+      <EditSessionStartTimeForm
+        date="2025-09-10"
+        site={mockSite}
+        existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        updatedSession={mockSession1}
+      />,
+    );
+
+    expect(screen.getByRole('radio', { name: '09:00am' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '09:05am' })).toBeInTheDocument();
+  });
+
+  it('displays a validation message when no option selected', async () => {
+    const { user } = render(
+      <EditSessionStartTimeForm
+        date="2025-09-10"
+        site={mockSite}
+        existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        updatedSession={mockSession1}
+      />,
+    );
+
+    const changeSessionButton = screen.getByRole('button', {
+      name: 'Change session',
+    });
+    await user.click(changeSessionButton);
+
+    expect(screen.getByText('Select an option')).toBeInTheDocument();
+    expect(editSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('calls edit session when the form is valid', async () => {
+    const date = '2025-09-10';
+    const { user } = render(
+      <EditSessionStartTimeForm
+        date={date}
+        site={mockSite}
+        existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        updatedSession={mockSession1}
+      />,
+    );
+
+    const startTimeOptionRadio = screen.getByRole('radio', {
+      name: '09:05am',
+    });
+    await user.click(startTimeOptionRadio);
+
+    const changeSessionButton = screen.getByRole('button', {
+      name: 'Change session',
+    });
+    await user.click(changeSessionButton);
+
+    expect(editSessionMock).toHaveBeenCalledTimes(1);
+    expect(editSessionMock).toHaveBeenCalledWith({
+      date: date,
+      site: mockSite.id,
+      mode: 'Edit',
+      sessions: [
+        {
+          from: '09:05',
+          until: '12:00',
+          slotLength: 5,
+          capacity: 2,
+          services: ['RSV:Adult'],
+        },
+      ],
+      sessionToEdit: {
+        from: '09:00',
+        until: '12:00',
+        slotLength: 5,
+        capacity: 2,
+        services: ['RSV:Adult'],
+      },
+    });
+  });
+});

--- a/src/client/src/app/site/[site]/availability/edit/edit-start-time/edit-session-start-time-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-start-time/edit-session-start-time-form.tsx
@@ -8,9 +8,11 @@ import {
 } from '@components/nhsuk-frontend';
 import { editSession } from '@services/appointmentsService';
 import {
+  dateTimeFormat,
   getNearestAlignedTimes,
   parseDateAndTimeComponentsToUkDateTime,
   parseToTimeComponents,
+  parseToUkDatetime,
   toTimeFormat,
 } from '@services/timeService';
 import { AvailabilitySession, SessionSummary, Site } from '@types';
@@ -60,17 +62,28 @@ const EditSessionStartTimeForm = ({
     const parsedTime = parseToTimeComponents(form.newStartTime) ?? '';
     const session = { ...updatedSession, from: toTimeFormat(parsedTime) ?? '' };
 
+    const existingUkStartTime = parseToUkDatetime(
+      existingSession.ukStartDatetime,
+      dateTimeFormat,
+    ).format('HH:mm');
+    const existingUkEndTime = parseToUkDatetime(
+      existingSession.ukEndDatetime,
+      dateTimeFormat,
+    ).format('HH:mm');
+
     await editSession({
       date,
       site: site.id,
       mode: 'Edit',
       sessions: [session],
       sessionToEdit: {
-        from: session.from,
-        until: session.until,
-        capacity: session.capacity,
-        services: session.services,
-        slotLength: session.slotLength,
+        from: existingUkStartTime,
+        until: existingUkEndTime,
+        capacity: existingSession.capacity,
+        services: Object.keys(
+          existingSession.totalSupportedAppointmentsByService,
+        ).map(service => service),
+        slotLength: existingSession.slotLength,
       },
     });
 

--- a/src/client/src/app/site/[site]/availability/edit/edit-start-time/edit-session-start-time-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-start-time/edit-session-start-time-form.tsx
@@ -1,0 +1,118 @@
+'use client';
+import {
+  SmallSpinnerWithText,
+  Button,
+  FormGroup,
+  RadioGroup,
+  Radio,
+} from '@components/nhsuk-frontend';
+import {
+  getNearestAlignedTimes,
+  parseDateAndTimeComponentsToUkDateTime,
+  parseToTimeComponents,
+  parseToUkDatetime,
+} from '@services/timeService';
+import { AvailabilitySession, SessionSummary, Site } from '@types';
+import { notFound } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+
+type EditSessionStartTimeFormValues = {
+  newStartTime: string;
+};
+
+type Props = {
+  date: string;
+  site: Site;
+  existingSession: SessionSummary;
+  updatedSession: AvailabilitySession;
+};
+
+const EditSessionStartTimeForm = ({
+  date,
+  site,
+  existingSession,
+  updatedSession,
+}: Props) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting, isSubmitSuccessful, errors },
+  } = useForm<EditSessionStartTimeFormValues>();
+
+  const requestedStartTime = parseToTimeComponents(updatedSession.from);
+  const requestedEndTime = parseToTimeComponents(updatedSession.until);
+  const existingStart = parseToUkDatetime(existingSession.ukStartDatetime);
+  const existingEnd = parseToUkDatetime(existingSession.ukEndDatetime);
+
+  const existingStartTimeComponent = parseToTimeComponents(
+    `${existingStart.hour()}:${existingStart.minute()}`,
+  );
+  const existingEndTimeComponent = parseToTimeComponents(
+    `${existingEnd.hour()}:${existingEnd.minute()}`,
+  );
+
+  if (
+    requestedStartTime === undefined ||
+    requestedEndTime === undefined ||
+    existingStartTimeComponent === undefined ||
+    existingEndTimeComponent === undefined
+  ) {
+    notFound(); // TODO: temp solution to stop build errors
+  }
+
+  const requestedStart = parseDateAndTimeComponentsToUkDateTime(
+    date,
+    requestedStartTime,
+  );
+
+  const nearestOptions = getNearestAlignedTimes(
+    requestedStart,
+    existingSession.slotLength,
+  );
+
+  const submitForm = async (form: EditSessionStartTimeFormValues) => {
+    alert('Hello');
+  };
+
+  return (
+    <>
+      <p>
+        There are booked appointments in this sessions which means the start
+        time cannot be changed to: {requestedStart.format('HH:mma')}
+      </p>
+      <form>
+        <FormGroup
+          legend="What time do you want the session to start?"
+          error={errors.newStartTime?.message}
+        >
+          <RadioGroup>
+            <Radio
+              label={'timeOption1'}
+              id="start-time-option-1"
+              value={'timeOption1'}
+              {...register('newStartTime', {
+                required: { value: true, message: 'Select an option' },
+              })}
+            />
+            <Radio
+              label={'timeOption2'}
+              id="start-time-option-2"
+              value={'timeOption2'}
+              {...register('newStartTime', {
+                required: { value: true, message: 'Select an option' },
+              })}
+            />
+          </RadioGroup>
+        </FormGroup>
+
+        {isSubmitting || isSubmitSuccessful ? (
+          <SmallSpinnerWithText text="Working..." />
+        ) : (
+          <Button type="submit">Change session</Button>
+        )}
+      </form>
+    </>
+  );
+};
+
+export default EditSessionStartTimeForm;

--- a/src/client/src/app/site/[site]/availability/edit/edit-start-time/edit-session-start-time-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-start-time/edit-session-start-time-form.tsx
@@ -86,22 +86,19 @@ const EditSessionStartTimeForm = ({
           error={errors.newStartTime?.message}
         >
           <RadioGroup>
-            <Radio
-              label={'timeOption1'}
-              id="start-time-option-1"
-              value={'timeOption1'}
-              {...register('newStartTime', {
-                required: { value: true, message: 'Select an option' },
-              })}
-            />
-            <Radio
-              label={'timeOption2'}
-              id="start-time-option-2"
-              value={'timeOption2'}
-              {...register('newStartTime', {
-                required: { value: true, message: 'Select an option' },
-              })}
-            />
+            {nearestOptions.map((option, index) => {
+              return (
+                <Radio
+                  label={`${option.format('HH:mma')}`}
+                  id={`start-time-option-${index}`}
+                  key={index}
+                  value={`${option.format('HH:mma')}`}
+                  {...register('newStartTime', {
+                    required: { value: true, message: 'Select an option' },
+                  })}
+                />
+              );
+            })}
           </RadioGroup>
         </FormGroup>
 

--- a/src/client/src/app/site/[site]/availability/edit/edit-start-time/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-start-time/page.tsx
@@ -1,0 +1,59 @@
+import NhsPage from '@components/nhs-page';
+import { assertPermission, fetchSite } from '@services/appointmentsService';
+import { dateTimeFormat, parseToUkDatetime } from '@services/timeService';
+import { AvailabilitySession, SessionSummary } from '@types';
+import { notFound } from 'next/navigation';
+import EditSessionStartTimeForm from './edit-session-start-time-form';
+
+type PageProps = {
+  searchParams?: Promise<{
+    date: string;
+    site: string;
+    existingSession: string;
+    updatedSession: string;
+  }>;
+  params: Promise<{
+    site: string;
+  }>;
+};
+
+const Page = async ({ searchParams, params }: PageProps) => {
+  const { site: siteFromPath } = { ...(await params) };
+  const { date, existingSession, updatedSession } = { ...(await searchParams) };
+  if (
+    date === undefined ||
+    existingSession === undefined ||
+    updatedSession === undefined
+  ) {
+    return notFound();
+  }
+
+  await assertPermission(siteFromPath, 'availability:setup');
+  const parsedDate = parseToUkDatetime(date);
+  const site = await fetchSite(siteFromPath);
+
+  const existing: SessionSummary = JSON.parse(atob(existingSession));
+  const updated: AvailabilitySession = JSON.parse(atob(updatedSession));
+
+  return (
+    <NhsPage
+      title={`Edit time and capacity for ${parsedDate.format('DD MMMM YYYY')}`}
+      caption={site.name}
+      originPage="edit-session-start-time"
+      backLink={{
+        href: `/site/${site.id}/availability/edit?session=${existingSession}&date=${date}`,
+        renderingStrategy: 'server',
+        text: 'Back',
+      }}
+    >
+      <EditSessionStartTimeForm
+        date={date}
+        existingSession={existing}
+        updatedSession={updated}
+        site={site}
+      />
+    </NhsPage>
+  );
+};
+
+export default Page;

--- a/src/client/src/app/site/[site]/availability/edit/edit-start-time/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-start-time/page.tsx
@@ -1,6 +1,6 @@
 import NhsPage from '@components/nhs-page';
 import { assertPermission, fetchSite } from '@services/appointmentsService';
-import { dateTimeFormat, parseToUkDatetime } from '@services/timeService';
+import { parseToUkDatetime } from '@services/timeService';
 import { AvailabilitySession, SessionSummary } from '@types';
 import { notFound } from 'next/navigation';
 import EditSessionStartTimeForm from './edit-session-start-time-form';

--- a/src/client/src/app/testing/data.ts
+++ b/src/client/src/app/testing/data.ts
@@ -803,4 +803,5 @@ export {
   mockMultipleServices,
   mockOfflineSite,
   mockCancelDayResponse,
+  mockSession1,
 };


### PR DESCRIPTION
# Description

Adding a new screen to offer 2 alternative session start times, this screen only appears in the following scenarios:
- Bookings in the session and the session length isn't divisible by the slot length using the new requested start time. E.g. session 9:00-10:00 with slot lengths of 10 minutes and the requested start time is 9:05
---------------------------------------------------------------------------------------------
- If there are no bookings or the slot length is divisible by the new session length - continue as we previously did.
- Unit tests for the above
- There are no e2e tests in this yet as there are other change session tickets in progress which would mean re-doing them so those will come after

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
