### PR TITLE
APPT-1370 - Hiding the cancel day link if the user lacks permission

### DIFF
--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
@@ -398,6 +398,23 @@ describe('Day Summary Card', () => {
         `/site/mock-site/cancel-day?date=${mockDaySummaries[0].ukDate.format(RFC3339Format)}`,
       );
     });
+
+    it('hides the "Cancel Day" link when the user lacks permission', () => {
+      mockIsFutureCalendarDateUk.mockReturnValue(true);
+
+      render(
+        <DaySummaryCard
+          daySummary={mockDaySummaries[0]}
+          siteId={'mock-site'}
+          canManageAvailability={false}
+          clinicalServices={mockSingleService}
+          canViewDailyAppointments={true}
+          cancelDayFlag={true}
+        />,
+      );
+
+      expect(screen.queryByRole('link', { name: 'Cancel day' })).toBeNull();
+    });
   });
 
   describe('when there is no availability', () => {

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
@@ -72,7 +72,7 @@ export const DaySummaryCard = ({
   ].filter(p => p !== false);
 
   const futureCancelDayLink =
-    cancelDayFlag && isFutureCalendarDate ? (
+    cancelDayFlag && canManageAvailability && isFutureCalendarDate ? (
       <Link
         className="nhsuk-link"
         href={`/site/${siteId}/cancel-day?date=${ukDate.format(RFC3339Format)}`}


### PR DESCRIPTION
# Description

Hiding the cancel day link on the day summary card when a user lacks the permission to manage availability

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
