### PR TITLE
APPT-1348 - Enabling the cancel a day feature flag in all environment…

### DIFF
--- a/features/dev.feature.flags.json
+++ b/features/dev.feature.flags.json
@@ -5,7 +5,7 @@
     "JointBookings": false,
     "SiteSummaryReport": true,
     "SiteStatus": true,
-    "CancelDay": false,
+    "CancelDay": true,
     "TestFeaturePercentageEnabled": {
       "EnabledFor": [
         {

--- a/features/int.feature.flags.json
+++ b/features/int.feature.flags.json
@@ -4,6 +4,6 @@
     "JointBookings": false,
     "SiteSummaryReport": true,
     "SiteStatus": true,
-    "CancelDay": false
+    "CancelDay": true
   }
 }

--- a/features/pen.feature.flags.json
+++ b/features/pen.feature.flags.json
@@ -5,6 +5,6 @@
     "BulkImport": true,
     "SiteSummaryReport": true,
     "SiteStatus": true,
-    "CancelDay": false
+    "CancelDay": true
   }
 }

--- a/features/perf.feature.flags.json
+++ b/features/perf.feature.flags.json
@@ -5,6 +5,6 @@
     "BulkImport": true,
     "SiteSummaryReport": true,
     "SiteStatus": true,
-    "CancelDay": false
+    "CancelDay": true
   }
 }

--- a/features/prod.feature.flags.json
+++ b/features/prod.feature.flags.json
@@ -4,6 +4,6 @@
     "JointBookings": false,
     "SiteSummaryReport": true,
     "SiteStatus": true,
-    "CancelDay": false
+    "CancelDay": true
   }
 }

--- a/features/stag.feature.flags.json
+++ b/features/stag.feature.flags.json
@@ -4,6 +4,6 @@
     "JointBookings": false,
     "SiteSummaryReport": true,
     "SiteStatus": true,
-    "CancelDay": false
+    "CancelDay": true
   }
 }


### PR DESCRIPTION
…s (#999)

# Description

Enabling the CancelDay feature flag in all environments.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests

(cherry picked from commit 6f6fbd970ff47b6731172899268473f88e8138cd)