### PR TITLE
Appt 2102 - Add home navigation link and update styling on 'current' navigation link

### DIFF
--- a/src/client/src/app/lib/components/nhs-page.test.tsx
+++ b/src/client/src/app/lib/components/nhs-page.test.tsx
@@ -22,6 +22,13 @@ const fetchPermissionsMock = fetchPermissions as jest.Mock<
   Promise<ServerActionResult<string[]>>
 >;
 
+const mockUsePathname = jest.fn();
+jest.mock('next/navigation', () => {
+  return {
+    usePathname: () => mockUsePathname(),
+  };
+});
+
 jest.mock('@components/nhs-header-log-in', () => {
   const MockNhsHeaderLogIn = () => {
     return <button type="submit">log in</button>;
@@ -70,6 +77,7 @@ describe('Nhs Page', () => {
         'users:view',
       ]),
     );
+    mockUsePathname.mockReturnValue('/test/current/path');
   });
 
   afterEach(() => {
@@ -424,7 +432,7 @@ describe('Nhs Page', () => {
     );
   });
 
-  it('displays site navigation links when site is defined', async () => {
+  it('displays site navigation links when site is defined and correct sets aria current attribute', async () => {
     fetchPermissionsMock.mockResolvedValue(
       asServerActionResult([
         'availability:query',
@@ -435,6 +443,7 @@ describe('Nhs Page', () => {
       ]),
     );
     mockGetCurrentDatTime.mockReturnValue('2026-06-05');
+    mockUsePathname.mockReturnValue(`/site/${mockSite.id}`);
 
     const jsx = await NhsPage({
       title: 'Test title',
@@ -454,6 +463,10 @@ describe('Nhs Page', () => {
       'href',
       `/manage-your-appointments/site/${mockSite.id}`,
     );
+    expect(screen.queryByRole('link', { name: 'Home' })).toHaveAttribute(
+      'aria-current',
+      'true',
+    );
 
     expect(
       screen.queryByRole('link', { name: 'View availability' }),
@@ -464,6 +477,9 @@ describe('Nhs Page', () => {
       'href',
       `/manage-your-appointments/site/${mockSite.id}/view-availability/daily-appointments?date=2026-06-05&page=1`,
     );
+    expect(
+      screen.queryByRole('link', { name: 'View availability' }),
+    ).not.toHaveAttribute('aria-current', 'true');
 
     expect(
       screen.queryByRole('link', { name: 'Create availability' }),
@@ -474,6 +490,9 @@ describe('Nhs Page', () => {
       'href',
       `/manage-your-appointments/site/${mockSite.id}/create-availability`,
     );
+    expect(
+      screen.queryByRole('link', { name: 'Create availability' }),
+    ).not.toHaveAttribute('aria-current', 'true');
 
     expect(
       screen.queryByRole('link', { name: 'Change site details' }),
@@ -484,6 +503,9 @@ describe('Nhs Page', () => {
       'href',
       `/manage-your-appointments/site/${mockSite.id}/details`,
     );
+    expect(
+      screen.queryByRole('link', { name: 'Change site details' }),
+    ).not.toHaveAttribute('aria-current', 'true');
 
     expect(
       screen.queryByRole('link', { name: 'Manage users' }),
@@ -494,5 +516,8 @@ describe('Nhs Page', () => {
       'href',
       `/manage-your-appointments/site/${mockSite.id}/users`,
     );
+    expect(
+      screen.queryByRole('link', { name: 'Manage users' }),
+    ).not.toHaveAttribute('aria-current', 'true');
   });
 });

--- a/src/client/src/app/lib/components/nhs-page.test.tsx
+++ b/src/client/src/app/lib/components/nhs-page.test.tsx
@@ -272,6 +272,7 @@ describe('Nhs Page', () => {
       screen.queryByRole('navigation', { name: 'Primary navigation' }),
     ).toBeNull();
 
+    expect(screen.queryByRole('link', { name: 'Home' })).toBeNull();
     expect(
       screen.queryByRole('link', { name: 'View availability' }),
     ).toBeNull();
@@ -363,7 +364,7 @@ describe('Nhs Page', () => {
     ).toHaveAttribute('href', '/test/url');
   });
 
-  it('displays secondary navgation with the correct details when provided', async () => {
+  it('displays secondary navigation with the correct details when provided', async () => {
     fetchPermissionsMock.mockResolvedValue(asServerActionResult([]));
 
     const secondaryNavJsx = await SecondaryNavigation({
@@ -420,6 +421,78 @@ describe('Nhs Page', () => {
     expect(screen.getByRole('link', { name: 'Link Three' })).toHaveAttribute(
       'href',
       '/link/three/url',
+    );
+  });
+
+  it('displays site navigation links when site is defined', async () => {
+    fetchPermissionsMock.mockResolvedValue(
+      asServerActionResult([
+        'availability:query',
+        'availability:setup',
+        'site:manage',
+        'users:view',
+        'site:view',
+      ]),
+    );
+    mockGetCurrentDatTime.mockReturnValue('2026-06-05');
+
+    const jsx = await NhsPage({
+      title: 'Test title',
+      children: null,
+      site: mockSite,
+      breadcrumbs: [],
+      originPage: '',
+    });
+    render(jsx);
+
+    expect(fetchPermissionsMock).toHaveBeenCalledWith(
+      '34e990af-5dc9-43a6-8895-b9123216d699',
+    );
+
+    expect(screen.queryByRole('link', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Home' })).toHaveAttribute(
+      'href',
+      `/manage-your-appointments/site/${mockSite.id}`,
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'View availability' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'View availability' }),
+    ).toHaveAttribute(
+      'href',
+      `/manage-your-appointments/site/${mockSite.id}/view-availability/daily-appointments?date=2026-06-05&page=1`,
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'Create availability' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Create availability' }),
+    ).toHaveAttribute(
+      'href',
+      `/manage-your-appointments/site/${mockSite.id}/create-availability`,
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'Change site details' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Change site details' }),
+    ).toHaveAttribute(
+      'href',
+      `/manage-your-appointments/site/${mockSite.id}/details`,
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'Manage users' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Manage users' }),
+    ).toHaveAttribute(
+      'href',
+      `/manage-your-appointments/site/${mockSite.id}/users`,
     );
   });
 });

--- a/src/client/src/app/lib/components/nhs-page.tsx
+++ b/src/client/src/app/lib/components/nhs-page.tsx
@@ -126,7 +126,10 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Home',
         href: `${basePath}/site/${site.id}`,
-        pathToCheckIfCurrent: `/site/${site.id}`,
+        pathToCheckIfCurrent: {
+          checkType: 'endsWith',
+          pathToCheckIfCurrent: `/site/${site.id}`,
+        },
       });
     }
 
@@ -134,7 +137,10 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'View availability',
         href: `${basePath}/site/${site.id}/view-availability/daily-appointments?date=${GetCurrentDateTime('YYYY-MM-DD')}&page=1`,
-        pathToCheckIfCurrent: 'view-availability',
+        pathToCheckIfCurrent: {
+          checkType: 'includes',
+          pathToCheckIfCurrent: `/site/${site.id}/view-availability`,
+        },
       });
     }
 
@@ -142,7 +148,10 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Create availability',
         href: `${basePath}/site/${site.id}/create-availability`,
-        pathToCheckIfCurrent: 'create-availability',
+        pathToCheckIfCurrent: {
+          checkType: 'includes',
+          pathToCheckIfCurrent: `/site/${site.id}/create-availability`,
+        },
       });
     }
 
@@ -153,7 +162,10 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Change site details',
         href: `${basePath}/site/${site.id}/details`,
-        pathToCheckIfCurrent: 'details',
+        pathToCheckIfCurrent: {
+          checkType: 'includes',
+          pathToCheckIfCurrent: `/site/${site.id}/details`,
+        },
       });
     }
 
@@ -161,7 +173,10 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Manage users',
         href: `${basePath}/site/${site.id}/users`,
-        pathToCheckIfCurrent: 'users',
+        pathToCheckIfCurrent: {
+          checkType: 'includes',
+          pathToCheckIfCurrent: `/site/${site.id}/users`,
+        },
       });
     }
   }
@@ -170,7 +185,10 @@ const getLinksForSite = async (
     navigationLinks.push({
       label: 'Reports',
       href: `${basePath}/reports`,
-      pathToCheckIfCurrent: 'reports',
+      pathToCheckIfCurrent: {
+        checkType: 'endsWith',
+        pathToCheckIfCurrent: '/reports',
+      },
     });
   }
 

--- a/src/client/src/app/lib/components/nhs-page.tsx
+++ b/src/client/src/app/lib/components/nhs-page.tsx
@@ -126,9 +126,9 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Home',
         href: `${basePath}/site/${site.id}`,
-        pathToCheckIfCurrent: {
-          checkType: 'endsWith',
-          pathToCheckIfCurrent: `/site/${site.id}`,
+        active: {
+          type: 'endsWith',
+          path: `/site/${site.id}`,
         },
       });
     }
@@ -137,9 +137,9 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'View availability',
         href: `${basePath}/site/${site.id}/view-availability/daily-appointments?date=${GetCurrentDateTime('YYYY-MM-DD')}&page=1`,
-        pathToCheckIfCurrent: {
-          checkType: 'includes',
-          pathToCheckIfCurrent: `/site/${site.id}/view-availability`,
+        active: {
+          type: 'includes',
+          path: `/site/${site.id}/view-availability`,
         },
       });
     }
@@ -148,9 +148,9 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Create availability',
         href: `${basePath}/site/${site.id}/create-availability`,
-        pathToCheckIfCurrent: {
-          checkType: 'includes',
-          pathToCheckIfCurrent: `/site/${site.id}/create-availability`,
+        active: {
+          type: 'includes',
+          path: `/site/${site.id}/create-availability`,
         },
       });
     }
@@ -162,9 +162,9 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Change site details',
         href: `${basePath}/site/${site.id}/details`,
-        pathToCheckIfCurrent: {
-          checkType: 'includes',
-          pathToCheckIfCurrent: `/site/${site.id}/details`,
+        active: {
+          type: 'includes',
+          path: `/site/${site.id}/details`,
         },
       });
     }
@@ -173,9 +173,9 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Manage users',
         href: `${basePath}/site/${site.id}/users`,
