### PR TITLE
Appt-921: terraform error keyvault

### DIFF
--- a/infrastructure/resources/containerapp.tf
+++ b/infrastructure/resources/containerapp.tf
@@ -31,7 +31,7 @@ resource "azurerm_container_app_job" "nbs_mya_booking_extracts_job" {
   }
   secret {
     name  = "blob-connection-string"
-    value = var.data_extract_file_sender_options_type == "blob" ? azurerm_storage_account.nbs_mya_container_app_storage_account[0].primary_blob_connection_string : ""
+    value = var.data_extract_file_sender_options_type == "blob" ? azurerm_storage_account.nbs_mya_container_app_storage_account[0].primary_blob_connection_string : "UNSET"
   }
   secret {
     name  = "key-vault-secret"

--- a/infrastructure/resources/variables.tf
+++ b/infrastructure/resources/variables.tf
@@ -394,6 +394,6 @@ variable "keyvault_client_id" {
 
 variable "keyvault_client_secret" {
   type = string
-  default = ""
+  default = "UNSET"
   sensitive = true      
 }


### PR DESCRIPTION
# Description

Empty or Null secret values are not supported in container apps, set them to UNSET

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
