### PR TITLE
APPT 1386: cherry pick 2.6

### DIFF
--- a/infrastructure/resources/locals.tf
+++ b/infrastructure/resources/locals.tf
@@ -1,5 +1,4 @@
 locals {
-  mya_function_app_url     = var.environment == "dev" ? var.func_app_base_uri : "${var.nhs_host_url}/manage-your-appointments"
   auth_provider_return_uri = var.environment == "dev" ? "${var.func_app_base_uri}/api/auth-return" : "${var.nhs_host_url}/manage-your-appointments/api/auth-return"
   client_code_exchange_uri = var.environment == "dev" ? "${var.web_app_base_uri}/manage-your-appointments/auth/set-cookie" : "${var.nhs_host_url}/manage-your-appointments/auth/set-cookie"
   resource_group_name = var.environment == "pen"  ? azurerm_resource_group.nbs_mya_resource_group[0].name : var.environment == "perf" ? "${var.application}perf-rg-stag-${var.loc}" : var.environment == "dev" ? "${var.application}dev-rg-int-${var.loc}" : "${var.application}-rg-${var.environment}-${var.loc}"

--- a/infrastructure/resources/web_appservice.tf
+++ b/infrastructure/resources/web_appservice.tf
@@ -24,8 +24,8 @@ resource "azurerm_linux_web_app" "nbs_mya_web_app_service" {
   }
 
   app_settings = {
-    NBS_API_BASE_URL = local.mya_function_app_url
-    AUTH_HOST        = local.mya_function_app_url
+    NBS_API_BASE_URL = "https://${azurerm_windows_function_app.nbs_mya_http_func_app.default_hostname}"
+    AUTH_HOST        = "https://${azurerm_windows_function_app.nbs_mya_http_func_app.default_hostname}"
     CLIENT_BASE_PATH = "/manage-your-appointments"
     BUILD_NUMBER     = var.build_number
   }


### PR DESCRIPTION
**(cherry picked from commit 7d1716e1fc0709e86a635fca30dbbd4ca0a925fa)**

# Description

Update the web app to use the http functions urls directly instead of going via Akamai and the Frontdoor

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
