### PR TITLE
APPT-1299 - Adding booking batch size (when present) to reports

### DIFF
--- a/data/BookingsDataExtracts/BookingDataConverter.cs
+++ b/data/BookingsDataExtracts/BookingDataConverter.cs
@@ -42,6 +42,8 @@ public class BookingDataConverter(IEnumerable<SiteDocument> sites)
     public static string ExtractService(BookingDocument booking) => booking.Service;
 
     public static string ExtractCancelledDateTime(BookingDocument booking) => booking.Status == AppointmentStatus.Cancelled ? booking.StatusUpdated.ToString("yyyy-MM-ddTHH:mm:sszzz") : null;
+
+    public static int? ExtractBatchSize(BookingDocument booking) => booking.BookingBatchSize ?? null;
     
     private static string TransposeSource(string source)
     {

--- a/data/BookingsDataExtracts/BookingDataExtractFields.cs
+++ b/data/BookingsDataExtracts/BookingDataExtractFields.cs
@@ -20,5 +20,6 @@ public static class BookingDataExtractFields
     public static string BookingSystem => "BOOKING_SYSTEM";
     public static string CancelledDateTime => "CANCELLED_DATE_TIME";
     public static string CancellationReason => "CANCELLATION_REASON";
+    public static string BatchSize => "BATCH_SIZE";
 
 }

--- a/data/BookingsDataExtracts/BookingsDataExtract.cs
+++ b/data/BookingsDataExtracts/BookingsDataExtract.cs
@@ -48,6 +48,7 @@ public class BookingDataExtract(
             new DataFactory<BookingDocument, string>(BookingDataExtractFields.IntegratedCareBoard, dataConverter.ExtractICB),
             new DataFactory<BookingDocument, string>(BookingDataExtractFields.BookingSystem, doc => "MYA"),
             new DataFactory<BookingDocument, string>(BookingDataExtractFields.CancelledDateTime, BookingDataConverter.ExtractCancelledDateTime),
+            new DataFactory<BookingDocument, int?>(BookingDataExtractFields.BatchSize, BookingDataConverter.ExtractBatchSize),
         };
            
         logger.LogInformation("Preparing to write");

--- a/tests/BookingDataExtracts.UnitTests/BookingDataConverterTests.cs
+++ b/tests/BookingDataExtracts.UnitTests/BookingDataConverterTests.cs
@@ -229,6 +229,27 @@ public class BookingDataConverterTests
         result.Should().Be(expectedData);
     }
 
+    [Fact]
+    public void ExtractBatchSize_IsNull_WhenBatchSizeNoPresent()
+    {
+        var testDocument = new NbsBookingDocument();
+        var converter = new BookingDataConverter(TestSites);
+        var result = BookingDataConverter.ExtractBatchSize(testDocument);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractBatchSize_ReturnsCorrectSize()
+    {
+        var testDocument = new NbsBookingDocument
+        {
+            BookingBatchSize = 2
+        };
+        var result = BookingDataConverter.ExtractBatchSize(testDocument);
+
+        result.Should().Be(2);
+    }
 
     private IEnumerable<SiteDocument> TestSites => new[]
     {


### PR DESCRIPTION
# Description

Adding booking batch size (when present) to reports

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
