### PR TITLE
APPT-1389 update to terraform scaling out rules for the web application

### DIFF
--- a/infrastructure/environments/pen/main.tf
+++ b/infrastructure/environments/pen/main.tf
@@ -76,7 +76,8 @@ module "mya_application_pen" {
   app_service_plan_zone_redundancy_enabled        = true
   web_app_service_plan_min_worker_count           = 1
   web_app_service_plan_max_worker_count           = 20
-  web_app_service_plan_scale_out_worker_count     = 3
+  web_app_service_plan_scale_out_worker_count_max = 3
+  web_app_service_plan_scale_out_worker_count_min = 2
   web_app_service_plan_scale_in_worker_count      = 1
   app_insights_sampling_percentage                = 12.5
   storage_account_replication_type                = "ZRS"

--- a/infrastructure/environments/perf-ukw/main.tf
+++ b/infrastructure/environments/perf-ukw/main.tf
@@ -75,9 +75,9 @@ module "mya_application_perf" {
   create_cosmos_db                                = false
   create_app_config                               = false
   web_app_service_sku                             = "P1v3"
-  web_app_service_plan_default_worker_count       = 3
+  web_app_service_plan_default_worker_count       = 6
   app_service_plan_zone_redundancy_enabled        = false
-  web_app_service_plan_min_worker_count           = 1
+  web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
   web_app_service_plan_scale_out_worker_count     = 1
   web_app_service_plan_scale_in_worker_count      = 1

--- a/infrastructure/environments/perf-ukw/main.tf
+++ b/infrastructure/environments/perf-ukw/main.tf
@@ -79,7 +79,8 @@ module "mya_application_perf" {
   app_service_plan_zone_redundancy_enabled        = false
   web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
-  web_app_service_plan_scale_out_worker_count     = 1
+  web_app_service_plan_scale_out_worker_count_max = 1
+  web_app_service_plan_scale_out_worker_count_min = 1
   web_app_service_plan_scale_in_worker_count      = 1
   app_insights_sampling_percentage                = 12.5
   storage_account_replication_type                = "LRS"

--- a/infrastructure/environments/perf/main.tf
+++ b/infrastructure/environments/perf/main.tf
@@ -72,9 +72,9 @@ module "mya_application_perf" {
   create_cosmos_db                                = true
   create_app_config                               = true
   web_app_service_sku                             = "P1v3"
-  web_app_service_plan_default_worker_count       = 3
+  web_app_service_plan_default_worker_count       = 6
   app_service_plan_zone_redundancy_enabled        = true
-  web_app_service_plan_min_worker_count           = 1
+  web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
   web_app_service_plan_scale_out_worker_count     = 3
   web_app_service_plan_scale_in_worker_count      = 1

--- a/infrastructure/environments/perf/main.tf
+++ b/infrastructure/environments/perf/main.tf
@@ -76,7 +76,8 @@ module "mya_application_perf" {
   app_service_plan_zone_redundancy_enabled        = true
   web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
-  web_app_service_plan_scale_out_worker_count     = 3
+  web_app_service_plan_scale_out_worker_count_max = 3
+  web_app_service_plan_scale_out_worker_count_min = 2
   web_app_service_plan_scale_in_worker_count      = 1
   app_insights_sampling_percentage                = 12.5
   storage_account_replication_type                = "ZRS"

--- a/infrastructure/environments/prod-ukw/main.tf
+++ b/infrastructure/environments/prod-ukw/main.tf
@@ -75,9 +75,9 @@ module "mya_application_prod_ukw" {
   create_cosmos_db                                = false
   create_app_config                               = false
   web_app_service_sku                             = "P1v3"
-  web_app_service_plan_default_worker_count       = 3
+  web_app_service_plan_default_worker_count       = 6
   app_service_plan_zone_redundancy_enabled        = false
-  web_app_service_plan_min_worker_count           = 1
+  web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
   web_app_service_plan_scale_out_worker_count     = 3
   web_app_service_plan_scale_in_worker_count      = 1

--- a/infrastructure/environments/prod-ukw/main.tf
+++ b/infrastructure/environments/prod-ukw/main.tf
@@ -79,7 +79,8 @@ module "mya_application_prod_ukw" {
   app_service_plan_zone_redundancy_enabled        = false
   web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
-  web_app_service_plan_scale_out_worker_count     = 3
+  web_app_service_plan_scale_out_worker_count_max = 3
+  web_app_service_plan_scale_out_worker_count_min = 2
   web_app_service_plan_scale_in_worker_count      = 1
   app_insights_sampling_percentage                = 12.5
   storage_account_replication_type                = "LRS"

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -76,7 +76,8 @@ module "mya_application_prod" {
   app_service_plan_zone_redundancy_enabled        = true
   web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
-  web_app_service_plan_scale_out_worker_count     = 3
+  web_app_service_plan_scale_out_worker_count_max = 3
+  web_app_service_plan_scale_out_worker_count_min = 2
   web_app_service_plan_scale_in_worker_count      = 1
   app_insights_sampling_percentage                = 12.5
   storage_account_replication_type                = "ZRS"

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -72,9 +72,9 @@ module "mya_application_prod" {
   create_cosmos_db                                = true
   create_app_config                               = true
   web_app_service_sku                             = "P1v3"
-  web_app_service_plan_default_worker_count       = 3
+  web_app_service_plan_default_worker_count       = 6
   app_service_plan_zone_redundancy_enabled        = true
-  web_app_service_plan_min_worker_count           = 1
+  web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
   web_app_service_plan_scale_out_worker_count     = 3
   web_app_service_plan_scale_in_worker_count      = 1

--- a/infrastructure/environments/stag-ukw/main.tf
+++ b/infrastructure/environments/stag-ukw/main.tf
@@ -79,7 +79,8 @@ module "mya_application_stag_ukw" {
   app_service_plan_zone_redundancy_enabled        = false
   web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
-  web_app_service_plan_scale_out_worker_count     = 3
+  web_app_service_plan_scale_out_worker_count_max = 3
+  web_app_service_plan_scale_out_worker_count_min = 2
   web_app_service_plan_scale_in_worker_count      = 1
   app_insights_sampling_percentage                = 12.5
   storage_account_replication_type                = "LRS"

--- a/infrastructure/environments/stag-ukw/main.tf
+++ b/infrastructure/environments/stag-ukw/main.tf
@@ -75,9 +75,9 @@ module "mya_application_stag_ukw" {
   create_cosmos_db                                = false
   create_app_config                               = false
   web_app_service_sku                             = "P1v3"
-  web_app_service_plan_default_worker_count       = 3
+  web_app_service_plan_default_worker_count       = 6
   app_service_plan_zone_redundancy_enabled        = false
-  web_app_service_plan_min_worker_count           = 1
+  web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
   web_app_service_plan_scale_out_worker_count     = 3
   web_app_service_plan_scale_in_worker_count      = 1

--- a/infrastructure/environments/stag/main.tf
+++ b/infrastructure/environments/stag/main.tf
@@ -76,7 +76,8 @@ module "mya_application_stag" {
   app_service_plan_zone_redundancy_enabled        = true
   web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
-  web_app_service_plan_scale_out_worker_count     = 3
+  web_app_service_plan_scale_out_worker_count_max = 3
+  web_app_service_plan_scale_out_worker_count_min = 2
   web_app_service_plan_scale_in_worker_count      = 1
   app_insights_sampling_percentage                = 12.5
   storage_account_replication_type                = "ZRS"

--- a/infrastructure/environments/stag/main.tf
+++ b/infrastructure/environments/stag/main.tf
@@ -72,9 +72,9 @@ module "mya_application_stag" {
   create_cosmos_db                                = true
   create_app_config                               = true
   web_app_service_sku                             = "P1v3"
-  web_app_service_plan_default_worker_count       = 3
+  web_app_service_plan_default_worker_count       = 6
   app_service_plan_zone_redundancy_enabled        = true
-  web_app_service_plan_min_worker_count           = 1
+  web_app_service_plan_min_worker_count           = 4
   web_app_service_plan_max_worker_count           = 20
   web_app_service_plan_scale_out_worker_count     = 3
   web_app_service_plan_scale_in_worker_count      = 1

--- a/infrastructure/resources/variables.tf
+++ b/infrastructure/resources/variables.tf
@@ -214,7 +214,12 @@ variable "web_app_service_plan_max_worker_count" {
   default = 1
 }
 
-variable "web_app_service_plan_scale_out_worker_count" {
+variable "web_app_service_plan_scale_out_worker_count_max" {
+  type    = number
+  default = 1
+}
+
+variable "web_app_service_plan_scale_out_worker_count_min" {
   type    = number
   default = 1
 }

--- a/infrastructure/resources/web_appservice.tf
+++ b/infrastructure/resources/web_appservice.tf
@@ -82,7 +82,94 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
       maximum = var.web_app_service_plan_max_worker_count
     }
 
-    # CPU auto scale rule
+    # Scale out rules for MYA
+
+    # Memory scaling
+    rule {
+      metric_trigger {
+        metric_name        = "MemoryPercentage"
+        metric_resource_id = azurerm_service_plan.nbs_mya_web_app_service_plan.id
+        time_grain         = "PT1M"
+        statistic          = "Average"
+        time_window        = "PT3M"
+        time_aggregation   = "Average"
+        operator           = "GreaterThan"
+        threshold          = 70
+        metric_namespace   = "microsoft.web/serverfarms"
+      }
+
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = var.web_app_service_plan_scale_out_worker_count
+        cooldown  = "PT10M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name        = "MemoryPercentage"
+        metric_resource_id = azurerm_service_plan.nbs_mya_web_app_service_plan.id
+        time_grain         = "PT1M"
+        statistic          = "Average"
+        time_window        = "PT5M"
+        time_aggregation   = "Average"
+        operator           = "GreaterThan"
+        threshold          = 55
+        metric_namespace   = "microsoft.web/serverfarms"
+      }
+
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = var.web_app_service_plan_scale_out_worker_count
+        cooldown  = "PT15M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name        = "MemoryPercentage"
+        metric_resource_id = azurerm_service_plan.nbs_mya_web_app_service_plan.id
+        time_grain         = "PT1M"
+        statistic          = "Average"
+        time_window        = "PT10M"
+        time_aggregation   = "Average"
+        operator           = "GreaterThan"
+        threshold          = 40
+        metric_namespace   = "microsoft.web/serverfarms"
+      }
+
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = var.web_app_service_plan_scale_out_worker_count
+        cooldown  = "PT20M"
+      }
+    }    
+
+    # CPU scaling
+    rule {
+      metric_trigger {
+        metric_name        = "CpuPercentage"
+        metric_resource_id = azurerm_service_plan.nbs_mya_web_app_service_plan.id
+        time_grain         = "PT1M"
+        statistic          = "Average"
+        time_window        = "PT3M"
+        time_aggregation   = "Average"
+        operator           = "GreaterThan"
+        threshold          = 60
+        metric_namespace   = "microsoft.web/serverfarms"
+      }
+
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = var.web_app_service_plan_scale_out_worker_count
+        cooldown  = "PT10M"
+      }
+    }
+
     rule {
       metric_trigger {
         metric_name        = "CpuPercentage"
@@ -100,9 +187,9 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
         direction = "Increase"
         type      = "ChangeCount"
         value     = var.web_app_service_plan_scale_out_worker_count
-        cooldown  = "PT5M"
+        cooldown  = "PT15M"
       }
-    }
+    }    
 
     rule {
       metric_trigger {
@@ -110,73 +197,7 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
         metric_resource_id = azurerm_service_plan.nbs_mya_web_app_service_plan.id
         time_grain         = "PT1M"
         statistic          = "Average"
-        time_window        = "PT5M"
-        time_aggregation   = "Average"
-        operator           = "LessThan"
-        threshold          = 30
-        metric_namespace   = "microsoft.web/serverfarms"
-      }
-
-      scale_action {
-        direction = "Decrease"
-        type      = "ChangeCount"
-        value     = var.web_app_service_plan_scale_in_worker_count
-        cooldown  = "PT10M"
-      }
-    }
-
-    # Memory auto scale rule
-    rule {
-      metric_trigger {
-        metric_name        = "MemoryPercentage"
-        metric_resource_id = azurerm_service_plan.nbs_mya_web_app_service_plan.id
-        time_grain         = "PT1M"
-        statistic          = "Average"
-        time_window        = "PT5M"
-        time_aggregation   = "Average"
-        operator           = "GreaterThan"
-        threshold          = 50
-        metric_namespace   = "microsoft.web/serverfarms"
-      }
-
-      scale_action {
-        direction = "Increase"
-        type      = "ChangeCount"
-        value     = var.web_app_service_plan_scale_out_worker_count
-        cooldown  = "PT5M"
-      }
-    }
-
-
-    rule {
-      metric_trigger {
-        metric_name        = "MemoryPercentage"
-        metric_resource_id = azurerm_service_plan.nbs_mya_web_app_service_plan.id
-        time_grain         = "PT1M"
-        statistic          = "Average"
-        time_window        = "PT5M"
-        time_aggregation   = "Average"
-        operator           = "LessThan"
-        threshold          = 40
-        metric_namespace   = "microsoft.web/serverfarms"
-      }
-
-      scale_action {
-        direction = "Decrease"
-        type      = "ChangeCount"
-        value     = var.web_app_service_plan_scale_in_worker_count
-        cooldown  = "PT10M"
-      }
-    }
-
-    # HttpQueueLength auto scale rule
-    rule {
-      metric_trigger {
-        metric_name        = "HttpQueueLength"
-        metric_resource_id = azurerm_service_plan.nbs_mya_web_app_service_plan.id
-        time_grain         = "PT1M"
-        statistic          = "Average"
-        time_window        = "PT5M"
+        time_window        = "PT10M"
         time_aggregation   = "Average"
         operator           = "GreaterThan"
         threshold          = 20
@@ -187,18 +208,17 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
         direction = "Increase"
         type      = "ChangeCount"
         value     = var.web_app_service_plan_scale_out_worker_count
-        cooldown  = "PT5M"
+        cooldown  = "PT20M"
       }
-    }
-
+    }    
 
     rule {
       metric_trigger {
-        metric_name        = "HttpQueueLength"
+        metric_name        = "CpuPercentage"
         metric_resource_id = azurerm_service_plan.nbs_mya_web_app_service_plan.id
         time_grain         = "PT1M"
         statistic          = "Average"
-        time_window        = "PT5M"
+        time_window        = "PT45M"
         time_aggregation   = "Average"
         operator           = "LessThan"
         threshold          = 10
@@ -209,7 +229,7 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
         direction = "Decrease"
         type      = "ChangeCount"
         value     = var.web_app_service_plan_scale_in_worker_count
-        cooldown  = "PT10M"
+        cooldown  = "PT40M"
       }
     }
   }

--- a/infrastructure/resources/web_appservice.tf
+++ b/infrastructure/resources/web_appservice.tf
@@ -101,7 +101,7 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
-        value     = var.web_app_service_plan_scale_out_worker_count
+        value     = var.web_app_service_plan_scale_out_worker_count_max
         cooldown  = "PT10M"
       }
     }
@@ -122,7 +122,7 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
-        value     = var.web_app_service_plan_scale_out_worker_count
+        value     = var.web_app_service_plan_scale_out_worker_count_max
         cooldown  = "PT15M"
       }
     }
@@ -143,7 +143,7 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
-        value     = var.web_app_service_plan_scale_out_worker_count
+        value     = var.web_app_service_plan_scale_out_worker_count_min
         cooldown  = "PT20M"
       }
     }    
