### PR TITLE
APPT-1353 - Fix up - feature toggling the cancel session integration tests

### DIFF
--- a/tests/Nhs.Appointments.Api.Integration/ChangeSessionUpliftedJourneySerialToggleCollection.cs
+++ b/tests/Nhs.Appointments.Api.Integration/ChangeSessionUpliftedJourneySerialToggleCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Nhs.Appointments.Api.Integration;
+
+[CollectionDefinition("ChangeSessionUpliftedJourneyToggle")]
+public class ChangeSessionUpliftedJourneySerialToggleCollection : ICollectionFixture<object>
+{
+}

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CancelSession/CancelSessionFeatureSteps.cs
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CancelSession/CancelSessionFeatureSteps.cs
@@ -1,17 +1,18 @@
+using FluentAssertions;
+using Gherkin.Ast;
+using Nhs.Appointments.Api.Json;
+using Nhs.Appointments.Core.Features;
 using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using FluentAssertions;
-using Gherkin.Ast;
-using Nhs.Appointments.Api.Json;
+using Xunit;
 using Xunit.Gherkin.Quick;
 
 namespace Nhs.Appointments.Api.Integration.Scenarios.CancelSession;
 
-[FeatureFile("./Scenarios/CancelSession/CancelSession.feature")]
-public class CancelSessionFeatureSteps : BaseFeatureSteps
+public abstract class CancelSessionFeatureSteps(string flag, bool enabled) : FeatureToggledSteps(flag, enabled)
 {
     private Core.Booking _actualResponse;
     private HttpResponseMessage _response;
@@ -74,5 +75,16 @@ public class CancelSessionFeatureSteps : BaseFeatureSteps
         _actualResponse.Service.Should().Be(expectedBooking.Service);
         _actualResponse.Site.Should().Be(expectedBooking.Site);
     }
+
+    [Then(@"the call should fail with (\d*)")]
+    public void AssertFailureCode(int statusCode) => _response.StatusCode.Should().Be((HttpStatusCode)statusCode);
+
+    [Collection("ChangeSessionUpliftedJourneyToggle")]
+    [FeatureFile("./Scenarios/CancelSession/CancelSession_Disabled.feature")]
+    public class CancelSessionFeatureSteps_Enabled() : CancelSessionFeatureSteps(Flags.ChangeSessionUpliftedJourney, true);
+
+    [Collection("ChangeSessionUpliftedJourneyToggle")]
+    [FeatureFile("./Scenarios/CancelSession/CancelSession.feature")]
+    public class CancelSessionFeatureSteps_Disabled() : CancelSessionFeatureSteps(Flags.ChangeSessionUpliftedJourney, false);
 }
 

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CancelSession/CancelSession_Disabled.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CancelSession/CancelSession_Disabled.feature
@@ -1,0 +1,13 @@
+Feature: Cancel a session
+
+  Scenario: Cancel the only session on a day
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following bookings have been made
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:45 | 5        | COVID   | 68537-44913 |
+    When I cancel the following session
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    Then the call should fail with 404


### PR DESCRIPTION
# Description

The introduction of the ChangeSessionUpliftedJourney feature toggle meant the CancelSession endpoint would return a 404 if that toggle is enabled but the integration tests weren't updated so this PR sorts that. 

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