-        pathToCheckIfCurrent: {
-          checkType: 'includes',
-          pathToCheckIfCurrent: `/site/${site.id}/users`,
+        active: {
+          type: 'includes',
+          path: `/site/${site.id}/users`,
         },
       });
     }
@@ -185,9 +185,9 @@ const getLinksForSite = async (
     navigationLinks.push({
       label: 'Reports',
       href: `${basePath}/reports`,
-      pathToCheckIfCurrent: {
-        checkType: 'endsWith',
-        pathToCheckIfCurrent: '/reports',
+      active: {
+        type: 'endsWith',
+        path: '/reports',
       },
     });
   }

--- a/src/client/src/app/lib/components/nhs-page.tsx
+++ b/src/client/src/app/lib/components/nhs-page.tsx
@@ -1,9 +1,5 @@
 'use server';
-import {
-  Breadcrumbs,
-  Breadcrumb,
-  NavigationLink,
-} from '@nhsuk-frontend-components';
+import { Breadcrumbs, Breadcrumb } from '@nhsuk-frontend-components';
 import { ReactNode } from 'react';
 import NhsNotificationBanner from '@components/notification-banner';
 import { cookies } from 'next/headers';
@@ -20,7 +16,9 @@ import FeedbackBanner from '@components/feedback-banner';
 import BuildNumber from './build-number';
 import PrintPageButton from './print-page-button';
 import fromServer from '@server/fromServer';
-import NhsPageHeader from './nhsuk-frontend/nhs-page-header';
+import NhsPageHeader, {
+  NavigationLink,
+} from './nhsuk-frontend/nhs-page-header';
 import { GetCurrentDateTime } from '@services/timeService';
 
 type Props = {
@@ -128,6 +126,7 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Home',
         href: `${basePath}/site/${site.id}`,
+        pathToCheckIfCurrent: `/site/${site.id}`,
       });
     }
 
