### PR TITLE
APPT-1372/APPT-1376 - A couple of minor fixups for cancel a day

### DIFF
--- a/src/client/src/app/site/[site]/cancel-day/cancel-day-form.test.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancel-day-form.test.tsx
@@ -30,7 +30,7 @@ const defaultProps = {
     maximumCapacity: 10,
     totalRemainingCapacity: 7,
     totalSupportedAppointments: 3,
-    totalOrphanedAppointments: 0,
+    totalOrphanedAppointments: 1,
     totalCancelledAppointments: 0,
     sessionSummaries: [],
   },
@@ -51,7 +51,7 @@ describe('CancelDayForm', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "3 booked appointments will be cancelled. We'll notify people that their appointment has been cancelled",
+        "4 booked appointments will be cancelled. We'll notify people that their appointment has been cancelled",
       ),
     ).toBeInTheDocument();
   });

--- a/src/client/src/app/site/[site]/cancel-day/cancel-day-form.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancel-day-form.tsx
@@ -76,8 +76,10 @@ const CancelDayForm = ({
         tableCaption={`Sessions for ${parsedDate.format('dddd D MMMM')}`}
       />
       <InsetText>
-        {daySummary.totalSupportedAppointments} booked appointments will be
-        cancelled. We'll notify people that their appointment has been cancelled
+        {daySummary.totalSupportedAppointments +
+          daySummary.totalOrphanedAppointments}{' '}
+        booked appointments will be cancelled. We'll notify people that their
+        appointment has been cancelled
       </InsetText>
 
       {!confirmStep ? (

--- a/src/client/src/app/site/[site]/cancel-day/cancelled-appointments/cancelled-appointments.test.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancelled-appointments/cancelled-appointments.test.tsx
@@ -26,12 +26,12 @@ describe('Cancelled Appointments Without Contact Details Page', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('row', {
-        name: '09:00 John Smith 9999999990 1 February 1979 RSV Adult',
+        name: '09:00 John Smith 9999999990 1 February 1979 Not provided RSV Adult',
       }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('row', {
-        name: '09:10 Brian Smith 9999999995 1 February 1984 FLU 18-64',
+        name: '09:10 Brian Smith 9999999995 1 February 1984 Not provided FLU 18-64',
       }),
     ).toBeInTheDocument();
 

--- a/src/client/src/app/site/[site]/cancel-day/cancelled-appointments/page.tsx
+++ b/src/client/src/app/site/[site]/cancel-day/cancelled-appointments/page.tsx
@@ -49,6 +49,10 @@ const Page = async ({ params, searchParams }: PageProps) => {
     fetchClinicalServices(),
   ]);
 
+  const bookingsWithoutContactDetails = bookings.filter(
+    b => b.contactDetails === null || b.contactDetails?.length === 0,
+  );
+
   return (
     <NhsPage
       title={fromDate.format('dddd D MMMM')}
@@ -56,7 +60,7 @@ const Page = async ({ params, searchParams }: PageProps) => {
       originPage="cancel-day-confirmation"
     >
       <CancelledAppointments
-        bookings={bookings}
+        bookings={bookingsWithoutContactDetails}
         clinicalServices={clinicalServices}
         site={site.name}
       />

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.test.tsx
@@ -26,12 +26,12 @@ describe('View Daily Appointments', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('row', {
-        name: '14:05 John Smith 9999999990 1 February 1979 RSV Adult Cancel',
+        name: '14:05 John Smith 9999999990 1 February 1979 Not provided RSV Adult Cancel',
       }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('row', {
-        name: '09:34 Ian Goldsmith 9999999995 3 March 1973 FLU 18-64 Cancel',
+        name: '09:34 Ian Goldsmith 9999999995 3 March 1973 Not provided FLU 18-64 Cancel',
       }),
     ).toBeInTheDocument();
 

--- a/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/daily-appointments/daily-appointments-page.tsx
@@ -81,9 +81,9 @@ export const DailyAppointmentsPage = ({
         toTimeFormat(booking.from),
         mapNameAndNHSNumber(booking.attendeeDetails),
         jsDateFormat(booking.attendeeDetails.dateOfBirth),
-        booking.contactDetails
+        booking.contactDetails && booking.contactDetails.length > 0
           ? mapContactDetails(booking.contactDetails)
-          : null,
+          : 'Not provided',
         clinicalServices.find(c => c.value === booking.service)?.label ??
           booking.service,
       ];

--- a/tests/Nhs.Appointments.Persistance.UnitTests/BookingCosmosDocumentStoreTests.cs
+++ b/tests/Nhs.Appointments.Persistance.UnitTests/BookingCosmosDocumentStoreTests.cs
@@ -318,7 +318,8 @@ public class BookingCosmosDocumentStoreTests
                     LastName = "Bloggs"
                 },
                 From = new DateTime(2025, 1, 1, 12, 25, 0),
-                Status = AppointmentStatus.Booked
+                Status = AppointmentStatus.Booked,
+                Site = "TEST_SITE_123"
             },
             new()
             {
@@ -335,7 +336,8 @@ public class BookingCosmosDocumentStoreTests
                         Type = ContactItemType.Phone,
                         Value = "1234567890"
                     }
-                ]
+                ],
+                Site = "TEST_SITE_123"
             },
             new()
             {
@@ -352,7 +354,8 @@ public class BookingCosmosDocumentStoreTests
                         Type = ContactItemType.Phone,
                         Value = "1234567890"
                     }
-                ]
+                ],
+                Site = "TEST_SITE_123"
             },
             new()
             {
@@ -363,20 +366,21 @@ public class BookingCosmosDocumentStoreTests
                     LastName = "Bloggs"
                 },
                 From = new DateTime(2025, 1, 1, 9, 25, 0),
