### PR TITLE
Appt 1354: Comma separated strings

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/GetReportSiteSummaryFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetReportSiteSummaryFunction.cs
@@ -85,20 +85,22 @@ public class GetReportSiteSummaryFunction(
         foreach (var row in rows)
         {
             await csvWriter.WriteLineAsync(string.Join(',', [
-                SiteReportMap.SiteName(row),
-                SiteReportMap.ICB(row),
-                SiteReportMap.Region(row),
-                SiteReportMap.OdsCode(row),
-                SiteReportMap.Longitude(row),
-                SiteReportMap.Latitude(row),
-                string.Join(',', distinctServices.Select(service => SiteReportMap.BookingsCount(row, service))),
-                SiteReportMap.TotalBookings(row).ToString(),
-                SiteReportMap.Cancelled(row).ToString(),
-                SiteReportMap.MaximumCapacity(row).ToString(),
-                string.Join(',', distinctServices.Select(service => SiteReportMap.CapacityCount(row, service)))
+                CsvValue(SiteReportMap.SiteName(row)),
+                CsvValue(SiteReportMap.ICB(row)),
+                CsvValue(SiteReportMap.Region(row)),
+                CsvValue(SiteReportMap.OdsCode(row)),
+                CsvValue(SiteReportMap.Longitude(row)),
+                CsvValue(SiteReportMap.Latitude(row)),
+                string.Join(',', distinctServices.Select(service => CsvValue(SiteReportMap.BookingsCount(row, service)))),
+                CsvValue(SiteReportMap.TotalBookings(row).ToString()),
+                CsvValue(SiteReportMap.Cancelled(row).ToString()),
+                CsvValue(SiteReportMap.MaximumCapacity(row).ToString()),
+                string.Join(',', distinctServices.Select(service => CsvValue(SiteReportMap.CapacityCount(row, service))))
             ]));
         }
     }
+    
+    private static string CsvValue(object value) => "\"" + value + "\"";
 
     protected override
         Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, SiteReportRequest request)>

--- a/src/api/Nhs.Appointments.Api/Functions/GetReportSiteSummaryFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/GetReportSiteSummaryFunction.cs
@@ -85,22 +85,22 @@ public class GetReportSiteSummaryFunction(
         foreach (var row in rows)
         {
             await csvWriter.WriteLineAsync(string.Join(',', [
-                CsvValue(SiteReportMap.SiteName(row)),
-                CsvValue(SiteReportMap.ICB(row)),
-                CsvValue(SiteReportMap.Region(row)),
-                CsvValue(SiteReportMap.OdsCode(row)),
-                CsvValue(SiteReportMap.Longitude(row)),
-                CsvValue(SiteReportMap.Latitude(row)),
-                string.Join(',', distinctServices.Select(service => CsvValue(SiteReportMap.BookingsCount(row, service)))),
-                CsvValue(SiteReportMap.TotalBookings(row).ToString()),
-                CsvValue(SiteReportMap.Cancelled(row).ToString()),
-                CsvValue(SiteReportMap.MaximumCapacity(row).ToString()),
-                string.Join(',', distinctServices.Select(service => CsvValue(SiteReportMap.CapacityCount(row, service))))
+                CsvStringValue(SiteReportMap.SiteName(row)),
+                CsvStringValue(SiteReportMap.ICB(row)),
+                CsvStringValue(SiteReportMap.Region(row)),
+                CsvStringValue(SiteReportMap.OdsCode(row)),
+                SiteReportMap.Longitude(row),
+                SiteReportMap.Latitude(row),
+                string.Join(',', distinctServices.Select(service => SiteReportMap.BookingsCount(row, service))),
+                SiteReportMap.TotalBookings(row).ToString(),
+                SiteReportMap.Cancelled(row).ToString(),
+                SiteReportMap.MaximumCapacity(row).ToString(),
+                string.Join(',', distinctServices.Select(service => SiteReportMap.CapacityCount(row, service)))
             ]));
         }
     }
     
-    private static string CsvValue(object value) => "\"" + value + "\"";
+    private static string CsvStringValue(string value) => "\"" + value + "\"";
 
     protected override
         Task<(IReadOnlyCollection<ErrorMessageResponseItem> errors, SiteReportRequest request)>


### PR DESCRIPTION
# Description

Surround string values with quotes when exporting to CSV. Currently commas and other special characters are breaking reports

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
