### PR TITLE
APPT-1370 - Adding a permission check around the daily appointment links on the day card

### DIFF
--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.test.tsx
@@ -415,6 +415,28 @@ describe('Day Summary Card', () => {
 
       expect(screen.queryByRole('link', { name: 'Cancel day' })).toBeNull();
     });
+
+    it('hides the view appointments links when the user lacks permission', () => {
+      mockIsFutureCalendarDateUk.mockReturnValue(true);
+
+      render(
+        <DaySummaryCard
+          daySummary={mockDaySummaries[0]}
+          siteId={'mock-site'}
+          canManageAvailability={false}
+          clinicalServices={mockSingleService}
+          canViewDailyAppointments={false}
+          cancelDayFlag={true}
+        />,
+      );
+
+      expect(
+        screen.queryByRole('link', { name: 'View Cancelled Appointments' }),
+      ).toBeNull();
+      expect(
+        screen.queryByRole('link', { name: 'View Manual Cancellations' }),
+      ).toBeNull();
+    });
   });
 
   describe('when there is no availability', () => {

--- a/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
+++ b/src/client/src/app/site/[site]/view-availability/week/day-summary-card.tsx
@@ -37,14 +37,16 @@ export const DaySummaryCard = ({
           text: 'Add availability to this day',
           href: `/site/${siteId}/create-availability/wizard?date=${ukDate.format(RFC3339Format)}`,
         },
-      cancelledAppointments > 0 && {
-        text: 'View cancelled appointments',
-        href: `daily-appointments?date=${ukDate.format(RFC3339Format)}&page=1&tab=1`,
-      },
-      orphanedAppointments > 0 && {
-        text: 'View manual cancellations',
-        href: `daily-appointments?date=${ukDate.format(RFC3339Format)}&page=1&tab=2`,
-      },
+      canViewDailyAppointments &&
+        cancelledAppointments > 0 && {
+          text: 'View cancelled appointments',
+          href: `daily-appointments?date=${ukDate.format(RFC3339Format)}&page=1&tab=1`,
+        },
+      canViewDailyAppointments &&
+        orphanedAppointments > 0 && {
+          text: 'View manual cancellations',
+          href: `daily-appointments?date=${ukDate.format(RFC3339Format)}&page=1&tab=2`,
+        },
     ].filter(p => p !== false);
 
     return (
@@ -61,14 +63,16 @@ export const DaySummaryCard = ({
       text: 'View daily appointments',
       href: `daily-appointments?date=${ukDate.format(RFC3339Format)}&page=1`,
     },
-    cancelledAppointments > 0 && {
-      text: 'View cancelled appointments',
-      href: `daily-appointments?date=${ukDate.format(RFC3339Format)}&page=1&tab=1`,
-    },
-    orphanedAppointments > 0 && {
-      text: 'View manual cancellations',
-      href: `daily-appointments?date=${ukDate.format(RFC3339Format)}&page=1&tab=2`,
-    },
+    canViewDailyAppointments &&
+      cancelledAppointments > 0 && {
+        text: 'View cancelled appointments',
+        href: `daily-appointments?date=${ukDate.format(RFC3339Format)}&page=1&tab=1`,
+      },
+    canViewDailyAppointments &&
+      orphanedAppointments > 0 && {
+        text: 'View manual cancellations',
+        href: `daily-appointments?date=${ukDate.format(RFC3339Format)}&page=1&tab=2`,
+      },
   ].filter(p => p !== false);
 
   const futureCancelDayLink =


### PR DESCRIPTION
# Description

The 'View cancelled appointments' / 'View manual cancellations' links didn't have a permission check around them. This PR adds those in

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
