### PR TITLE
APPT-1847 - Adding a couple of extra view availability playwright tests

### DIFF
--- a/src/client/testing/tests-v2/view-availability/day-view.spec.ts
+++ b/src/client/testing/tests-v2/view-availability/day-view.spec.ts
@@ -4,6 +4,7 @@ import {
   clockBackwardDaysData,
   clockForwardDaysData,
 } from '../../availability';
+import { parseToUkDatetime } from '@services/timeService';
 
 test.describe('View Daily Availability', () => {
   ['Europe/London', 'Asia/Kamchatka', 'US/Pacific'].forEach(async timezone => {
@@ -364,6 +365,71 @@ test.describe('View Daily Availability', () => {
                 `**/site/${site.id}/view-availability/daily-appointments?date=${dayCase.day}&page=1`,
               );
             }
+          });
+
+          test('View daily appointments can use next day pagination and has correct information', async ({
+            setup,
+            page,
+            dailyAppointmentDetailsPage,
+          }) => {
+            const { site } = await setup({
+              availability: forwardDayData.availability?.concat(
+                backwardDayData.availability!,
+              ),
+              bookings: forwardDayData.bookings?.concat(
+                backwardDayData.bookings!,
+              ),
+            });
+
+            await page.goto(
+              `manage-your-appointments/site/${site.id}/view-availability/week?date=${dayCase.day}`,
+            );
+            await page.waitForURL(
+              `**/site/${site.id}/view-availability/week?date=${dayCase.day}`,
+            );
+            await page.waitForSelector('.nhsuk-loader', {
+              state: 'detached',
+            });
+
+            const viewDailyAppointmentsButton = page
+              .getByRole('heading', {
+                name: dayCase.dayCardHeader,
+              })
+              .locator('../..')
+              .getByRole('link', {
+                name: 'View daily appointments',
+              });
+
+            await viewDailyAppointmentsButton.click();
+
+            await page.waitForURL(
+              `**/site/${site.id}/view-availability/daily-appointments?date=${dayCase.day}&page=1`,
+            );
+
+            const nextPageLink = page.getByRole('link', {
+              name: 'Next',
+            });
+
+            await nextPageLink.click();
+
+            const testDay = parseToUkDatetime(dayCase.day);
+            const nextDay = testDay.add(1, 'day');
+
+            await page.waitForURL(
+              `**/site/${site.id}/view-availability/daily-appointments?date=${nextDay.format('YYYY-MM-DD')}&page=1`,
+            );
+
+            const allTableRows =
+              await dailyAppointmentDetailsPage.appointmentsTable
+                .getByRole('row')
+                .all();
+
+            expect(
+              page.getByRole('heading', {
+                name: nextDay.format('dddd D MMMM YYYY'),
+              }),
+            ).toBeVisible();
+            expect(allTableRows.length).toBe(1);
           });
         });
       });

--- a/src/client/testing/tests-v2/view-availability/month-view.spec.ts
+++ b/src/client/testing/tests-v2/view-availability/month-view.spec.ts
@@ -1,5 +1,5 @@
 import { DayJsType, getUkWeeksOfTheMonth, ukNow } from '@services/timeService';
-import { test } from '../../fixtures-v2';
+import { expect, test } from '../../fixtures-v2';
 import {
   clockBackwardWeeksData,
   clockForwardWeeksData,
@@ -189,6 +189,61 @@ test.describe('View Month Availability', () => {
                 expectedWeekOverviews2[i],
               );
             }
+          });
+
+          test('Date persists between month, week and day views', async ({
+            setup,
+            page,
+          }) => {
+            const nextYear = ukNow().year() + yearIncrement;
+            const data = clockForwardWeeksData(nextYear);
+
+            const { site } = await setup({
+              ...data,
+            });
+
+            const marchWeeks = getUkWeeksOfTheMonth(data.firstDate);
+            const firstDate = marchWeeks[0][0];
+
+            await page.goto(
+              `manage-your-appointments/site/${site.id}/view-availability?date=${firstDate.format('YYYY-MM-DD')}`,
+            );
+            await page.waitForURL(
+              `**/site/${site.id}/view-availability?date=${firstDate.format('YYYY-MM-DD')}`,
+            );
+            await page.waitForSelector('.nhsuk-loader', {
+              state: 'detached',
+            });
+
+            const weekViewLink = page.getByRole('link', { name: 'Week view' });
+            await weekViewLink.click();
+            await page.waitForURL(
+              `**/site/${site.id}/view-availability/week?date=${firstDate.format('YYYY-MM-DD')}&page=1`,
+            );
+            await page.waitForSelector('.nhsuk-loader', {
+              state: 'detached',
+            });
+
+            const expectedWeekHeader = `${marchWeeks[0][0].format('D MMMM')} to ${marchWeeks[0][6].format('D MMMM')}`;
+            expect(
+              page.getByRole('heading', { name: `${expectedWeekHeader}` }),
+            ).toBeVisible();
+
+            const dayViewLink = page.getByRole('link', { name: 'Day view' });
+            await dayViewLink.click();
+            await page.waitForURL(
+              `**/site/${site.id}/view-availability/daily-appointments?date=${firstDate.format(
+                'YYYY-MM-DD',
+              )}&page=1`,
+            );
+            await page.waitForSelector('.nhsuk-loader', {
+              state: 'detached',
+            });
+            expect(
+              page.getByRole('heading', {
+                name: `${firstDate.format('dddd D MMMM YYYY')}`,
+              }),
+            ).toBeVisible();
           });
         });
       });


### PR DESCRIPTION
# Description

Most view availability playwright tests have been covered but there were a couple that needed adding after the secondary navigation updates including the new day view pagination and the persisting of dates between the 3 views so I've added in a test for each.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [x] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
- [ ] If I've added/updated an end-point, I've added the appropriate annotations and tested the Swagger documentation reflects the change