@@ -165,7 +165,7 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
-        value     = var.web_app_service_plan_scale_out_worker_count
+        value     = var.web_app_service_plan_scale_out_worker_count_max
         cooldown  = "PT10M"
       }
     }
@@ -186,7 +186,7 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
-        value     = var.web_app_service_plan_scale_out_worker_count
+        value     = var.web_app_service_plan_scale_out_worker_count_max
         cooldown  = "PT15M"
       }
     }    
@@ -207,7 +207,7 @@ resource "azurerm_monitor_autoscale_setting" "nbs_mya_web_app_service_autoscale_
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
-        value     = var.web_app_service_plan_scale_out_worker_count
+        value     = var.web_app_service_plan_scale_out_worker_count_min
         cooldown  = "PT20M"
       }
     }    


### PR DESCRIPTION
# Description

1. Update to the scale out settings for the MYA web app
- This is increasing from 1 running instance (actually 2 in production) to 4 minimum instances in production
- The default is set to 6 and the minimum is set to 4
- So:
   - Idle 6 instances will be available
   - Low load but above minimum - scales down to 4
   - High load it can scale up to 20

2. Scale out and in rules
- Adopting the recommended settings from our performance test findings

This is a temporary increase, so only adjusting for STAG and PROD

# Checklist:

- [ N/A ] My work is behind a feature toggle (if appropriate)
- [ N/A ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ Y ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ N/A ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ N/A ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ N/A ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ N/A ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ N/A ] If I've made UI changes, I've added appropriate Playwright and Jest tests