### PR TITLE
fix css rules for thead when in print mode

### DIFF
--- a/src/client/src/app/styles/print.css
+++ b/src/client/src/app/styles/print.css
@@ -55,6 +55,16 @@
   text-align: right;
 }
 
+@media (max-width: 48.0525em) {
+  .no-print.has-printable-children .always-print thead {
+    position: relative !important;
+    display: table-header-group !important;
+    clip: unset !important;
+    clip-path: none !important;
+    clip-path: none !important;
+  }
+}
+
 @media (max-width: 768px) {
   .custom-print-button-wrapper {
     text-align: left;


### PR DESCRIPTION
# Description

Some media queries were running when in print modes that aren't needed, overridden those styles in the print.css  

Before - 
<img width="1298" height="848" alt="image" src="https://github.com/user-attachments/assets/df7d10cc-a99e-4937-87c9-6fdd5eadf542" />

After -
<img width="1311" height="857" alt="image" src="https://github.com/user-attachments/assets/42a09176-d8e2-4cbc-a5fe-e2c44355a1ee" />

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
