### PR TITLE
APPT-1233: Make the cancel session page transactional (#998)

### DIFF
--- a/src/client/src/app/lib/components/nhs-transactional-page.test.tsx
+++ b/src/client/src/app/lib/components/nhs-transactional-page.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from '@testing-library/react';
+import { fetchPermissions } from '@services/appointmentsService';
+import { mockAllPermissions } from '@testing/data';
+import NhsTransactionalPage from './nhs-transactional-page';
+
+jest.mock('@services/appointmentsService');
+const fetchPermissionsMock = fetchPermissions as jest.Mock<
+  Promise<string[] | undefined>
+>;
+
+jest.mock('@components/nhs-header-log-out', () => {
+  const MockNhsHeaderLogOut = () => {
+    return <button type="submit">log out</button>;
+  };
+  return MockNhsHeaderLogOut;
+});
+
+let mockGetCookies = jest.fn().mockImplementation((cookieName: string) => {
+  return cookieName === 'ams-notification'
+    ? { value: 'This is a notification' }
+    : undefined;
+});
+
+jest.mock('next/headers', () => {
+  return {
+    cookies: () => {
+      return {
+        get: mockGetCookies,
+      };
+    },
+  };
+});
+
+jest.mock('@components/close-notification-form', () => {
+  const MockCloseNotificationButton = () => {
+    return (
+      <button
+        type="button"
+        className="nhsuk-warning-callout-custom__close-button"
+      >
+        Close
+      </button>
+    );
+  };
+  return MockCloseNotificationButton;
+});
+
+describe('Nhs Page', () => {
+  beforeEach(() => {
+    fetchPermissionsMock.mockResolvedValue([
+      'availability:query',
+      'availability:setup',
+      'site:manage',
+      'users:view',
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('shows the correct title', async () => {
+    const jsx = await NhsTransactionalPage({
+      title: 'Test title',
+      children: null,
+      originPage: '',
+    });
+    render(jsx);
+    expect(screen.getByRole('heading', { name: /Test title/i })).toBeVisible();
+  });
+
+  it('Displays a notification banner when there is an ams-notification cookie', async () => {
+    mockGetCookies = jest.fn().mockImplementation((cookieName: string) => {
+      return cookieName === 'ams-notification'
+        ? { value: 'This is a notification' }
+        : undefined;
+    });
+
+    const jsx = await NhsTransactionalPage({
+      title: 'Test title',
+      children: null,
+      originPage: '',
+    });
+    render(jsx);
+
+    expect(screen.getByText('This is a notification')).toBeVisible();
+  });
+
+  it('Does not display a notification banner when there is not an ams-notification cookie', async () => {
+    mockGetCookies = jest.fn().mockReturnValue(undefined);
+
+    const jsx = await NhsTransactionalPage({
+      title: 'Test title',
+      children: null,
+      originPage: '',
+    });
+    render(jsx);
+
+    expect(screen.queryByText('This is a notification')).toBeNull();
+  });
+
+  it('Does not display any navigation links even if all permissions are present', async () => {
+    fetchPermissionsMock.mockResolvedValue(mockAllPermissions);
+
+    const jsx = await NhsTransactionalPage({
+      title: 'Test title',
+      children: null,
+      originPage: '',
+    });
+    render(jsx);
+
+    expect(
+      screen.queryByRole('navigation', { name: 'Primary navigation' }),
+    ).toBeNull();
+
+    expect(
+      screen.queryByRole('link', { name: 'View availability' }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole('link', { name: 'Create availability' }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole('link', { name: 'Change site details' }),
+    ).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Manage users' })).toBeNull();
+  });
+
+  it('displays the back link with the correct title and URL', async () => {
+    fetchPermissionsMock.mockResolvedValue([]);
+
+    const jsx = await NhsTransactionalPage({
+      title: 'Test title',
+      children: null,
+      backLink: {
+        href: '/test/url',
+        renderingStrategy: 'server',
+        text: 'Test back link',
+      },
+      originPage: '',
+    });
+
+    render(jsx);
+    expect(
+      screen.getByRole('link', { name: 'Test back link' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Test back link' }),
+    ).toHaveAttribute('href', '/test/url');
+  });
+});

--- a/src/client/src/app/lib/components/nhs-transactional-page.tsx
+++ b/src/client/src/app/lib/components/nhs-transactional-page.tsx
@@ -5,6 +5,8 @@ import NhsHeaderLogOut from './nhs-header-log-out';
 import FeedbackBanner from '@components/feedback-banner';
 import BackLink, { BackLinkProps } from '@components/nhsuk-frontend/back-link';
 import NhsHeading from './nhs-heading';
+import { cookies } from 'next/headers';
+import NotificationBanner from './notification-banner';
 
 type Props = {
   children: ReactNode;
@@ -14,13 +16,16 @@ type Props = {
   backLink?: BackLinkProps;
 };
 
-const NhsTransactionalPage = ({
+const NhsTransactionalPage = async ({
   children = null,
   originPage,
   title,
   caption,
   backLink,
 }: Props) => {
+  const cookieStore = await cookies();
+  const notification = cookieStore.get('ams-notification')?.value;
+
   return (
     <>
       <Header showChangeSiteButton={false}>
@@ -30,6 +35,7 @@ const NhsTransactionalPage = ({
       <NhsMainContainer>
         {backLink && <BackLink {...backLink} />}
         {title && <NhsHeading title={title} caption={caption} />}
+        <NotificationBanner notification={notification} />
         {children}
       </NhsMainContainer>
       <Footer />

--- a/src/client/src/app/site/[site]/availability/cancel/page.tsx
+++ b/src/client/src/app/site/[site]/availability/cancel/page.tsx
@@ -5,8 +5,8 @@ import {
 } from '@services/appointmentsService';
 import { notFound } from 'next/navigation';
 import ConfirmCancellation from './confirm-cancellation';
-import NhsPage from '@components/nhs-page';
 import { NavigationByHrefProps } from '@components/nhsuk-frontend/back-link';
+import NhsTransactionalPage from '@components/nhs-transactional-page';
 
 type PageProps = {
   searchParams?: Promise<{
@@ -40,7 +40,7 @@ const Page = async ({ searchParams, params }: PageProps) => {
   };
 
   return (
-    <NhsPage
+    <NhsTransactionalPage
       title="Are you sure you want to cancel this session?"
       caption="Cancel session"
       originPage="edit-session"
@@ -52,7 +52,7 @@ const Page = async ({ searchParams, params }: PageProps) => {
         site={site.id}
         clinicalServices={clinicalServices}
       />
-    </NhsPage>
+    </NhsTransactionalPage>
   );
 };
 


### PR DESCRIPTION
**(cherry picked from commit 30687830fb527c2554b507f4e2c47401bcb82a15)**

# Description

As has been raised during testing 1233, the Reports link is still showing on the Cancel Session page because it's not transactional. This was just missed in the original PR:

<img width="2516" height="1566" alt="image"
src="https://github.com/user-attachments/assets/b3cd1b29-b728-4d07-8d5d-01888d71b998" />

Fixes # ([issue](https://nhsd-jira.digital.nhs.uk/browse/APPT-1233))

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests

