### PR TITLE
APPT-1427 - add covid 5_11 and 12_17 to site by area function

### DIFF
--- a/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
+++ b/src/api/Nhs.Appointments.Api/Validators/GetSitesByAreaRequestValidator.cs
@@ -48,8 +48,8 @@ public class GetSitesByAreaRequestValidator : AbstractValidator<GetSitesByAreaRe
                     () =>
                     {
                         RuleFor(x => x.Services)
-                            .Must(services => services.Length == 1 && (services.Single() == "RSV:Adult" || services.Single() == "FLU:2_3"))
-                            .WithMessage("'Services' currently only supports: 'RSV:Adult or 'FLU:2_3'");
+                            .Must(services => services.Length == 1 && (services.Single() == "RSV:Adult" || services.Single() == "FLU:2_3" || services.Single() == "COVID:5_11" || services.Single() == "COVID:12_17"))
+                            .WithMessage("'Services' currently only supports: 'RSV:Adult or 'FLU:2_3' or  'COVID:5_11' or 'COVID:12_17'");
                         RuleFor(x => x)
                             .Cascade(CascadeMode.Stop)
                             .Must(x => DateOnly.TryParseExact(x.From, "yyyy-MM-dd", out _))

--- a/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Validators/GetSitesByAreaRequestValidatorTests.cs
@@ -126,7 +126,9 @@ public class GetSitesByAreaRequestValidatorTests
     
     [Theory]
     [InlineData("RSV:Adult")]
-    [InlineData("FLU:2_3")]
+    [InlineData("FLU:2_3")]    
+    [InlineData("COVID:5_11")]
+    [InlineData("COVID:12_17")]
     public void Validate_ReturnsSuccess_WhenRequestIsValid_SiteSupportService(string service)
     {
         var request = new GetSitesByAreaRequest(


### PR DESCRIPTION
# Description

Release 2.6.1 enables NBS to query site by area for covid services in cohort 5_11 and 12_17

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
