### PR TITLE
APPT-1366 - Send notifications when cancelling a day to all booking with contact details

### DIFF
--- a/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Core/IBookingsDocumentStore.cs
@@ -18,7 +18,7 @@ public interface IBookingsDocumentStore
     Task<IEnumerable<string>> RemoveUnconfirmedProvisionalBookings();
     Task DeleteBooking(string reference, string site);
     Task<bool> UpdateAvailabilityStatus(string bookingReference, AvailabilityStatus status);
-    Task<(int cancelledBookingsCount, int bookingsWithoutContactDetailsCount)> CancelAllBookingsInDay(string site, DateOnly date);
+    Task<(int cancelledBookingsCount, int bookingsWithoutContactDetailsCount, List<Booking> bookingsWithContactDetails)> CancelAllBookingsInDay(string site, DateOnly date);
 }
 
 public interface IRolesStore

--- a/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
+++ b/src/api/Nhs.Appointments.Persistance/BookingCosmosDocumentStore.cs
@@ -320,7 +320,7 @@ public class BookingCosmosDocumentStore(
         bookingStore.DeleteDocument(reference, site)
     );
 
-    public async Task<(int cancelledBookingsCount, int bookingsWithoutContactDetailsCount)> CancelAllBookingsInDay(string site, DateOnly date)
+    public async Task<(int cancelledBookingsCount, int bookingsWithoutContactDetailsCount, List<Booking> bookingsWithContactDetails)> CancelAllBookingsInDay(string site, DateOnly date)
     {
         using (metricsRecorder.BeginScope("CancelAllBookingsInDay"))
         {
@@ -345,7 +345,7 @@ public class BookingCosmosDocumentStore(
                 }
             }
 
-            return (successfulCancellations, bookingsWithoutContactDetailsCount);
+            return (successfulCancellations, bookingsWithoutContactDetailsCount, bookings.Where(b => b.ContactDetails is not null).ToList());
         }
     }
 }    

--- a/tests/Nhs.Appointments.Persistance.UnitTests/BookingCosmosDocumentStoreTests.cs
+++ b/tests/Nhs.Appointments.Persistance.UnitTests/BookingCosmosDocumentStoreTests.cs
@@ -422,7 +422,9 @@ public class BookingCosmosDocumentStoreTests
 
         var result = await _sut.CancelAllBookingsInDay("TEST_SITE_123", new DateOnly(2025, 1, 1));
 
-        result.Should().Be((4, 1));
+        result.cancelledBookingsCount.Should().Be(4);
+        result.bookingsWithoutContactDetailsCount.Should().Be(1);
+        result.bookingsWithContactDetails.Count.Should().Be(3);
 
         _bookingStore.Verify(x => x.PatchDocument(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PatchOperation[]>()), Times.Exactly(4));
     }
@@ -435,7 +437,9 @@ public class BookingCosmosDocumentStoreTests
 
         var result = await _sut.CancelAllBookingsInDay("TEST_SITE_123", new DateOnly(2025, 1, 1));
 
-        result.Should().Be((0, 0));
+        result.cancelledBookingsCount.Should().Be(0);
+        result.bookingsWithoutContactDetailsCount.Should().Be(0);
+        result.bookingsWithContactDetails.Should().BeEmpty();
 
         _bookingStore.Verify(x => x.PatchDocument(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PatchOperation[]>()), Times.Never);
     }


### PR DESCRIPTION
# Description

When cancelling a day, sending notifications to bookings with contact details was missed - this PR adds that in

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
