### PR TITLE
APPT-1347: Correct transposing of source for booking extracts

### DIFF
--- a/data/BookingsDataExtracts/BookingDataConverter.cs
+++ b/data/BookingsDataExtracts/BookingDataConverter.cs
@@ -33,9 +33,7 @@ public class BookingDataConverter(IEnumerable<SiteDocument> sites)
 
     public static bool ExtractSelfReferral(NbsBookingDocument booking) => booking.AdditionalData?.ReferralType == "SelfReferred";
 
-    public static string ExtractSource(NbsBookingDocument booking) => booking.AdditionalData != null ? 
-        booking.AdditionalData.Source.Equals("NBS", StringComparison.OrdinalIgnoreCase) ? "NBS_Website" : booking.AdditionalData.Source.Replace(" ", "_")
-        : "Unknown";
+    public static string ExtractSource(NbsBookingDocument booking) => TransposeSource(booking.AdditionalData.Source);
 
     public static string ExtractDateOfBirth(BookingDocument booking) => booking.AttendeeDetails.DateOfBirth.ToString("yyyy-MM-dd");
 
@@ -44,4 +42,19 @@ public class BookingDataConverter(IEnumerable<SiteDocument> sites)
     public static string ExtractService(BookingDocument booking) => booking.Service;
 
     public static string ExtractCancelledDateTime(BookingDocument booking) => booking.Status == AppointmentStatus.Cancelled ? booking.StatusUpdated.ToString("yyyy-MM-ddTHH:mm:sszzz") : null;
+    
+    private static string TransposeSource(string source)
+    {
+        switch (source)
+        {
+            case "NBS":
+                return "NBS_Website";
+            case "NHSApp":
+                return "NHS_App";
+            case "NHSCallCentre":
+                return "NHS_Call_Centre";
+            default:
+                return "UNKNOWN";
+        }
+    }
 }

--- a/data/DataExtract/Documents/NbsAdditionalData.cs
+++ b/data/DataExtract/Documents/NbsAdditionalData.cs
@@ -13,14 +13,8 @@ public record NbsAdditionalData
 {
     [JsonProperty("referralType")]
     public string ReferralType { get; set; }
-
-    [JsonProperty("isAppBooking")]
-    public bool IsAppBooking { get; set; }
-
-    [JsonProperty("isCallCentreBooking")]
-    public bool IsCallCentreBooking { get; set; }
-
-    [JsonIgnore]
-    public string Source => IsAppBooking ? "NHS App" : IsCallCentreBooking ? "NHS Call Centre" : "NBS";
+    
+    [JsonProperty("source")]
+    public string Source { get; set; }
 
 }

--- a/tests/BookingDataExtractTests/Specification/BookingExtractsFeatureSteps.cs
+++ b/tests/BookingDataExtractTests/Specification/BookingExtractsFeatureSteps.cs
@@ -97,9 +97,8 @@ public sealed class BookingExtractsFeatureSteps : Feature
                 },
                 AdditionalData = new NbsAdditionalData
                 {
-                    IsAppBooking = true,
-                    ReferralType = "",
-                    IsCallCentreBooking = false
+                    Source = "NHSApp",
+                    ReferralType = ""
                 }
             });
 

--- a/tests/BookingDataExtracts.UnitTests/BookingDataConverterTests.cs
+++ b/tests/BookingDataExtracts.UnitTests/BookingDataConverterTests.cs
@@ -115,18 +115,18 @@ public class BookingDataConverterTests
     }
 
     [Theory]
-    [InlineData(false, false, "NBS_Website")]
-    [InlineData(true, false, "NHS_App")]
-    [InlineData(true, true, "NHS_App")]
-    [InlineData(false, true, "NHS_Call_Centre")]
-    public void ExtractSource_GetsCorrectData(bool isNhsApp, bool isCallCentre, string expectedData)
+    [InlineData("NBS", "NBS_Website")]
+    [InlineData("NHSApp", "NHS_App")]
+    [InlineData("", "UNKNOWN")]
+    [InlineData(null, "UNKNOWN")]
+    [InlineData("NHSCallCentre", "NHS_Call_Centre")]
+    public void ExtractSource_GetsCorrectData(string source, string expectedData)
     {
         var testDocument = new NbsBookingDocument
         {
             AdditionalData = new()
             {
-                IsAppBooking = isNhsApp,
-                IsCallCentreBooking = isCallCentre
+                Source = source
             }
         };
         var result = BookingDataConverter.ExtractSource(testDocument);


### PR DESCRIPTION
# Description

Bug raised around Source in the booking extract. The code suggests we were meant to be consuming booleans for source, this is not reality, NBS are sending us a string. Updated the code to reflect this

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
