### PR TITLE
APPT-1395 - Wrapping the session validation page in the change session uplift feature flag

### DIFF
--- a/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.test.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.test.tsx
@@ -35,6 +35,7 @@ describe('Edit Session Time And Capacity Form', () => {
         date={'2024-06-10 07:00:00'}
         site={mockSite}
         existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        changeSessionUpliftedJourneyEnabled={false}
       />,
     );
 
@@ -49,6 +50,7 @@ describe('Edit Session Time And Capacity Form', () => {
         date={'2024-06-10 07:00:00'}
         site={mockSite}
         existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        changeSessionUpliftedJourneyEnabled={false}
       />,
     );
 
@@ -119,6 +121,7 @@ describe('Edit Session Time And Capacity Form', () => {
         date={'2024-06-10 07:00:00'}
         site={mockSite}
         existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        changeSessionUpliftedJourneyEnabled={false}
       />,
     );
 
@@ -175,6 +178,7 @@ describe('Edit Session Time And Capacity Form', () => {
           date={'2024-06-10 07:00:00'}
           site={mockSite}
           existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+          changeSessionUpliftedJourneyEnabled={false}
         />,
       );
 
@@ -218,6 +222,7 @@ describe('Edit Session Time And Capacity Form', () => {
         date={'2024-06-10 07:00:00'}
         site={mockSite}
         existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        changeSessionUpliftedJourneyEnabled={false}
       />,
     );
 
@@ -237,6 +242,7 @@ describe('Edit Session Time And Capacity Form', () => {
         date={'2024-06-10 07:00:00'}
         site={mockSite}
         existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        changeSessionUpliftedJourneyEnabled={false}
       />,
     );
 
@@ -256,6 +262,7 @@ describe('Edit Session Time And Capacity Form', () => {
         date={'2024-06-10 07:00:00'}
         site={mockSite}
         existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        changeSessionUpliftedJourneyEnabled={false}
       />,
     );
 
@@ -284,6 +291,7 @@ describe('Edit Session Time And Capacity Form', () => {
         date={'2024-06-10 07:00:00'}
         site={mockSite}
         existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        changeSessionUpliftedJourneyEnabled={true}
       />,
     );
 
@@ -315,5 +323,45 @@ describe('Edit Session Time And Capacity Form', () => {
     await user.click(screen.getByRole('button', { name: 'Continue' }));
 
     expect(editSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate to the edit start time page when the change session uplift feature flag is disabled', async () => {
+    const { user } = render(
+      <EditSessionTimeAndCapacityForm
+        date={'2024-06-10 07:00:00'}
+        site={mockSite}
+        existingSession={mockWeekAvailability__Summary[0].sessions[0]}
+        changeSessionUpliftedJourneyEnabled={false}
+      />,
+    );
+
+    const startTimeHourInput = screen.getByRole('textbox', {
+      name: 'Session start time - hour',
+    });
+    const startTimeMinuteInput = screen.getByRole('textbox', {
+      name: 'Session start time - minute',
+    });
+    const endTimeHourInput = screen.getByRole('textbox', {
+      name: 'Session end time - hour',
+    });
+    const endTimeMinuteInput = screen.getByRole('textbox', {
+      name: 'Session end time - minute',
+    });
+
+    await user.clear(startTimeHourInput);
+    await user.type(startTimeHourInput, '10');
+
+    await user.clear(startTimeMinuteInput);
+    await user.type(startTimeMinuteInput, '27');
+
+    await user.clear(endTimeHourInput);
+    await user.type(endTimeHourInput, '12');
+
+    await user.clear(endTimeMinuteInput);
+    await user.type(endTimeMinuteInput, '00');
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(editSessionMock).toHaveBeenCalled();
   });
 });

--- a/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-session-time-and-capacity-form.tsx
@@ -33,12 +33,14 @@ type Props = {
   date: string;
   site: Site;
   existingSession: SessionSummary;
+  changeSessionUpliftedJourneyEnabled: boolean;
 };
 
 const EditSessionTimeAndCapacityForm = ({
   site,
   existingSession,
   date,
+  changeSessionUpliftedJourneyEnabled,
 }: Props) => {
   const [pendingSubmit, startTransition] = useTransition();
   const existingUkStartTime = parseToUkDatetime(
@@ -110,7 +112,8 @@ const EditSessionTimeAndCapacityForm = ({
 
       if (
         existingSession.totalSupportedAppointments === 0 ||
-        validSessionStartTime
+        validSessionStartTime ||
+        !changeSessionUpliftedJourneyEnabled
       ) {
         await updateSession(form, updatedSession);
         return;

--- a/src/client/src/app/site/[site]/availability/edit/edit-start-time/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/edit-start-time/page.tsx
@@ -1,4 +1,8 @@
-import { assertPermission, fetchSite } from '@services/appointmentsService';
+import {
+  assertFeatureEnabled,
+  assertPermission,
+  fetchSite,
+} from '@services/appointmentsService';
 import { parseToUkDatetime } from '@services/timeService';
 import { AvailabilitySession, SessionSummary } from '@types';
 import { notFound } from 'next/navigation';
@@ -30,6 +34,8 @@ const Page = async ({ searchParams, params }: PageProps) => {
   }
 
   await fromServer(assertPermission(siteFromPath, 'availability:setup'));
+  await fromServer(assertFeatureEnabled('ChangeSessionUpliftedJourney'));
+
   const parsedDate = parseToUkDatetime(date);
   const site = await fromServer(fetchSite(siteFromPath));
 

--- a/src/client/src/app/site/[site]/availability/edit/page.tsx
+++ b/src/client/src/app/site/[site]/availability/edit/page.tsx
@@ -1,4 +1,8 @@
-import { assertPermission, fetchSite } from '@services/appointmentsService';
+import {
+  assertPermission,
+  fetchFeatureFlag,
+  fetchSite,
+} from '@services/appointmentsService';
 import { SessionSummary } from '@types';
 import EditSessionTimeAndCapacityForm from './edit-session-time-and-capacity-form';
 import { parseToUkDatetime } from '@services/timeService';
@@ -26,6 +30,9 @@ const Page = async ({ searchParams, params }: PageProps) => {
   await fromServer(assertPermission(siteFromPath, 'availability:setup'));
   const parsedDate = parseToUkDatetime(date);
   const site = await fromServer(fetchSite(siteFromPath));
+  const changeSessionUpliftedJourney = await fromServer(
+    fetchFeatureFlag('ChangeSessionUpliftedJourney'),
+  );
 
   const sessionSummary: SessionSummary = JSON.parse(atob(session));
 
@@ -44,6 +51,9 @@ const Page = async ({ searchParams, params }: PageProps) => {
         date={date}
         site={site}
         existingSession={sessionSummary}
+        changeSessionUpliftedJourneyEnabled={
+          changeSessionUpliftedJourney.enabled
+        }
       />
     </NhsTransactionalPage>
   );


### PR DESCRIPTION
# Description

The new session time / validation page is part of the change session uplift work which now has a feature flag. This PR wraps that page in the feature flag and ensures it doesn't appear if it's disabled.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [x] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