@@ -135,6 +134,7 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'View availability',
         href: `${basePath}/site/${site.id}/view-availability/daily-appointments?date=${GetCurrentDateTime('YYYY-MM-DD')}&page=1`,
+        pathToCheckIfCurrent: 'view-availability',
       });
     }
 
@@ -142,6 +142,7 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Create availability',
         href: `${basePath}/site/${site.id}/create-availability`,
+        pathToCheckIfCurrent: 'create-availability',
       });
     }
 
@@ -152,6 +153,7 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Change site details',
         href: `${basePath}/site/${site.id}/details`,
+        pathToCheckIfCurrent: 'details',
       });
     }
 
@@ -159,6 +161,7 @@ const getLinksForSite = async (
       navigationLinks.push({
         label: 'Manage users',
         href: `${basePath}/site/${site.id}/users`,
+        pathToCheckIfCurrent: 'users',
       });
     }
   }
@@ -167,6 +170,7 @@ const getLinksForSite = async (
     navigationLinks.push({
       label: 'Reports',
       href: `${basePath}/reports`,
+      pathToCheckIfCurrent: 'reports',
     });
   }
 

--- a/src/client/src/app/lib/components/nhs-page.tsx
+++ b/src/client/src/app/lib/components/nhs-page.tsx
@@ -124,6 +124,13 @@ const getLinksForSite = async (
   const navigationLinks: NavigationLink[] = [];
 
   if (site !== undefined) {
+    if (permissionsAtSite.includes('site:view')) {
+      navigationLinks.push({
+        label: 'Home',
+        href: `${basePath}/site/${site.id}`,
+      });
+    }
+
     if (permissionsAtSite.includes('availability:query')) {
       navigationLinks.push({
         label: 'View availability',

--- a/src/client/src/app/lib/components/nhsuk-frontend/nhs-page-header.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/nhs-page-header.tsx
@@ -1,9 +1,12 @@
 'use client';
+import { usePathname } from 'next/navigation';
 import { Header, HeaderAccountItem } from 'nhsuk-react-components';
+import path from 'path';
 
 export type NavigationLink = {
   label: string;
   href: string;
+  pathToCheckIfCurrent?: string;
 };
 
 type Props = {
@@ -19,6 +22,8 @@ const NhsPageHeader = ({
   showChangeSiteButton,
   siteName,
 }: Props) => {
+  const pathname = usePathname();
+
   return (
     <Header
       service={{
@@ -51,6 +56,9 @@ const NhsPageHeader = ({
               <Header.NavigationItem
                 href={link.href}
                 key={`naviagtion-item-${index}`}
+                {...(isCurrentPage(pathname, link.pathToCheckIfCurrent)
+                  ? { 'aria-current': 'true' }
+                  : {})}
               >
                 {link.label}
               </Header.NavigationItem>
@@ -60,6 +68,16 @@ const NhsPageHeader = ({
       )}
     </Header>
   );
+};
+
+const isCurrentPage = (
+  pathname: string,
+  pathToCheckIfCurrent: string | undefined,
+) => {
+  if (!pathToCheckIfCurrent) {
+    return false;
+  }
+  return pathname.includes(pathToCheckIfCurrent);
 };
 
 export default NhsPageHeader;

--- a/src/client/src/app/lib/components/nhsuk-frontend/nhs-page-header.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/nhs-page-header.tsx
@@ -5,12 +5,12 @@ import { Header, HeaderAccountItem } from 'nhsuk-react-components';
 export type NavigationLink = {
   label: string;
   href: string;
-  pathToCheckIfCurrent?: LinkCurrentCheck;
+  active?: ActiveLinkMatch;
 };
 
-export type LinkCurrentCheck = {
-  pathToCheckIfCurrent?: string;
-  checkType: 'includes' | 'endsWith';
+export type ActiveLinkMatch = {
+  path?: string;
+  type: 'includes' | 'endsWith';
 };
 
 type Props = {
@@ -77,15 +77,15 @@ const NhsPageHeader = ({
 // Adding checkType so the new 'Home' link does not have the aria-current attribute
 // when other pages were also 'current' as they included 'site/:id' in their path as well
 const isCurrentPage = (pathname: string, link: NavigationLink) => {
-  const { pathToCheckIfCurrent, checkType } = link.pathToCheckIfCurrent || {};
-  if (!pathToCheckIfCurrent) {
+  const { path, type } = link.active || {};
+  if (!path) {
     return false;
   }
-  if (checkType === 'includes') {
-    return pathname.includes(pathToCheckIfCurrent);
+  if (type === 'includes') {
+    return pathname.includes(path);
   }
-  if (checkType === 'endsWith') {
-    return pathname.endsWith(pathToCheckIfCurrent);
+  if (type === 'endsWith') {
+    return pathname.endsWith(path);
   }
 
   return false;

--- a/src/client/src/app/lib/components/nhsuk-frontend/nhs-page-header.tsx
+++ b/src/client/src/app/lib/components/nhsuk-frontend/nhs-page-header.tsx
@@ -1,12 +1,16 @@
 'use client';
 import { usePathname } from 'next/navigation';
 import { Header, HeaderAccountItem } from 'nhsuk-react-components';
-import path from 'path';
 
 export type NavigationLink = {
   label: string;
   href: string;
+  pathToCheckIfCurrent?: LinkCurrentCheck;
+};
+
+export type LinkCurrentCheck = {
   pathToCheckIfCurrent?: string;
+  checkType: 'includes' | 'endsWith';
 };
 
 type Props = {
@@ -56,7 +60,7 @@ const NhsPageHeader = ({
               <Header.NavigationItem
                 href={link.href}
                 key={`naviagtion-item-${index}`}
-                {...(isCurrentPage(pathname, link.pathToCheckIfCurrent)
+                {...(isCurrentPage(pathname, link)
                   ? { 'aria-current': 'true' }
                   : {})}
               >
@@ -70,14 +74,21 @@ const NhsPageHeader = ({
   );
 };
 
-const isCurrentPage = (
-  pathname: string,
-  pathToCheckIfCurrent: string | undefined,
-) => {
+// Adding checkType so the new 'Home' link does not have the aria-current attribute
+// when other pages were also 'current' as they included 'site/:id' in their path as well
+const isCurrentPage = (pathname: string, link: NavigationLink) => {
+  const { pathToCheckIfCurrent, checkType } = link.pathToCheckIfCurrent || {};
   if (!pathToCheckIfCurrent) {
     return false;
   }
-  return pathname.includes(pathToCheckIfCurrent);
+  if (checkType === 'includes') {
+    return pathname.includes(pathToCheckIfCurrent);
+  }
+  if (checkType === 'endsWith') {
+    return pathname.endsWith(pathToCheckIfCurrent);
+  }
+
+  return false;
 };
 
 export default NhsPageHeader;


### PR DESCRIPTION
# Description

Adding a new home link to the main navigation when in the context of a site. Also adding the `aria-current` attribute to the link if it is the active page. Unit tests added / updated to reflect those changes.

<img width="1363" height="1424" alt="image" src="https://github.com/user-attachments/assets/a83b1bdf-1305-4970-b281-b08adc44ef67" />
<img width="1349" height="586" alt="image" src="https://github.com/user-attachments/assets/4a0501cc-826b-4e94-a582-469c0b648c3a" />
<img width="1328" height="688" alt="image" src="https://github.com/user-attachments/assets/dc4bd71e-529c-464a-a81f-10d93d5a7b53" />
<img width="1357" height="477" alt="image" src="https://github.com/user-attachments/assets/16f7c897-79f5-487b-bfa2-1c46ce38ca4a" />
<img width="1347" height="904" alt="image" src="https://github.com/user-attachments/assets/e5c72c98-e5ab-459e-b81f-dd7da06bb471" />



Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
- [ ] If I've added/updated an end-point, I've added the appropriate annotations and tested the Swagger documentation reflects the change
