### PR TITLE
APPT-1512 - Removing missed site status feature toggle check in the front end

### DIFF
--- a/src/client/src/app/lib/services/siteService.ts
+++ b/src/client/src/app/lib/services/siteService.ts
@@ -4,7 +4,6 @@ import { Site, WellKnownOdsEntry } from '@types';
 export const mapSiteOverviewSummaryData = (
   site: Site,
   wellKnownOdsCodeEntries: WellKnownOdsEntry[],
-  siteStatusEnabled: boolean,
 ) => {
   if (!site) {
     return undefined;
@@ -33,9 +32,7 @@ export const mapSiteOverviewSummaryData = (
     },
   ];
 
-  if (siteStatusEnabled) {
-    items = [siteStatusSummaryItem(site), ...items];
-  }
+  items = [siteStatusSummaryItem(site), ...items];
 
   return { items, border: false };
 };

--- a/src/client/src/app/lib/services/siteService.ts
+++ b/src/client/src/app/lib/services/siteService.ts
@@ -40,10 +40,7 @@ export const mapSiteOverviewSummaryData = (
   return { items, border: false };
 };
 
-export const mapCoreSiteSummaryData = (
-  site: Site,
-  siteStatusEnabled: boolean,
-) => {
+export const mapCoreSiteSummaryData = (site: Site) => {
   if (!site) {
     return undefined;
   }
@@ -73,9 +70,7 @@ export const mapCoreSiteSummaryData = (
     items.push({ title: 'Phone Number', value: site.phoneNumber });
   }
 
-  if (siteStatusEnabled) {
-    items = [siteStatusSummaryItem(site), ...items];
-  }
+  items = [siteStatusSummaryItem(site), ...items];
 
   return { items, border: false };
 };

--- a/src/client/src/app/site/[site]/details/site-details-page.tsx
+++ b/src/client/src/app/site/[site]/details/site-details-page.tsx
@@ -22,17 +22,16 @@ const SiteDetailsPage = async ({
   permissions,
   wellKnownOdsEntries,
 }: Props) => {
-  const [accessibilityDefinitions, site, siteStatus] = await Promise.all([
+  const [accessibilityDefinitions, site] = await Promise.all([
     fromServer(fetchAccessibilityDefinitions()),
     fromServer(fetchSite(siteId)),
-    fromServer(fetchFeatureFlag('SiteStatus')),
   ]);
 
   const siteReferenceSummaryData = mapSiteReferenceSummaryData(
     site,
     wellKnownOdsEntries,
   );
-  const siteCoreSummary = mapCoreSiteSummaryData(site, siteStatus.enabled);
+  const siteCoreSummary = mapCoreSiteSummaryData(site);
 
   return (
     <ol className="card-list">
@@ -46,13 +45,11 @@ const SiteDetailsPage = async ({
               Edit site details
             </Card.Action>
           ) : null}
-          {siteStatus.enabled && permissions.includes('site:manage') ? (
-            <Card.Action
-              href={`/manage-your-appointments/site/${site.id}/details/edit-site-status`}
-            >
-              Change site status
-            </Card.Action>
-          ) : null}
+          <Card.Action
+            href={`/manage-your-appointments/site/${site.id}/details/edit-site-status`}
+          >
+            Change site status
+          </Card.Action>
           <SummaryList>
             {siteCoreSummary?.items.map((item, index) => (
               <SummaryList.Row key={index}>

--- a/src/client/src/app/site/[site]/details/site-details-page.tsx
+++ b/src/client/src/app/site/[site]/details/site-details-page.tsx
@@ -1,7 +1,6 @@
 import fromServer from '@server/fromServer';
 import {
   fetchAccessibilityDefinitions,
-  fetchFeatureFlag,
   fetchSite,
 } from '@services/appointmentsService';
 import {

--- a/src/client/src/app/site/[site]/page.tsx
+++ b/src/client/src/app/site/[site]/page.tsx
@@ -1,7 +1,6 @@
 import NhsPage from '@components/nhs-page';
 import {
   assertPermission,
-  fetchFeatureFlag,
   fetchPermissions,
   fetchSite,
   fetchWellKnownOdsCodeEntries,
@@ -28,19 +27,13 @@ const Page = async ({ params }: PageProps) => {
 
   await fromServer(assertPermission(siteFromPath, 'site:view'));
 
-  const [
-    site,
-    wellKnownOdsCodeEntries,
-    sitePermissions,
-    permissionsAtAnySite,
-    siteStatusFeature,
-  ] = await Promise.all([
-    fromServer(fetchSite(siteFromPath)),
-    fromServer(fetchWellKnownOdsCodeEntries()),
-    fromServer(fetchPermissions(siteFromPath)),
-    fromServer(fetchPermissions('*')),
-    fromServer(fetchFeatureFlag('SiteStatus')),
-  ]);
+  const [site, wellKnownOdsCodeEntries, sitePermissions, permissionsAtAnySite] =
+    await Promise.all([
+      fromServer(fetchSite(siteFromPath)),
+      fromServer(fetchWellKnownOdsCodeEntries()),
+      fromServer(fetchPermissions(siteFromPath)),
+      fromServer(fetchPermissions('*')),
+    ]);
 
   return (
     <NhsPage title={site.name} site={site} originPage="site">
@@ -49,7 +42,6 @@ const Page = async ({ params }: PageProps) => {
         permissions={sitePermissions}
         permissionsAtAnySite={permissionsAtAnySite}
         wellKnownOdsCodeEntries={wellKnownOdsCodeEntries}
-        siteStatusEnabled={siteStatusFeature.enabled}
       />
     </NhsPage>
   );

--- a/src/client/src/app/site/[site]/site-page.test.tsx
+++ b/src/client/src/app/site/[site]/site-page.test.tsx
@@ -43,7 +43,6 @@ describe('Site Page', () => {
         permissions={mockAllPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteStatusEnabled
       />,
     );
 
@@ -59,7 +58,6 @@ describe('Site Page', () => {
         permissions={mockAllPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteStatusEnabled
       />,
     );
 
@@ -81,7 +79,6 @@ describe('Site Page', () => {
         permissions={mockAllPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteStatusEnabled
       />,
     );
     verifyV10SummaryListItem('Region', mockSite.region);
@@ -102,7 +99,6 @@ describe('Site Page', () => {
         permissions={mockNonManagerPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteStatusEnabled
       />,
     );
 
@@ -118,7 +114,6 @@ describe('Site Page', () => {
         permissions={mockNonManagerPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteStatusEnabled
       />,
     );
 
@@ -177,7 +172,6 @@ describe('Site Page', () => {
             permission === 'reports:sitesummary' ? ['reports:sitesummary'] : []
           }
           wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-          siteStatusEnabled
         />,
       );
 
@@ -215,7 +209,6 @@ describe('Site Page', () => {
           permissions={mockAllPermissions.filter(p => !permissions.includes(p))}
           permissionsAtAnySite={[]}
           wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-          siteStatusEnabled
         />,
       );
 
@@ -236,7 +229,6 @@ describe('Site Page', () => {
         permissions={mockAllPermissions}
         permissionsAtAnySite={[]}
         wellKnownOdsCodeEntries={mockWellKnownOdsCodeEntries}
-        siteStatusEnabled
       />,
     );
 

--- a/src/client/src/app/site/[site]/site-page.tsx
+++ b/src/client/src/app/site/[site]/site-page.tsx
@@ -15,7 +15,6 @@ interface SitePageProps {
   permissions: string[];
   permissionsAtAnySite: string[];
   wellKnownOdsCodeEntries: WellKnownOdsEntry[];
-  siteStatusEnabled: boolean;
 }
 
 export const SitePage = ({
@@ -23,7 +22,6 @@ export const SitePage = ({
   permissions,
   permissionsAtAnySite,
   wellKnownOdsCodeEntries,
-  siteStatusEnabled,
 }: SitePageProps) => {
   useEffect(() => {
     const appInsightsClient = getAppInsightsClient();
@@ -46,7 +44,6 @@ export const SitePage = ({
   const overviewData = mapSiteOverviewSummaryData(
     site,
     wellKnownOdsCodeEntries,
-    siteStatusEnabled,
   );
 
   return (

--- a/src/client/testing/tests-v2/site-management/edit-site-status.spec.ts
+++ b/src/client/testing/tests-v2/site-management/edit-site-status.spec.ts
@@ -2,31 +2,11 @@ import { test, expect } from '../../fixtures-v2';
 
 test.describe.configure({ mode: 'serial' });
 
-test('A site manager cannot edit site status when the feature toggle is disabled', async ({
-  setup,
-}) => {
-  await setup({
-    features: [{ name: 'SiteStatus', enabled: false }],
-  })
-    .then(({ sitePage }) => {
-      return sitePage.clickSiteDetailsCard();
-    })
-    .then(async siteDetailsPage => {
-      await expect(
-        siteDetailsPage.detailsCard.summaryList.getV10Item('Site status'),
-      ).not.toBeVisible();
-
-      await expect(siteDetailsPage.detailsCard.editLinks[1]).not.toBeVisible();
-    });
-});
-
 test('A site manager takes an online site offline', async ({ setup }) => {
-  await setup({
-    features: [{ name: 'SiteStatus', enabled: true }],
-  })
-    .then(({ sitePage }) => {
-      return sitePage.clickSiteDetailsCard();
-    })
+  const { sitePage } = await setup();
+
+  await sitePage
+    .clickSiteDetailsCard()
     .then(async siteDetailsPage => {
       return siteDetailsPage.clickEditSiteStatusLink();
     })
@@ -57,7 +37,6 @@ test('A site manager takes an online site offline', async ({ setup }) => {
 
 test('A site manager takes an offline site online', async ({ setup }) => {
   await setup({
-    features: [{ name: 'SiteStatus', enabled: true }],
     siteConfig: { status: 'Offline' },
   })
     .then(({ sitePage }) => {
@@ -94,10 +73,10 @@ test('A site manager takes an offline site online', async ({ setup }) => {
 test('A user starts to update site status then changes their mind using the back button', async ({
   setup,
 }) => {
-  await setup({ features: [{ name: 'SiteStatus', enabled: true }] })
-    .then(({ sitePage }) => {
-      return sitePage.clickSiteDetailsCard();
-    })
+  const { sitePage } = await setup();
+
+  await sitePage
+    .clickSiteDetailsCard()
     .then(async siteDetailsPage => {
       return siteDetailsPage.clickEditSiteStatusLink();
     })


### PR DESCRIPTION
# Description

Missed removal of some `SiteStatus` feature toggle checks in the front end.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [x] If I've made UI changes, I've added appropriate Playwright and Jest tests
- [ ] If I've added/updated an end-point, I've added the appropriate annotations and tested the Swagger documentation reflects the change
