### PR TITLE
Appt 1401 - Update cancel session integration tests

### DIFF
--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/AvailabilityCalculations/BestFit_ChangeSessionUpliftDisabled.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/AvailabilityCalculations/BestFit_ChangeSessionUpliftDisabled.feature
@@ -1,0 +1,18 @@
+Feature: The Best Fit Problem
+
+  Scenario: Cancelling a session orphans the last created booking
+    Given the site is configured for MYA
+    When I create the following availability
+      | Date     | From  | Until | SlotLength | Capacity | Services    |
+      | Tomorrow | 09:00 | 10:00 | 10         | 1        | Green,Blue  |
+      | Tomorrow | 09:00 | 10:00 | 10         | 1        | Blue,Orange |
+      | Tomorrow | 09:00 | 10:00 | 10         | 1        | Orange,Blue |
+    Then I make the following bookings
+      | Date     | Time  | Duration | Service |
+      | Tomorrow | 09:00 | 10       | Blue    |
+      | Tomorrow | 09:00 | 10       | Orange  |
+      | Tomorrow | 09:00 | 10       | Blue    |
+    When I cancel the following sessions
+      | Date     | From  | Until | Blue        | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | Blue,Orange | 10          | 1        |
+    Then the call should fail with 501

--- a/tests/Nhs.Appointments.Api.Integration/Scenarios/CancelSession/CancelSession_Disabled.feature
+++ b/tests/Nhs.Appointments.Api.Integration/Scenarios/CancelSession/CancelSession_Disabled.feature
@@ -1,0 +1,13 @@
+Feature: Cancel a session
+
+  Scenario: Cancel the only session on a day
+    Given the following sessions
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    And the following bookings have been made
+      | Date     | Time  | Duration | Service | Reference   |
+      | Tomorrow | 09:45 | 5        | COVID   | 68537-44913 |
+    When I cancel the following session
+      | Date     | From  | Until | Services | Slot Length | Capacity |
+      | Tomorrow | 09:00 | 10:00 | COVID    | 5           | 1        |
+    Then the call should fail with 501


### PR DESCRIPTION
# Description

As we're going to retire the existing cancel session endpoint, we need to update integration tests to use the new endpoint and update them to use the feature toggle pattern. This also includes changes to the best fit tests as some of them use the same cancel session endpoint.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
