### PR TITLE
APPT-1252 - Removing the feature flag check on the cancel session endpoint

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/CancelSessionFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelSessionFunction.cs
@@ -46,15 +46,7 @@ public class CancelSessionFunction(
 
     protected override async Task<ApiResult<EmptyResponse>> HandleRequest(CancelSessionRequest request, ILogger logger)
     {
-        if(await featureToggleHelper.IsFeatureEnabled(Flags.ChangeSessionUpliftedJourney))
-        {
-            return ApiResult<EmptyResponse>.Failed(
-                HttpStatusCode.NotFound, "Cancel session function is not available."
-            );
-        }
-        else
-        {
-            await availabilityWriteService.CancelSession(
+        await availabilityWriteService.CancelSession(
                 request.Site,
                 request.Date,
                 request.From,
@@ -64,7 +56,6 @@ public class CancelSessionFunction(
                 request.Capacity
             );
 
-            return Success(new EmptyResponse());
-        }
+        return Success(new EmptyResponse());
     }
 }

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelSessionFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/CancelSessionFunctionTests.cs
@@ -63,35 +63,6 @@ public class CancelSessionFunctionTests
             cancelSessionRequest.Capacity), Times.Once());
     }
 
-    [Fact]
-    public async Task RunAsync_ReturnsNotFound_WhenChangeSessionUpliftedJourneyFlagIsOn()
-    {
-        var cancelSessionRequest = new CancelSessionRequest(
-            "TEST01",
-            new DateOnly(2025, 1, 10),
-            "09:00",
-            "12:00",
-            ["RSV:Adult"],
-            5, 
-            2
-        );
-        var request = BuildRequest(cancelSessionRequest);
-        _featureToggleHelper.Setup(x => x.IsFeatureEnabled(Flags.ChangeSessionUpliftedJourney)).ReturnsAsync(true);
-
-        var response = await _sut.RunAsync(request) as ContentResult;
-
-        response.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
-        _availabilityWriteService.Verify(x => x.CancelSession(
-            cancelSessionRequest.Site,
-            It.IsAny<DateOnly>(),
-            It.IsAny<string>(),
-            It.IsAny<string>(),
-            cancelSessionRequest.Services,
-            cancelSessionRequest.SlotLength,
-            cancelSessionRequest.Capacity
-        ), Times.Never());
-    }
-
     private static HttpRequest BuildRequest(CancelSessionRequest requestBody)
     {
         var body = JsonConvert.SerializeObject(requestBody);


### PR DESCRIPTION
# Description

This is a temporary change to remove the feature flag check on the cancel session endpoint. The change was made but subsequent integration tests which use that endpoint were not updated and it is blocking the new edit session endpoint change from being merged. I will keep the feature flag change in as it is needed elsewhere but there is already a ticket to update all integration tests which use this endpoint to use the new endpoint. Once that work has been done, this feature flag check can be added back in.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
