### PR TITLE
APPT-2192 Returning 404 when booking not found

### DIFF
--- a/src/api/Nhs.Appointments.Api/Functions/HttpFunctions/QueryBookingByReferenceFunction.cs
+++ b/src/api/Nhs.Appointments.Api/Functions/HttpFunctions/QueryBookingByReferenceFunction.cs
@@ -54,6 +54,12 @@ public class QueryBookingByReferenceFunction(
         ILogger logger)
     {
         var booking = await bookingQueryService.GetBookingByReference(request.bookingReference);
+
+        if (booking == null)
+        {
+            return Failed(HttpStatusCode.NotFound, "Booking not found.");
+        }
+
         if (await siteService.GetSiteByIdAsync(booking.Site) is null)
         {
             return Failed(HttpStatusCode.NotFound, "Site not found.");

--- a/tests/Nhs.Appointments.Api.UnitTests/Functions/QueryBookingByReferenceFunctionTests.cs
+++ b/tests/Nhs.Appointments.Api.UnitTests/Functions/QueryBookingByReferenceFunctionTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
+using Grpc.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -15,7 +16,7 @@ using Nhs.Appointments.Core.Users;
 
 namespace Nhs.Appointments.Api.Tests.Functions;
 
-public class QueryBookingByReferenceNumberTests
+public class QueryBookingByReferenceFunctionTests
 {
     private readonly Mock<IBookingQueryService> _bookingQueryService = new();
     private readonly Mock<ILogger<QueryBookingByReferenceFunction>> _logger = new();
@@ -26,7 +27,7 @@ public class QueryBookingByReferenceNumberTests
     private readonly Mock<IValidator<QueryBookingByReferenceRequest>> _validator = new();
     private readonly Mock<ISiteService> _siteService = new();
 
-    public QueryBookingByReferenceNumberTests()
+    public QueryBookingByReferenceFunctionTests()
     {
         _sut = new QueryBookingByReferenceFunction(
             _bookingQueryService.Object,
@@ -166,6 +167,26 @@ public class QueryBookingByReferenceNumberTests
 
         var result = await _sut.RunAsync(httpRequest) as ContentResult;
         result.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task ReturnsNotFound_WhenProvisionalBookingNotFound()
+    {
+        //Arrange
+        const string bookingRef = "ABC123";
+
+        _bookingQueryService.Setup(x => x.GetBookingByReference(It.IsAny<string>()))
+            .ReturnsAsync(() => null);
+
+        //Act
+        var request = new QueryBookingByReferenceRequest(bookingRef, "TEST03");
+        var httpRequest = CreateRequest(request.site);
+
+        //Assert
+        var result = await _sut.RunAsync(httpRequest) as ContentResult;
+        result.StatusCode.Should().Be(404);
+
+        _siteService.Verify(x => x.GetSiteByIdAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     private static HttpRequest CreateRequest(string site)


### PR DESCRIPTION
# Description

QueryBookingByReferenceFunction had an issue where booking is null, and later we try to access Site Property on null booking object. To handle it gracefully, we added additional null check, and in case booking is null, we return 404 status with message "Booking not found."

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
- [ ] If I've added/updated an end-point, I've added the appropriate annotations and tested the Swagger documentation reflects the change
