### PR TITLE
APPT-875: Create AutoCancelled cancellation reason

### DIFF
--- a/src/api/Nhs.Appointments.Core/Booking.cs
+++ b/src/api/Nhs.Appointments.Core/Booking.cs
@@ -115,5 +115,6 @@ public enum CancellationReason
 {
     CancelledByCitizen,
     CancelledBySite,
-    RescheduledByCitizen
+    RescheduledByCitizen,
+    AutoCancelled
 }

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Cancel.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/Booking/Cancel.feature
@@ -60,6 +60,17 @@ Feature: Appointment cancellation
     Then the booking has been 'Cancelled'
     And 'CancelledBySite' cancellation reason has been used
 
+  Scenario: Cancel a booking appointment with AutoCancelled cancellation reason
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following bookings have been made
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:20 | 5        | COVID   |
+    When I cancel the appointment with cancellation reason 'AutoCancelled'
+    Then the booking has been 'Cancelled'
+    And 'AutoCancelled' cancellation reason has been used
+
   Scenario: Cancel a booking appointment which can be replaced by an orphaned appointment of a different service
     Given the following sessions
       | Date     | From  | Until | Services   | Slot Length | Capacity |

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/CancelBookingRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/CancelBookingRequestValidatorTests.cs
@@ -27,4 +27,13 @@ public class CancelBookingRequestValidatorTests
         result.IsValid.Should().BeTrue();
         result.Errors.Should().HaveCount(0);
     }
+
+    [Fact]
+    public void Validate_ReturnsTrue_WhenRequestIsValid__CancellationReason()
+    {
+        var testRequest = new CancelBookingRequest("ref", string.Empty, CancellationReason.AutoCancelled);
+        var result = _sut.Validate(testRequest);
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().HaveCount(0);
+    }
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingQueryFilterTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingQueryFilterTests.cs
@@ -96,7 +96,8 @@ public class BookingQueryFilterTests
             TestBooking("02", cancellationReason: CancellationReason.CancelledBySite),
             TestBooking("03", cancellationReason: CancellationReason.RescheduledByCitizen),
             TestBooking("04", cancellationReason: CancellationReason.CancelledBySite),
-            TestBooking("05", cancellationReason: CancellationReason.CancelledByCitizen)
+            TestBooking("05", cancellationReason: CancellationReason.CancelledByCitizen),
+            TestBooking("05", cancellationReason: CancellationReason.AutoCancelled)
         };
 
         var filter = new BookingQueryFilter(TestDateAt("09:00"), TestDateAt("17:30"),
@@ -111,6 +112,7 @@ public class BookingQueryFilterTests
         result.Should().Contain(bookings[2]);
         result.Should().NotContain(bookings[3]);
         result.Should().NotContain(bookings[4]);
+        result.Should().NotContain(bookings[5]);
     }
 
     [Fact]
@@ -175,7 +177,9 @@ public class BookingQueryFilterTests
             TestBooking("09", "10:00", AppointmentStatus.Booked, null, CancellationNotificationStatus.Unknown),
             // Cancelled booking at 10:10, automatically notified but notification failed
             TestBooking("10", "10:10", AppointmentStatus.Cancelled, CancellationReason.CancelledBySite,
-                CancellationNotificationStatus.AutomaticNotificationFailed)
+                CancellationNotificationStatus.AutomaticNotificationFailed),
+            TestBooking("11", "10:10", AppointmentStatus.Cancelled, CancellationReason.AutoCancelled,
+                CancellationNotificationStatus.Unknown)
         };
 
         // "Find me cancelled bookings between 09:30 and 10 where the citizens could not be notified OR their automatic notification failed"
@@ -185,8 +189,7 @@ public class BookingQueryFilterTests
             CancellationReason.CancelledBySite,
             new[]
             {
-                CancellationNotificationStatus.Unnotified,
-                CancellationNotificationStatus.AutomaticNotificationFailed
+                CancellationNotificationStatus.Unnotified, CancellationNotificationStatus.AutomaticNotificationFailed
             });
 
         var result = bookings.Where(filter.Matches).ToList();
@@ -203,5 +206,6 @@ public class BookingQueryFilterTests
         result.Should().Contain(bookings[7]);
         result.Should().NotContain(bookings[8]);
         result.Should().NotContain(bookings[9]);
+        result.Should().NotContain(bookings[10]);
     }
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
@@ -514,6 +514,7 @@ namespace Nhs.Appointments.Core.UnitTests
         [Theory]
         [InlineData(CancellationReason.CancelledByCitizen, CancellationReason.CancelledByCitizen)]
         [InlineData(CancellationReason.CancelledBySite, CancellationReason.CancelledBySite)]
+        [InlineData(CancellationReason.AutoCancelled, CancellationReason.AutoCancelled)]
         public async Task CancelBooking_ValidCancellationReasonIsUsed(CancellationReason reason,
             CancellationReason expectedReason)
         {


### PR DESCRIPTION
# Description

Introduces a new Cancellation Reason type, AutoCancelled. This will be used to track bookings cancelled by NBS. 

I have some concerns about us baking NBS-specific features into MYA. I think this should be in Additional Data instead, or at least renamed something more generic like "CancelledByThirdParty". Am raising with Product. 

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
