### PR TITLE
APPT-2103 - Updating the card text within the site home page

### DIFF
--- a/src/client/src/app/lib/components/nhs-page.test.tsx
+++ b/src/client/src/app/lib/components/nhs-page.test.tsx
@@ -285,17 +285,11 @@ describe('Nhs Page', () => {
   });
 
   it.each([
-    [
-      ['availability:query'],
-      'View availability and manage appointments for your site',
-    ],
+    [['availability:query'], 'View availability'],
     [['availability:setup'], 'Create availability'],
-    [
-      ['site:manage', 'site:view'],
-      'Change site details and accessibility information',
-    ],
+    [['site:manage', 'site:view'], 'Change site details'],
     [['users:view'], 'Manage users'],
-    [['reports:sitesummary'], 'Download reports'],
+    [['reports:sitesummary'], 'Reports'],
   ])(
     'hides the correct links when permissions are lacking',
     async (permissions: string[], cardTitle: string) => {

--- a/src/client/src/app/site/[site]/site-page.test.tsx
+++ b/src/client/src/app/site/[site]/site-page.test.tsx
@@ -129,25 +129,43 @@ describe('Site Page', () => {
   it.each([
     [
       'availability:query',
-      'View availability and manage appointments for your site',
+      'View availability',
       'view-availability/daily-appointments?date=2026-06-05&page=1',
+      'View and manage appointments for your site',
     ],
-    ['availability:setup', 'Create availability', 'create-availability'],
+    [
+      'availability:setup',
+      'Create availability',
+      'create-availability',
+      'Add new availability for your site',
+    ],
     [
       'site:manage',
-      'Change site details and accessibility information',
+      'Change site details',
       'details',
+      'Change site details and accessibility information',
     ],
     [
       'site:view',
-      'Change site details and accessibility information',
+      'Change site details',
       'details',
+      'Change site details and accessibility information',
     ],
-    ['users:view', 'Manage users', 'users'],
-    ['reports:sitesummary', 'Download reports', 'reports'],
+    [
+      'users:view',
+      'Manage users',
+      'users',
+      'Add or remove users for your site',
+    ],
+    ['reports:sitesummary', 'Reports', 'reports', 'Download reports'],
   ])(
     'displays the correct cards when permissions are present',
-    (permission: string, cardTitle: string, path: string) => {
+    (
+      permission: string,
+      cardTitle: string,
+      path: string,
+      cardDescription: string,
+    ) => {
       const mockSite = mockSites[0];
       mockGetCurrentDatTime.mockReturnValue('2026-06-05');
 
@@ -164,6 +182,7 @@ describe('Site Page', () => {
       );
 
       expect(screen.getByRole('link', { name: cardTitle })).toBeInTheDocument();
+      expect(screen.getByText(cardDescription)).toBeInTheDocument();
 
       if (path === 'reports') {
         expect(screen.getByRole('link', { name: cardTitle })).toHaveAttribute(

--- a/src/client/src/app/site/[site]/site-page.test.tsx
+++ b/src/client/src/app/site/[site]/site-page.test.tsx
@@ -199,17 +199,11 @@ describe('Site Page', () => {
   );
 
   it.each([
-    [
-      ['availability:query'],
-      'View availability and manage appointments for your site',
-    ],
+    [['availability:query'], 'View availability'],
     [['availability:setup'], 'Create availability'],
-    [
-      ['site:manage', 'site:view'],
-      'Change site details and accessibility information',
-    ],
+    [['site:manage', 'site:view'], 'Change site details'],
     [['users:view'], 'Manage users'],
-    [['reports:sitesummary'], 'Download reports'],
+    [['reports:sitesummary'], 'Reports'],
   ])(
     'hides the correct cards when permissions are lacking',
     (permissions: string[], cardTitle: string) => {

--- a/src/client/src/app/site/[site]/site-page.tsx
+++ b/src/client/src/app/site/[site]/site-page.tsx
@@ -85,9 +85,12 @@ export const SitePage = ({
                   <Card.Link
                     href={`/manage-your-appointments/site/${site.id}/view-availability/daily-appointments?date=${GetCurrentDateTime('YYYY-MM-DD')}&page=1`}
                   >
-                    View availability and manage appointments for your site
+                    View availability
                   </Card.Link>
                 </Card.Heading>
+                <Card.Description>
+                  View and manage appointments for your site
+                </Card.Description>
                 <ArrowRightCircleIcon />
               </Card>
             </li>
@@ -102,6 +105,9 @@ export const SitePage = ({
                     Create availability
                   </Card.Link>
                 </Card.Heading>
+                <Card.Description>
+                  Add new availability for your site
+                </Card.Description>
                 <ArrowRightCircleIcon />
               </Card>
             </li>
@@ -114,9 +120,12 @@ export const SitePage = ({
                   <Card.Link
                     href={`/manage-your-appointments/site/${site.id}/details`}
                   >
-                    Change site details and accessibility information
+                    Change site details
                   </Card.Link>
                 </Card.Heading>
+                <Card.Description>
+                  Change site details and accessibility information
+                </Card.Description>
                 <ArrowRightCircleIcon />
               </Card>
             </li>
@@ -131,6 +140,9 @@ export const SitePage = ({
                     Manage users
                   </Card.Link>
                 </Card.Heading>
+                <Card.Description>
+                  Add or remove users for your site
+                </Card.Description>
                 <ArrowRightCircleIcon />
               </Card>
             </li>
@@ -140,9 +152,10 @@ export const SitePage = ({
               <Card primary clickable>
                 <Card.Heading headingLevel="h3">
                   <Card.Link href={`/manage-your-appointments/reports`}>
-                    Download reports
+                    Reports
                   </Card.Link>
                 </Card.Heading>
+                <Card.Description>Download reports</Card.Description>
                 <ArrowRightCircleIcon />
               </Card>
             </li>

--- a/src/client/testing/page-objects-v2/site/site-page.ts
+++ b/src/client/testing/page-objects-v2/site/site-page.ts
@@ -21,7 +21,7 @@ export default class SitePage extends MYALayout {
   readonly siteManagementCard: Locator = this.page
     .getByRole('main')
     .getByRole('link', {
-      name: 'Change site details and accessibility information',
+      name: 'Change site details',
     });
 
   readonly createAvailabilityCard: Locator = this.page
@@ -41,13 +41,13 @@ export default class SitePage extends MYALayout {
   readonly viewAvailabilityAndManageAppointmentsCard: Locator = this.page
     .getByRole('main')
     .getByRole('link', {
-      name: 'View availability and manage appointments for your site',
+      name: 'View availability',
     });
 
   readonly reportsCard: Locator = this.page
     .getByRole('main')
     .getByRole('link', {
-      name: 'Download reports',
+      name: 'Reports',
       exact: true,
     });
 

--- a/src/client/testing/page-objects-v2/site/site-page.ts
+++ b/src/client/testing/page-objects-v2/site/site-page.ts
@@ -52,7 +52,9 @@ export default class SitePage extends MYALayout {
     });
 
   readonly topNav = {
-    reportsLink: this.page.getByRole('link', { name: 'Reports', exact: true }),
+    reportsLink: this.page.locator('.nhsuk-header__navigation-link', {
+      hasText: 'Reports',
+    }),
 
     clickReports: async (
       reportsUpliftEnabled: boolean,

--- a/src/client/testing/page-objects/site.ts
+++ b/src/client/testing/page-objects/site.ts
@@ -16,7 +16,7 @@ export default class SitePage extends RootPage {
       name: 'Manage users',
     });
     this.siteManagementCard = this.page.getByRole('main').getByRole('link', {
-      name: 'Change site details and accessibility information',
+      name: 'Change site details',
     });
     this.createAvailabilityCard = this.page
       .getByRole('main')
@@ -26,10 +26,10 @@ export default class SitePage extends RootPage {
     this.viewAvailabilityAndManageAppointmentsCard = this.page
       .getByRole('main')
       .getByRole('link', {
-        name: 'View availability and manage appointments for your site',
+        name: 'View availability',
       });
     this.reportsCard = this.page.getByRole('main').getByRole('link', {
-      name: 'Download reports',
+      name: 'Reports',
     });
   }
 


### PR DESCRIPTION
# Description

Text changes for the cards on the site home page, and unit test / playwright test updates to go with them.
<img width="930" height="897" alt="image" src="https://github.com/user-attachments/assets/f01ea817-8a28-4048-93d5-ea26f77db944" />


Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
- [ ] If I've added/updated an end-point, I've added the appropriate annotations and tested the Swagger documentation reflects the change
