### PR TITLE
APPT-2128 Update back links for change availability for daily, week and month and the reports page.

### DIFF
--- a/src/client/src/app/lib/components/nhs-page.test.tsx
+++ b/src/client/src/app/lib/components/nhs-page.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import { ComponentProps } from 'react';
 import NhsPage from './nhs-page';
 import {
   fetchUserProfile,
@@ -62,6 +63,13 @@ jest.mock('@services/timeService', () => {
 const mockGetCurrentDatTime = GetCurrentDateTime as jest.Mock<string>;
 
 describe('Nhs Page', () => {
+  const renderNhsPage = async (props: ComponentProps<typeof NhsPage>) => {
+    const jsx = await act(async () => {
+      return await NhsPage(props);
+    });
+    return render(jsx);
+  };
+
   beforeEach(() => {
     fetchUserProfileMock.mockResolvedValue(
       asServerActionResult({
@@ -85,25 +93,38 @@ describe('Nhs Page', () => {
   });
 
   it('shows the correct title', async () => {
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       breadcrumbs: [],
       originPage: '',
     });
-    render(jsx);
+
     expect(screen.getByRole('heading', { name: /Test title/i })).toBeVisible();
   });
 
   it('displays the print button', async () => {
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       breadcrumbs: [],
       originPage: '',
       showPrintButton: true,
     });
-    render(jsx);
+
+    expect(
+      screen.getByRole('button', { name: 'Print page' }),
+    ).toBeInTheDocument();
+  });
+
+  it('displays the print button', async () => {
+    await renderNhsPage({
+      title: 'Test title',
+      children: null,
+      breadcrumbs: [],
+      originPage: '',
+      showPrintButton: true,
+    });
 
     expect(
       screen.getByRole('button', { name: 'Print page' }),
@@ -111,13 +132,12 @@ describe('Nhs Page', () => {
   });
 
   it('hides the print button by default', async () => {
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       breadcrumbs: [],
       originPage: '',
     });
-    render(jsx);
 
     expect(
       screen.queryByRole('button', { name: 'Print page' }),
@@ -125,7 +145,7 @@ describe('Nhs Page', () => {
   });
 
   it('shows the correct breadcrumbs including title', async () => {
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       breadcrumbs: [
@@ -134,14 +154,13 @@ describe('Nhs Page', () => {
       ],
       originPage: '',
     });
-    render(jsx);
     expect(screen.getByRole('link', { name: 'Level One' })).toBeVisible();
     expect(screen.getByRole('link', { name: 'Level Two' })).toBeVisible();
     expect(screen.getByRole('listitem', { name: /Test title/i })).toBeVisible();
   });
 
   it('shows the correct breadcrumbs without title', async () => {
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       breadcrumbs: [
@@ -151,7 +170,6 @@ describe('Nhs Page', () => {
       omitTitleFromBreadcrumbs: true,
       originPage: '',
     });
-    render(jsx);
     expect(screen.getByRole('link', { name: 'Level One' })).toBeVisible();
     expect(screen.getByRole('link', { name: 'Level Two' })).toBeVisible();
     expect(screen.queryByRole('listitem', { name: /Test title/i })).toBeNull();
@@ -164,7 +182,7 @@ describe('Nhs Page', () => {
         : undefined;
     });
 
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       breadcrumbs: [
@@ -174,7 +192,6 @@ describe('Nhs Page', () => {
       omitTitleFromBreadcrumbs: true,
       originPage: '',
     });
-    render(jsx);
 
     expect(screen.getByText('This is a notification')).toBeVisible();
   });
@@ -182,7 +199,7 @@ describe('Nhs Page', () => {
   it('Does not display a notification banner when there is an ams-notification cookie', async () => {
     mockGetCookies = jest.fn().mockReturnValue(undefined);
 
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       breadcrumbs: [
@@ -192,7 +209,6 @@ describe('Nhs Page', () => {
       omitTitleFromBreadcrumbs: true,
       originPage: '',
     });
-    render(jsx);
 
     expect(screen.queryByText('This is a notification')).toBeNull();
   });
@@ -218,14 +234,13 @@ describe('Nhs Page', () => {
       );
       mockGetCurrentDatTime.mockReturnValue('2026-06-05');
 
-      const jsx = await NhsPage({
+      await renderNhsPage({
         title: 'Test title',
         children: null,
         site: mockSite,
         breadcrumbs: [],
         originPage: '',
       });
-      render(jsx);
 
       expect(fetchPermissionsMock).toHaveBeenCalledWith(
         '34e990af-5dc9-43a6-8895-b9123216d699',
@@ -235,7 +250,7 @@ describe('Nhs Page', () => {
       if (path === 'reports') {
         expect(screen.getByRole('link', { name: cardTitle })).toHaveAttribute(
           'href',
-          `/manage-your-appointments/${path}`,
+          `/manage-your-appointments/${path}?returnUrl=`,
         );
       } else {
         expect(screen.getByRole('link', { name: cardTitle })).toHaveAttribute(
@@ -247,13 +262,12 @@ describe('Nhs Page', () => {
   );
 
   it('Still requests global permissions if site is not provided', async () => {
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       breadcrumbs: [],
       originPage: '',
     });
-    render(jsx);
 
     expect(fetchPermissionsMock).toHaveBeenCalledTimes(2);
     expect(fetchPermissionsMock).toHaveBeenCalledWith(undefined);
@@ -263,14 +277,13 @@ describe('Nhs Page', () => {
   it('Does not display any navigation links if no permissions are present', async () => {
     fetchPermissionsMock.mockResolvedValue(asServerActionResult([]));
 
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       site: mockSite,
       breadcrumbs: [],
       originPage: '',
     });
-    render(jsx);
 
     expect(fetchPermissionsMock).toHaveBeenCalledWith(
       '34e990af-5dc9-43a6-8895-b9123216d699',
@@ -308,14 +321,13 @@ describe('Nhs Page', () => {
         ),
       );
 
-      const jsx = await NhsPage({
+      await renderNhsPage({
         title: 'Test title',
         children: null,
         site: mockSite,
         breadcrumbs: [],
         originPage: '',
       });
-      render(jsx);
 
       expect(fetchPermissionsMock).toHaveBeenCalledWith(
         '34e990af-5dc9-43a6-8895-b9123216d699',
@@ -330,7 +342,7 @@ describe('Nhs Page', () => {
   it('displays the back link with the correct title and URL', async () => {
     fetchPermissionsMock.mockResolvedValue(asServerActionResult([]));
 
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       site: {
@@ -357,7 +369,6 @@ describe('Nhs Page', () => {
       originPage: '',
     });
 
-    render(jsx);
     expect(
       screen.getByRole('link', { name: 'Test back link' }),
     ).toBeInTheDocument();
@@ -373,7 +384,7 @@ describe('Nhs Page', () => {
       links: mockSecondaryLinks,
     });
 
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       site: {
@@ -400,8 +411,6 @@ describe('Nhs Page', () => {
       originPage: '',
       secondaryNavigation: secondaryNavJsx,
     });
-
-    render(jsx);
 
     expect(screen.getByRole('link', { name: 'Link One' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Link One' })).toHaveAttribute(
@@ -439,14 +448,13 @@ describe('Nhs Page', () => {
     mockGetCurrentDatTime.mockReturnValue('2026-06-05');
     mockUsePathname.mockReturnValue(`/site/${mockSite.id}`);
 
-    const jsx = await NhsPage({
+    await renderNhsPage({
       title: 'Test title',
       children: null,
       site: mockSite,
       breadcrumbs: [],
       originPage: '',
     });
-    render(jsx);
 
     expect(fetchPermissionsMock).toHaveBeenCalledWith(
       '34e990af-5dc9-43a6-8895-b9123216d699',

--- a/src/client/src/app/lib/components/nhs-page.tsx
+++ b/src/client/src/app/lib/components/nhs-page.tsx
@@ -47,7 +47,7 @@ const NhsPage = async ({
 }: Props) => {
   const cookieStore = await cookies();
   const notification = cookieStore.get('ams-notification')?.value;
-  const navigationLinks = await getLinksForSite(site);
+  const navigationLinks = await getLinksForSite(site, originPage);
   const userProfile = await fromServer(fetchUserProfile());
 
   return (
@@ -103,6 +103,7 @@ const NhsPage = async ({
 
 const getLinksForSite = async (
   site: Site | undefined,
+  originUrl: string,
 ): Promise<NavigationLink[]> => {
   const [permissionsAtSite, permissionsAtAnySite] = await Promise.all([
     fromServer(fetchPermissions(site?.id)),
@@ -118,6 +119,9 @@ const getLinksForSite = async (
   };
 
   const basePath = process.env.CLIENT_BASE_PATH;
+
+  // Use the originUrl prop which is already reliable
+  const encodedReturnUrl = encodeURIComponent(originUrl);
 
   const navigationLinks: NavigationLink[] = [];
 
@@ -181,16 +185,18 @@ const getLinksForSite = async (
     }
   }
 
-  if (hasAnyReportPermissions()) {
-    navigationLinks.push({
-      label: 'Reports',
-      href: `${basePath}/reports`,
-      active: {
-        type: 'endsWith',
-        path: '/reports',
-      },
-    });
-  }
+    if (hasAnyReportPermissions()) {
+        navigationLinks.push({
+            label: 'Reports',
+            // Your logic for the return URL
+            href: `${basePath}/reports?returnUrl=${encodedReturnUrl}`,
+            // Main's logic for the active link styling
+            active: {
+                type: 'endsWith',
+                path: '/reports',
+            },
+        });
+    }
 
   return navigationLinks;
 };

--- a/src/client/src/app/lib/components/nhs-page.tsx
+++ b/src/client/src/app/lib/components/nhs-page.tsx
@@ -185,18 +185,16 @@ const getLinksForSite = async (
     }
   }
 
-    if (hasAnyReportPermissions()) {
-        navigationLinks.push({
-            label: 'Reports',
-            // Your logic for the return URL
-            href: `${basePath}/reports?returnUrl=${encodedReturnUrl}`,
-            // Main's logic for the active link styling
-            active: {
-                type: 'endsWith',
-                path: '/reports',
-            },
-        });
-    }
+  if (hasAnyReportPermissions()) {
+    navigationLinks.push({
+      label: 'Reports',
+      href: `${basePath}/reports?returnUrl=${encodedReturnUrl}`,
+      active: {
+        type: 'endsWith',
+        path: '/reports',
+      },
+    });
+  }
 
   return navigationLinks;
 };

--- a/src/client/src/app/reports/reports-page.tsx
+++ b/src/client/src/app/reports/reports-page.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/jsx-props-no-spreading */
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { DownloadReportFormValues } from './download-report-form-schema';
 import DownloadReportForm from './download-report-form';
 import DownloadReportConfirmation from './download-report-confirmation';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 export const ReportsPage = () => {
   // TODO: Atm this journey has 2 steps; one to select the dates and one to confirm the download.
@@ -13,7 +13,29 @@ export const ReportsPage = () => {
   const [reportRequest, setReportRequest] = useState<
     DownloadReportFormValues | undefined
   >(undefined);
+  const [originUrl, setOriginUrl] = useState<string | undefined>(undefined);
+
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Capture the returnUrl if it exists
+  useEffect(() => {
+    const returnUrl = searchParams.get('returnUrl');
+    const ref = document.referrer;
+    const isInternal = ref && ref.includes(window.location.host);
+
+    if (returnUrl && isInternal) {
+      setOriginUrl(returnUrl);
+    }
+  }, [searchParams]);
+
+  const handleBack = () => {
+    if (originUrl) {
+      router.push(originUrl);
+    } else {
+      router.push('/sites');
+    }
+  };
 
   return (
     <>
@@ -22,9 +44,7 @@ export const ReportsPage = () => {
           setReportRequest={setReportRequest}
           backLink={{
             renderingStrategy: 'client',
-            onClick: () => {
-              router.back();
-            },
+            onClick: handleBack,
             text: 'Back',
           }}
         />

--- a/src/client/src/app/site/[site]/change-availability/before-you-continue-step.test.tsx
+++ b/src/client/src/app/site/[site]/change-availability/before-you-continue-step.test.tsx
@@ -9,7 +9,10 @@ jest.mock('next/navigation', () => ({
 
 describe('BeforeYouContinueStep', () => {
   const mockGoToNextStep = jest.fn();
-  const mockRouter = { back: jest.fn() };
+  const mockRouter = {
+    back: jest.fn(),
+    push: jest.fn(),
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -82,7 +85,7 @@ describe('BeforeYouContinueStep', () => {
     expect(mockGoToNextStep).toHaveBeenCalledTimes(1);
   });
 
-  it('calls router.back when the BackLink is clicked', () => {
+  it('calls router.push when the BackLink is clicked', () => {
     render(
       <BeforeYouContinueStep
         {...defaultProps}
@@ -91,8 +94,9 @@ describe('BeforeYouContinueStep', () => {
     );
 
     const backButton = screen.getByText(/Back/i);
+
     fireEvent.click(backButton);
 
-    expect(mockRouter.back).toHaveBeenCalledTimes(1);
+    expect(mockRouter.push).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/client/src/app/site/[site]/change-availability/before-you-continue-step.tsx
+++ b/src/client/src/app/site/[site]/change-availability/before-you-continue-step.tsx
@@ -6,13 +6,27 @@ import { useRouter } from 'next/navigation';
 
 interface Props {
   cancelADateRangeWithBookingsEnabled: boolean;
+  previousUrl?: string;
 }
 
 const BeforeYouContinueStep = ({
   cancelADateRangeWithBookingsEnabled,
   goToNextStep,
+  previousUrl,
 }: InjectedWizardProps & Props) => {
   const router = useRouter();
+
+  const handleBack = () => {
+    if (previousUrl) {
+      // Because currentViewPath above starts with /site/...,
+      // router.push will treat it as relative to the application base path.
+      router.push(previousUrl);
+    } else {
+      // Fallback for external traffic
+      router.push('/sites');
+    }
+  };
+
   const onContinue = (e: React.FormEvent) => {
     e.preventDefault();
     goToNextStep();
@@ -20,13 +34,10 @@ const BeforeYouContinueStep = ({
 
   return (
     <>
-      <BackLink
-        onClick={() => router.back()}
-        renderingStrategy="client"
-        text="Back"
-      />
+      <BackLink onClick={handleBack} renderingStrategy="client" text="Back" />
 
       <Heading headingLevel="h2">Before you continue</Heading>
+
       <p>
         You cannot edit sessions after you create them. To change a session, you
         must:

--- a/src/client/src/app/site/[site]/change-availability/change-availability-wizard.tsx
+++ b/src/client/src/app/site/[site]/change-availability/change-availability-wizard.tsx
@@ -2,7 +2,7 @@
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import Wizard from '@components/wizard';
 import WizardStep from '@components/wizard-step';
-import { useTransition } from 'react';
+import { useTransition, useEffect, useState } from 'react';
 import BeforeYouContinueStep from './before-you-continue-step';
 import SelectDatesStep from './select-dates-step';
 import CancellationImpactStep from './cancellation-impact-step';
@@ -14,6 +14,7 @@ import {
   ChangeAvailabilityFormValues,
 } from './change-availability-form-schema';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useSearchParams } from 'next/navigation';
 
 interface Props {
   cancelADateRangeWithBookings: boolean;
@@ -27,6 +28,27 @@ const ChangeAvailabilityWizard = ({
   rangeMaximumDays,
 }: Props) => {
   const [pendingSubmit, startTransition] = useTransition();
+  const [originUrl, setOriginUrl] = useState<string | undefined>(undefined);
+
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const returnUrl = searchParams.get('returnUrl');
+    const ref = document.referrer;
+
+    // Only "lock in" the back destination if the user actually navigated
+    // from within MYA.
+    const isInternalNavigation = ref && ref.includes(window.location.host);
+
+    if (returnUrl && isInternalNavigation) {
+      setOriginUrl(returnUrl);
+    } else {
+      // If they pasted the link or came from an external link like Google, we keep originUrl undefined
+      // so that handleBack defaults to '/sites'
+      setOriginUrl(undefined);
+    }
+  }, [searchParams]);
+
   const methods = useForm<ChangeAvailabilityFormValues>({
     resolver: yupResolver(createChangeAvailabilityFormSchema(rangeMaximumDays)),
     defaultValues: {
@@ -45,7 +67,7 @@ const ChangeAvailabilityWizard = ({
         <Wizard
           id="change-availability-wizard"
           initialStep={1}
-          returnRouteUponCancellation={`/todo`}
+          returnRouteUponCancellation={`/manage-your-appointments/sites`}
           onCompleteFinalStep={() => {}}
           pendingSubmit={pendingSubmit}
         >
@@ -56,6 +78,7 @@ const ChangeAvailabilityWizard = ({
                 cancelADateRangeWithBookingsEnabled={
                   cancelADateRangeWithBookings
                 }
+                previousUrl={originUrl}
               />
             )}
           </WizardStep>

--- a/src/client/src/app/site/[site]/view-availability/(nhs-layout)/daily-appointments/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/(nhs-layout)/daily-appointments/page.tsx
@@ -33,7 +33,7 @@ type PageProps = {
 
 const Page = async ({ params, searchParams }: PageProps) => {
   const { site: siteFromPath } = { ...(await params) };
-  const { date, page } = { ...(await searchParams) };
+  const { date, page, tab } = { ...(await searchParams) };
   if (date === undefined || page === undefined) {
     return notFound();
   }
@@ -63,6 +63,13 @@ const Page = async ({ params, searchParams }: PageProps) => {
   const canChangeAvailability =
     cancelADateRange.enabled && sitePermissions.includes('availability:setup');
 
+  // Construct the return URL for the current Day View
+  // We include date, page, and tab so the user returns to exactly what they were seeing
+  const currentViewPath = `/site/${siteFromPath}/view-availability/daily-appointments?date=${date}&page=${page}${tab ? `&tab=${tab}` : ''}`;
+
+  // Encode it for safe URL passing
+  const encodedReturnUrl = encodeURIComponent(currentViewPath);
+
   return (
     <>
       <div className="nhsuk-button-group nhsuk-button-group--small">
@@ -76,7 +83,8 @@ const Page = async ({ params, searchParams }: PageProps) => {
 
       {canChangeAvailability && (
         <Link
-          href={`/site/${siteFromPath}/change-availability`}
+          /* Inject the returnUrl into the href */
+          href={`/site/${siteFromPath}/change-availability?returnUrl=${encodedReturnUrl}`}
           className="no-print nhsuk-u-margin-right-3"
         >
           <Button type="button" styleType="secondary">

--- a/src/client/src/app/site/[site]/view-availability/(nhs-layout)/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/(nhs-layout)/page.tsx
@@ -37,6 +37,13 @@ const Page = async ({ params, searchParams }: PageProps) => {
 
   const searchMonth = date ? parseToUkDatetime(date, RFC3339Format) : ukNow();
 
+  // Construct the return URL for the current view
+  // We include the date so the back button knows exactly which month to return to
+  const currentViewPath = `/site/${siteFromPath}/view-availability${date ? `?date=${date}` : ''}`;
+
+  // Encode it so it's safe to put inside another URL
+  const encodedReturnUrl = encodeURIComponent(currentViewPath);
+
   return (
     <>
       <Heading headingLevel="h2">
@@ -45,7 +52,10 @@ const Page = async ({ params, searchParams }: PageProps) => {
       </Heading>
 
       {canChangeAvailability && (
-        <Link href={`/site/${siteFromPath}/change-availability`}>
+        /* Pass the returnUrl to the wizard */
+        <Link
+          href={`/site/${siteFromPath}/change-availability?returnUrl=${encodedReturnUrl}`}
+        >
           <Button type="button" styleType="secondary">
             Change availability
           </Button>

--- a/src/client/src/app/site/[site]/view-availability/(nhs-layout)/week/page.tsx
+++ b/src/client/src/app/site/[site]/view-availability/(nhs-layout)/week/page.tsx
@@ -43,6 +43,13 @@ const Page = async ({ searchParams, params }: PageProps) => {
   const ukWeekStart = startOfUkWeek(date);
   const ukWeekEnd = endOfUkWeek(date);
 
+  // Construct the return URL for the current Week View
+  // Since date is required for this page, we know it exists here
+  const currentViewPath = `/site/${siteFromPath}/view-availability/week?date=${date}`;
+
+  // Encode it for the query string
+  const encodedReturnUrl = encodeURIComponent(currentViewPath);
+
   return (
     <>
       <Heading headingLevel="h2">
@@ -51,7 +58,10 @@ const Page = async ({ searchParams, params }: PageProps) => {
       </Heading>
 
       {canChangeAvailability && (
-        <Link href={`/site/${siteFromPath}/change-availability`}>
+        /* Inject the returnUrl */
+        <Link
+          href={`/site/${siteFromPath}/change-availability?returnUrl=${encodedReturnUrl}`}
+        >
           <Button type="button" styleType="secondary">
             Change availability
           </Button>

--- a/src/client/testing/page-objects-v2/site/site-page.ts
+++ b/src/client/testing/page-objects-v2/site/site-page.ts
@@ -62,9 +62,9 @@ export default class SitePage extends MYALayout {
       await this.topNav.reportsLink.click();
       reportsUpliftEnabled
         ? await this.page.waitForURL(
-            `**/manage-your-appointments/reports/select`,
+            `**/manage-your-appointments/reports/select**`,
           )
-        : await this.page.waitForURL(`**/manage-your-appointments/reports`);
+        : await this.page.waitForURL(`**/manage-your-appointments/reports**`);
       return new SiteSummaryReportPage(this.page, this.site);
     },
   };
@@ -98,8 +98,10 @@ export default class SitePage extends MYALayout {
   ): Promise<SiteSummaryReportPage> {
     await this.reportsCard.click();
     reportsUpliftEnabled
-      ? await this.page.waitForURL(`**/manage-your-appointments/reports/select`)
-      : await this.page.waitForURL(`**/manage-your-appointments/reports`);
+      ? await this.page.waitForURL(
+          `**/manage-your-appointments/reports/select**`,
+        )
+      : await this.page.waitForURL(`**/manage-your-appointments/reports**`);
     return new SiteSummaryReportPage(this.page, this.site);
   }
 

--- a/src/client/testing/page-objects-v2/view-availability-appointment-pages/day-view-availability-page.ts
+++ b/src/client/testing/page-objects-v2/view-availability-appointment-pages/day-view-availability-page.ts
@@ -11,8 +11,10 @@ export default class DayViewAvailabilityPage extends BaseViewAvailabilityPage {
   async clickChangeAvailabilityButton(): Promise<ChangeAvailabilityPage> {
     await this.changeAvailabilityButton.click();
 
-    await this.page.waitForURL(
-      `/manage-your-appointments/site/${this.site?.id}/change-availability`,
+    await this.page.waitForURL(url =>
+      url.pathname.includes(
+        `/manage-your-appointments/site/${this.site?.id}/change-availability`,
+      ),
     );
 
     return new ChangeAvailabilityPage(this.page, this.site);

--- a/src/client/testing/page-objects-v2/view-availability-appointment-pages/month-view-availability-page.ts
+++ b/src/client/testing/page-objects-v2/view-availability-appointment-pages/month-view-availability-page.ts
@@ -25,8 +25,10 @@ export default class MonthViewAvailabilityPage extends BaseViewAvailabilityPage 
   async clickChangeAvailabilityButton(): Promise<ChangeAvailabilityPage> {
     await this.changeAvailabilityButton.click();
 
-    await this.page.waitForURL(
-      `/manage-your-appointments/site/${this.site?.id}/change-availability`,
+    await this.page.waitForURL(url =>
+      url.pathname.includes(
+        `/manage-your-appointments/site/${this.site?.id}/change-availability`,
+      ),
     );
 
     return new ChangeAvailabilityPage(this.page, this.site);

--- a/src/client/testing/page-objects-v2/view-availability-appointment-pages/week-view-availability-page.ts
+++ b/src/client/testing/page-objects-v2/view-availability-appointment-pages/week-view-availability-page.ts
@@ -52,8 +52,10 @@ export default class WeekViewAvailabilityPage extends MYALayout {
   async clickChangeAvailabilityButton(): Promise<ChangeAvailabilityPage> {
     await this.changeAvailabilityButton.click();
 
-    await this.page.waitForURL(
-      `/manage-your-appointments/site/${this.site?.id}/change-availability`,
+    await this.page.waitForURL(url =>
+      url.pathname.includes(
+        `/manage-your-appointments/site/${this.site?.id}/change-availability`,
+      ),
     );
 
     return new ChangeAvailabilityPage(this.page, this.site);


### PR DESCRIPTION
# Description

Updated the back links for the Before you continue page for each of the Day, Week, Month view as the issue was when clicking the back link redirects to an incorrect URL when on a external non MYA page or when the session times out. I have also fixed the back link for the Reports Page.

The previous implementation relied on the browser's history stack (router.back()), which was unreliable in two key scenarios:
- When a session expired and the user logged back in, the redirect cycle cleared the history stack, causing the "Back" link to break or redirect to an incorrect URL.
- If the user landed on the page from an external source or a non-MYA page, the "Back" button would attempt to navigate the user out of the application context.

I have replaced the browser-history-dependent navigation with a redirect pattern. By passing the originating path via the URL, the "Back" link now:
- Persists through sessions: It remains functional even after a logout/login cycle.
- It always returns the user to a valid page, with a fallback to the site List if no specific origin is detected.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
- [ ] If I've added/updated an end-point, I've added the appropriate annotations and tested the Swagger documentation reflects the change
