### PR TITLE
Revert "APPT-1252 - Removing the feature flag check on the cancel session endpoint

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/CancelSessionFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/CancelSessionFunction.cs
@@ -46,7 +46,15 @@ public class CancelSessionFunction(
 
     protected override async Task<ApiResult<EmptyResponse>> HandleRequest(CancelSessionRequest request, ILogger logger)
     {
-        await availabilityWriteService.CancelSession(
+        if(await featureToggleHelper.IsFeatureEnabled(Flags.ChangeSessionUpliftedJourney))
+        {
+            return ApiResult<EmptyResponse>.Failed(
+                HttpStatusCode.NotFound, "Cancel session function is not available."
+            );
+        }
+        else
+        {
+            await availabilityWriteService.CancelSession(
                 request.Site,
                 request.Date,
                 request.From,
@@ -56,6 +64,7 @@ public class CancelSessionFunction(
                 request.Capacity
             );
 
-        return Success(new EmptyResponse());
+            return Success(new EmptyResponse());
+        }
     }
 }


### PR DESCRIPTION
This reverts commit a6474e901afca3987ffec54d00e1dc7d51fb59db.

# Description

Reverting the change for retiring the cancel session endpoint as integration tests have now been updated to use the new edit session endpoint.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