-                Status = AppointmentStatus.Booked,
+                Status = AppointmentStatus.Provisional,
                 ContactDetails = [
                     new () {
                         Type = ContactItemType.Email,
                         Value = "test.email@domain.com"
                     }
-                ]
+                ],
+                Site = "TEST_SITE_123"
             }
         };
         var bookingIndexDocuments = new List<BookingIndexDocument>
         {
             new()
             {
-                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                Site = "TEST_SITE_123",
                 DocumentType = "booking_index",
                 Id = "01-76-000001",
                 NhsNumber = "9999999999",
@@ -385,7 +389,7 @@ public class BookingCosmosDocumentStoreTests
             },
             new()
             {
-                Site = "34e990af-5dc9-43a6-8895-b9123216d699",
+                Site = "TEST_SITE_123",
                 DocumentType = "booking_index",
                 Id = "02-76-000001",
                 NhsNumber = "9999999999",
@@ -394,7 +398,7 @@ public class BookingCosmosDocumentStoreTests
             },
             new()
             {
-                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                Site = "TEST_SITE_123",
                 DocumentType = "booking_index",
                 Id = "01-76-000002",
                 NhsNumber = "9999999999",
@@ -403,12 +407,12 @@ public class BookingCosmosDocumentStoreTests
             },
             new()
             {
-                Site = "2de5bb57-060f-4cb5-b14d-16587d0c2e8f",
+                Site = "TEST_SITE_123",
                 DocumentType = "booking_index",
                 Id = "01-76-000003",
                 NhsNumber = "9999999999",
                 Reference = "01-76-000003",
-                Status = AppointmentStatus.Booked
+                Status = AppointmentStatus.Provisional
             }
         };
 
@@ -422,11 +426,11 @@ public class BookingCosmosDocumentStoreTests
 
         var (cancelledBookingsCount, bookingsWithoutContactDetailsCount, bookingsWithContactDetails) = await _sut.CancelAllBookingsInDay("TEST_SITE_123", new DateOnly(2025, 1, 1));
 
-        cancelledBookingsCount.Should().Be(3);
+        cancelledBookingsCount.Should().Be(2);
         bookingsWithoutContactDetailsCount.Should().Be(1);
-        bookingsWithContactDetails.Count.Should().Be(2);
+        bookingsWithContactDetails.Count.Should().Be(1);
 
-        _bookingStore.Verify(x => x.PatchDocument(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PatchOperation[]>()), Times.Exactly(3));
+        _bookingStore.Verify(x => x.PatchDocument(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PatchOperation[]>()), Times.Exactly(2));
     }
 
     [Fact]


### PR DESCRIPTION
# Description

- Only cancelling bookings on a day which don't have an already 'Cancelled Status'
- This should fix the numbers displayed on the front end as well
- Only returning the newly cancelled bookings with contact details to prevent duplicate cancelled notifications being sent
- Filtering out bookings with contact details on the front end when displaying bookings without them - this list now also includes bookings without contact details that were already cancelled before the cancel a day functionality was ran (assuming the reason was CancelledBySite)
- Including orphaned appointments in the summary booking count when cancelling a day
- Updating the appointments table to state 'Not provided' when no contact details are provided

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
