### PR TITLE
APPT-1353: Retire CancelSession endpoint with feature flag

### DIFF
--- a/src/api/Nhs.Appointments.Api/local.feature.flags.json
+++ b/src/api/Nhs.Appointments.Api/local.feature.flags.json
@@ -6,7 +6,8 @@
     "MultipleServices": false,
     "SiteSummaryReport": false,
     "SiteStatus": false,
-    "CancelDay":  false,
+    "CancelDay": false,
+    "ChangeSessionUpliftedJourney": false,
     "TestFeaturePercentageEnabled": {
       "EnabledFor": [
         {

--- a/src/api/Nhs.Appointments.Core/Features/Flags.cs
+++ b/src/api/Nhs.Appointments.Core/Features/Flags.cs
@@ -7,6 +7,7 @@ public static class Flags
     public const string SiteSummaryReport = "SiteSummaryReport";
     public const string SiteStatus = "SiteStatus";
     public const string CancelDay = "CancelDay";
+    public const string ChangeSessionUpliftedJourney = "ChangeSessionUpliftedJourney";
 
     #region TestFlags
     //a simple on/off global flag

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelSessionFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelSessionFunctionTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
@@ -10,19 +10,20 @@ using Nhs.Appointments.Api.Functions;
 using Nhs.Appointments.Api.Models;
 using Nhs.Appointments.Core;
 using Nhs.Appointments.Core.Features;
-using Nhs.Appointments.Core.UnitTests;
+using System.Net;
+using System.Text;
 
 namespace Nhs.Appointments.Api.Tests.Functions;
 
 public class CancelSessionFunctionTests
 {
+    private readonly CancelSessionFunction _sut;
     private readonly Mock<IAvailabilityWriteService> _availabilityWriteService = new();
     private readonly Mock<ILogger<CancelSessionFunction>> _logger = new();
     private readonly Mock<IMetricsRecorder> _metricsRecorder = new();
-
-    private readonly CancelSessionFunction _sut;
     private readonly Mock<IUserContextProvider> _userContextProvider = new();
     private readonly Mock<IValidator<CancelSessionRequest>> _validator = new();
+    private readonly Mock<IFeatureToggleHelper> _featureToggleHelper = new();
 
     public CancelSessionFunctionTests()
     {
@@ -31,7 +32,8 @@ public class CancelSessionFunctionTests
             _validator.Object,
             _userContextProvider.Object,
             _logger.Object,
-            _metricsRecorder.Object);
+            _metricsRecorder.Object,
+            _featureToggleHelper.Object);
         _validator.Setup(x => x.ValidateAsync(It.IsAny<CancelSessionRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ValidationResult());
     }
@@ -47,6 +49,7 @@ public class CancelSessionFunctionTests
             ["RSV:Adult"], 5, 2);
 
         var request = BuildRequest(cancelSessionRequest);
+        _featureToggleHelper.Setup(x => x.IsFeatureEnabled(Flags.ChangeSessionUpliftedJourney)).ReturnsAsync(false);
 
         var response = await _sut.RunAsync(request) as ContentResult;
 
@@ -58,6 +61,35 @@ public class CancelSessionFunctionTests
             cancelSessionRequest.Services,
             cancelSessionRequest.SlotLength,
             cancelSessionRequest.Capacity), Times.Once());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsNotFound_WhenChangeSessionUpliftedJourneyFlagIsOn()
+    {
+        var cancelSessionRequest = new CancelSessionRequest(
+            "TEST01",
+            new DateOnly(2025, 1, 10),
+            "09:00",
+            "12:00",
+            ["RSV:Adult"],
+            5, 
+            2
+        );
+        var request = BuildRequest(cancelSessionRequest);
+        _featureToggleHelper.Setup(x => x.IsFeatureEnabled(Flags.ChangeSessionUpliftedJourney)).ReturnsAsync(true);
+
+        var response = await _sut.RunAsync(request) as ContentResult;
+
+        response.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
+        _availabilityWriteService.Verify(x => x.CancelSession(
+            cancelSessionRequest.Site,
+            It.IsAny<DateOnly>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            cancelSessionRequest.Services,
+            cancelSessionRequest.SlotLength,
+            cancelSessionRequest.Capacity
+        ), Times.Never());
     }
 
     private static HttpRequest BuildRequest(CancelSessionRequest requestBody)


### PR DESCRIPTION
# Description
In this PR, we are adding feature flag that will disable CancelSession endpoint. At the same time, the feature flag will enable new endpoint for session edit, which will replace CancelSession endpoint. The new endpoint is being developed in APPT-1352.

# Checklist:

- [x] My work is behind a feature toggle (if appropriate)
- [x] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [x] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
