### PR TITLE
APPT-2110: Replace site locking with site+day locking for existing usages

### DIFF
--- a/src/api/Nhs.Appointments.Core/Bookings/Booking.cs
+++ b/src/api/Nhs.Appointments.Core/Bookings/Booking.cs
@@ -56,6 +56,9 @@ public class Booking
     /// </summary>
     [JsonProperty("bookingBatchSize")]
     public int? BookingBatchSize { get; set; }
+
+    [JsonIgnore]
+    public DateOnly Date => DateOnly.FromDateTime(From);
 }
 
 public class AttendeeDetails

--- a/src/api/Nhs.Appointments.Core/Bookings/BookingDayRange.cs
+++ b/src/api/Nhs.Appointments.Core/Bookings/BookingDayRange.cs
@@ -1,0 +1,9 @@
+
+namespace Nhs.Appointments.Core.Bookings;
+
+public class BookingDayRange(DateOnly date)
+{
+    public DateTime Start { get; } = new(date, new TimeOnly(0, 0));
+
+    public DateTime End { get; } = new(date, new TimeOnly(23, 59));
+}

--- a/src/api/Nhs.Appointments.Core/Bookings/BookingDayRange.cs
+++ b/src/api/Nhs.Appointments.Core/Bookings/BookingDayRange.cs
@@ -3,7 +3,7 @@ namespace Nhs.Appointments.Core.Bookings;
 
 public class BookingDayRange(DateOnly date)
 {
-    public DateTime Start { get; } = new(date, new TimeOnly(0, 0));
+    public DateTime Start { get; } = new(date, new TimeOnly(0, 0), DateTimeKind.Unspecified);
 
-    public DateTime End { get; } = new(date, new TimeOnly(23, 59));
+    public DateTime End { get; } = new(date, new TimeOnly(23, 59), DateTimeKind.Unspecified);
 }

--- a/src/api/Nhs.Appointments.Core/Bookings/BookingWriteService.cs
+++ b/src/api/Nhs.Appointments.Core/Bookings/BookingWriteService.cs
@@ -59,7 +59,7 @@ public class BookingWriteService(
 
     public async Task<(bool Success, string Reference)> MakeBooking(Booking booking)
     {
-        using var leaseContent = siteLeaseManager.Acquire(booking.Site);
+        using var leaseContent = siteLeaseManager.Acquire(booking.Site, booking.Date);
 
         var from = booking.From;
         var to = booking.From.AddMinutes(booking.Duration);
@@ -115,7 +115,7 @@ public class BookingWriteService(
 
         if (runRecalculation)
         {
-            await RecalculateAppointmentStatuses(booking.Site, DateOnly.FromDateTime(booking.From));
+            await RecalculateAppointmentStatuses(booking.Site, DateOnly.FromDateTime(booking.From)); // TODO: Change to use booking.Date
         }
 
         await RaiseBookingCancelledNotificationEvents(booking, cancellationReason, mergedAdditionalData);
@@ -178,16 +178,12 @@ public class BookingWriteService(
     public async Task RecalculateAppointmentStatuses(string site, DateOnly day,
         NewlyUnsupportedBookingAction newlyUnsupportedBookingAction = NewlyUnsupportedBookingAction.Orphan)
     {
-        using var leaseContent = siteLeaseManager.Acquire(site);
-
         await RecalculateAppointmentStatusesForDay(site, day, newlyUnsupportedBookingAction);
     }
 
     public async Task<BookingRecalculationsStatistics> RecalculateAppointmentStatuses(string site, DateOnly[] days,
         NewlyUnsupportedBookingAction newlyUnsupportedBookingAction = NewlyUnsupportedBookingAction.Orphan)
     {
-        using var leaseContent = siteLeaseManager.Acquire(site);
-
         var dayTasks = days.Select(async day => await RecalculateAppointmentStatusesForDay(site, day, newlyUnsupportedBookingAction));
 
         var results = await Task.WhenAll(dayTasks);
@@ -356,11 +352,12 @@ public class BookingWriteService(
         DateOnly day,
         NewlyUnsupportedBookingAction newlyUnsupportedBookingAction = NewlyUnsupportedBookingAction.Orphan)
     {
-        var dayStart = day.ToDateTime(new TimeOnly(0, 0));
-        var dayEnd = day.ToDateTime(new TimeOnly(23, 59));
+        var bookingDayRange = new BookingDayRange(day);
+
+        using var leaseContent = siteLeaseManager.Acquire(site, day);
 
         var recalculations =
-            (await bookingAvailabilityStateService.BuildRecalculations(site, dayStart, dayEnd,
+            (await bookingAvailabilityStateService.BuildRecalculations(site, bookingDayRange.Start, bookingDayRange.End,
                 newlyUnsupportedBookingAction)).ToArray();
 
         await PersistUpdatesForRecalculations(recalculations);

--- a/src/api/Nhs.Appointments.Core/Bookings/BookingWriteService.cs
+++ b/src/api/Nhs.Appointments.Core/Bookings/BookingWriteService.cs
@@ -59,10 +59,10 @@ public class BookingWriteService(
 
     public async Task<(bool Success, string Reference)> MakeBooking(Booking booking)
     {
-        using var leaseContent = siteLeaseManager.Acquire(booking.Site, booking.Date);
-
         var from = booking.From;
         var to = booking.From.AddMinutes(booking.Duration);
+
+        using var leaseContent = siteLeaseManager.Acquire(booking.Site, booking.Date);
 
         var availableSlots = await bookingAvailabilityStateService.GetAvailableSlots(booking.Site, from, to);
 

--- a/src/api/Nhs.Appointments.Core/Concurrency/AzureStorageSiteLeaseManager.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/AzureStorageSiteLeaseManager.cs
@@ -17,17 +17,21 @@ internal class AzureStorageSiteLeaseManager : ISiteLeaseManager
         _options = options.Value;
     }
 
-    public ISiteLeaseContext Acquire(string fileName)
+    public ISiteLeaseContext Acquire(string site, DateOnly date)
     {
         var containerClient = ResolveContainerClient();
 
-        var blobClient = containerClient.GetBlobClient(fileName);
+        var blobName = LeaseKeys.SiteKeyFactory.Create(site, date);
+
+        var blobClient = containerClient.GetBlobClient(blobName);
         if (blobClient.Exists() == false)
+        {
             blobClient.Upload(BinaryData.FromString(""));
+        }
 
         var leaseClient = blobClient.GetBlobLeaseClient();
         var leasePipeline = CreateResiliencePipeline();
-        leasePipeline.Execute(() => leaseClient.Acquire(TimeSpan.FromSeconds(20)));
+        leasePipeline.Execute(() => leaseClient.Acquire(TimeSpan.FromSeconds(20))); // TODO: Move this duration into the constructor parameter or options.
 
         return new SiteLeaseContext(() => leaseClient.Release());
     }

--- a/src/api/Nhs.Appointments.Core/Concurrency/AzureStorageSiteLeaseManager.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/AzureStorageSiteLeaseManager.cs
@@ -33,7 +33,7 @@ internal class AzureStorageSiteLeaseManager : ISiteLeaseManager
         var leasePipeline = CreateResiliencePipeline();
         leasePipeline.Execute(() => leaseClient.Acquire(TimeSpan.FromSeconds(20))); // TODO: Move this duration into the constructor parameter or options.
 
-        return new SiteLeaseContext(() => leaseClient.Release());
+        return new SiteLeaseContext(blobName , () => leaseClient.Release());
     }
 
     private BlobContainerClient ResolveContainerClient()
@@ -60,19 +60,4 @@ internal class AzureStorageSiteLeaseManager : ISiteLeaseManager
             })
             .Build();
     }                
-}
-
-public class SiteLeaseContext : ISiteLeaseContext
-{
-    private readonly Action _release;
-
-    public SiteLeaseContext(Action release) 
-    {
-        _release = release;
-    }
-
-    public void Dispose()
-    {
-        _release();
-    }
 }

--- a/src/api/Nhs.Appointments.Core/Concurrency/AzureStorageSiteLeaseManager.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/AzureStorageSiteLeaseManager.cs
@@ -24,7 +24,7 @@ internal class AzureStorageSiteLeaseManager : ISiteLeaseManager
         var blobName = LeaseKeys.SiteKeyFactory.Create(site, date);
 
         var blobClient = containerClient.GetBlobClient(blobName);
-        if (blobClient.Exists() == false)
+        if (!blobClient.Exists())
         {
             blobClient.Upload(BinaryData.FromString(""));
         }
@@ -33,7 +33,7 @@ internal class AzureStorageSiteLeaseManager : ISiteLeaseManager
         var leasePipeline = CreateResiliencePipeline();
         leasePipeline.Execute(() => leaseClient.Acquire(TimeSpan.FromSeconds(20))); // TODO: Move this duration into the constructor parameter or options.
 
-        return new SiteLeaseContext(blobName , () => leaseClient.Release());
+        return new SiteLeaseContext(blobName, () => leaseClient.Release());
     }
 
     private BlobContainerClient ResolveContainerClient()
@@ -56,7 +56,7 @@ internal class AzureStorageSiteLeaseManager : ISiteLeaseManager
                     _ => PredicateResult.False(),
                 },
                 MaxRetryAttempts = 20,
-                Delay = TimeSpan.FromMilliseconds(100)
+                Delay = TimeSpan.FromMilliseconds(100)  // TODO: Move this duration into the constructor parameter or options.
             })
             .Build();
     }                

--- a/src/api/Nhs.Appointments.Core/Concurrency/ISiteLeaseContext.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/ISiteLeaseContext.cs
@@ -1,6 +1,6 @@
-﻿namespace Nhs.Appointments.Core.Concurrency;
+namespace Nhs.Appointments.Core.Concurrency;
 
 public interface ISiteLeaseContext : IDisposable
 {
-
+    public string SiteKey { get; }
 }

--- a/src/api/Nhs.Appointments.Core/Concurrency/ISiteLeaseContext.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/ISiteLeaseContext.cs
@@ -2,5 +2,5 @@ namespace Nhs.Appointments.Core.Concurrency;
 
 public interface ISiteLeaseContext : IDisposable
 {
-    public string SiteKey { get; }
+    string SiteKey { get; }
 }

--- a/src/api/Nhs.Appointments.Core/Concurrency/ISiteLeaseManager.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/ISiteLeaseManager.cs
@@ -1,6 +1,7 @@
-﻿namespace Nhs.Appointments.Core.Concurrency;
+
+namespace Nhs.Appointments.Core.Concurrency;
 
 public interface ISiteLeaseManager
 {
-    ISiteLeaseContext Acquire(string site);
+    ISiteLeaseContext Acquire(string site, DateOnly date);
 }

--- a/src/api/Nhs.Appointments.Core/Concurrency/InMemorySiteLeaseManager.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/InMemorySiteLeaseManager.cs
@@ -21,18 +21,18 @@ internal class InMemorySiteLeaseManager : ISiteLeaseManager
 
         lock (_locks)
         {
-            if (_locks.ContainsKey(keyName) == false)
+            if (!_locks.ContainsKey(keyName))
             {
                 _locks.Add(keyName, new SemaphoreSlim(1,1));
             }
             mutex = _locks[keyName];
         }
 
-        if (mutex.Wait(_options.Timeout) == false)
+        if (!mutex.Wait(_options.Timeout))
         {
-            throw new AbandonedMutexException();
+            throw new AbandonedMutexException($"Abandoned attempt to acquire lock for site key {keyName}");
         }
 
         return new SiteLeaseContext(keyName, () => mutex.Release());
-    }        
+    }
 }

--- a/src/api/Nhs.Appointments.Core/Concurrency/InMemorySiteLeaseManager.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/InMemorySiteLeaseManager.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 
 namespace Nhs.Appointments.Core.Concurrency;
 
@@ -13,21 +13,25 @@ internal class InMemorySiteLeaseManager : ISiteLeaseManager
         _options = options.Value;
     }
 
-    public ISiteLeaseContext Acquire(string site)
+    public ISiteLeaseContext Acquire(string site, DateOnly date)
     {
         SemaphoreSlim mutex;
 
+        var keyName = LeaseKeys.SiteKeyFactory.Create(site, date);
+
         lock (_locks)
         {
-            if (_locks.ContainsKey(site) == false)
+            if (_locks.ContainsKey(keyName) == false)
             {
-                _locks.Add(site, new SemaphoreSlim(1,1));
+                _locks.Add(keyName, new SemaphoreSlim(1,1));
             }
-            mutex = _locks[site];
+            mutex = _locks[keyName];
         }
 
         if (mutex.Wait(_options.Timeout) == false)
+        {
             throw new AbandonedMutexException();
+        }
 
         return new SiteLeaseContext(() => mutex.Release());
     }        

--- a/src/api/Nhs.Appointments.Core/Concurrency/InMemorySiteLeaseManager.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/InMemorySiteLeaseManager.cs
@@ -33,6 +33,6 @@ internal class InMemorySiteLeaseManager : ISiteLeaseManager
             throw new AbandonedMutexException();
         }
 
-        return new SiteLeaseContext(() => mutex.Release());
+        return new SiteLeaseContext(keyName, () => mutex.Release());
     }        
 }

--- a/src/api/Nhs.Appointments.Core/Concurrency/LeaseKeys.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/LeaseKeys.cs
@@ -1,0 +1,24 @@
+namespace Nhs.Appointments.Core.Concurrency;
+
+/// <summary>
+/// This wrapper class is responsible for creating all lease keys
+/// </summary>
+public static class LeaseKeys
+{
+    /// <summary>
+    /// This factory class is responsible for creating a lease key from the combination of the site and the passed date values.
+    /// </summary>
+    public static class SiteKeyFactory
+    {
+        /// <summary>
+        /// This factory method creates a site lease key from the combination of the <paramref name="site"/> and <paramref name="date"/> values.
+        /// </summary>
+        /// <param name="site">The id of the site to be used to construct the key.</param>
+        /// <param name="date">The date to be used to construct the key.</param>
+        /// <returns></returns>
+        public static string Create(string site, DateOnly date)
+        {
+            return $"{site}_{date:YYYYMMDD}";
+        }
+    }
+}

--- a/src/api/Nhs.Appointments.Core/Concurrency/LeaseKeys.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/LeaseKeys.cs
@@ -11,14 +11,16 @@ public static class LeaseKeys
     public static class SiteKeyFactory
     {
         /// <summary>
-        /// This factory method creates a site lease key from the combination of the <paramref name="site"/> and <paramref name="date"/> values.
+        /// This factory method creates a site lease key from the combination of the <paramref name="siteId"/> and <paramref name="date"/> values.
         /// </summary>
-        /// <param name="site">The id of the site to be used to construct the key.</param>
+        /// <param name="siteId">The id of the site to be used to construct the key.</param>
         /// <param name="date">The date to be used to construct the key.</param>
-        /// <returns></returns>
-        public static string Create(string site, DateOnly date)
+        /// <returns>A key for the site lease lock.</returns>
+        public static string Create(string siteId, DateOnly date)
         {
-            return $"{site}_{date:YYYYMMDD}";
+            ArgumentException.ThrowIfNullOrEmpty(siteId, nameof(siteId));
+
+            return $"{siteId}_{date:yyyyMMdd}";
         }
     }
 }

--- a/src/api/Nhs.Appointments.Core/Concurrency/SiteLeaseContext.cs
+++ b/src/api/Nhs.Appointments.Core/Concurrency/SiteLeaseContext.cs
@@ -1,0 +1,22 @@
+namespace Nhs.Appointments.Core.Concurrency;
+
+public class SiteLeaseContext : ISiteLeaseContext
+{
+    private readonly Action _release;
+
+    public SiteLeaseContext(string siteKey, Action release)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(siteKey, nameof(siteKey));
+        ArgumentNullException.ThrowIfNull(release, nameof(release));
+
+        SiteKey = siteKey;
+        _release = release;
+    }
+
+    public void Dispose()
+    {
+        _release();
+    }
+
+    public string SiteKey { get; private set; }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
@@ -37,6 +37,7 @@ namespace Nhs.Appointments.Core.UnitTests
         [Fact]
         public async Task MakeBooking_AcquiresLock_WhenBooking()
         {
+            var expectedSiteId = Guid.NewGuid().ToString();
             var expectedFrom = new DateOnly(2077, 1, 1);
             var expectedUntil = expectedFrom.AddDays(1);
             SessionInstance[] availability =
@@ -46,10 +47,9 @@ namespace Nhs.Appointments.Core.UnitTests
 
             var booking = new Booking
             {
-                Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10
+                Site = expectedSiteId, Service = "TSERV", From = new DateTime(2077, 1, 1, 10, 0, 0, 0), Duration = 10
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
             _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync("TEST1");
 
             var bookingQueryService = new BookingQueryService(_bookingsDocumentStore.Object, TimeProvider.System);
@@ -94,7 +94,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Booked
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
 
             MockAvailability(availability);
 
@@ -134,7 +134,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Provisional
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
 
             MockAvailability(availability);
 
@@ -173,7 +173,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Provisional
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
 
             _bookingAvailabilityStateService.Setup(x => x.GetAvailableSlots(MockSite,
                     new DateTime(2077, 1, 1, 10, 0, 0, 0),
@@ -262,7 +262,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Provisional
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
 
             _bookingAvailabilityStateService.Setup(x => x.GetAvailableSlots(MockSite,
                     new DateTime(2077, 1, 1, 10, 0, 0, 0),
@@ -360,7 +360,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Booked
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
 
             MockAvailability(availability);
 
@@ -393,7 +393,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Booked
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
 
             MockAvailability(availability);
 
@@ -418,7 +418,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Booked
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
 
             _bookingAvailabilityStateService.Setup(x => x.GetAvailableSlots(MockSite,
                     new DateTime(2077, 1, 1, 13, 0, 0, 0),
@@ -547,7 +547,7 @@ namespace Nhs.Appointments.Core.UnitTests
 
             await _sut.CancelBooking(bookingRef, site, CancellationReason.CancelledByCitizen, runRecalculation: false);
 
-            _siteLeaseManager.Verify(x => x.Acquire(site), Times.Never);
+            _siteLeaseManager.Verify(x => x.Acquire(site, It.IsAny<DateOnly>()), Times.Never);
         }
 
         [Fact]
@@ -966,7 +966,7 @@ namespace Nhs.Appointments.Core.UnitTests
         {
             var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1) };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
             _bookingAvailabilityStateService
                 .Setup(x => x.GetAvailableSlots(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                 .ReturnsAsync(new List<SessionInstance>());
@@ -1300,7 +1300,7 @@ namespace Nhs.Appointments.Core.UnitTests
 
         public AutoResetEvent WaitHandle { get; }
 
-        public ISiteLeaseContext Acquire(string site)
+        public ISiteLeaseContext Acquire(string site, DateOnly date)
         {
             WaitHandle.WaitOne();
             return new FakeLeaseContext();

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
@@ -1309,6 +1309,8 @@ namespace Nhs.Appointments.Core.UnitTests
 
     public class FakeLeaseContext : ISiteLeaseContext
     {
+        public string SiteKey => throw new NotImplementedException();
+
         public void Dispose()
         {
             GC.SuppressFinalize(this);

--- a/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/BookingWriteServiceTests.cs
@@ -35,14 +35,16 @@ namespace Nhs.Appointments.Core.UnitTests
         }
 
         [Fact]
-        public async Task MakeBooking_AcquiresLock_WhenBooking()
+        public async Task MakeBooking_AcquiresLockForTheSiteIdAndDayOfTheBooking_WhenBooking()
         {
             var expectedSiteId = Guid.NewGuid().ToString();
             var expectedFrom = new DateOnly(2077, 1, 1);
             var expectedUntil = expectedFrom.AddDays(1);
             SessionInstance[] availability =
             [
-                new(new DateTime(2077, 1, 1, 9, 0, 0, 0), new DateTime(2077, 1, 1, 12, 0, 0, 0))
+                new(new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 9, 0, 0, 0), 
+                    new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 12, 0, 0, 0)
+                   )
             ];
 
             var booking = new Booking
@@ -56,20 +58,236 @@ namespace Nhs.Appointments.Core.UnitTests
             var availabilityQueryService =
                 new AvailabilityQueryService(_availabilityStore.Object, _availabilityCreatedEventStore.Object);
 
-            var leaseManager = new FakeLeaseManager();
+            _siteLeaseManager.Setup(x => x.Acquire(expectedSiteId, expectedFrom)).Returns(new FakeLeaseContext());
+
             var bookingService = new BookingWriteService(_bookingsDocumentStore.Object, bookingQueryService,
                 _referenceNumberProvider.Object,
-                leaseManager, new BookingAvailabilityStateService(availabilityQueryService, bookingQueryService),
+                _siteLeaseManager.Object, new BookingAvailabilityStateService(availabilityQueryService, bookingQueryService),
                 new EventFactory(), _messageBus.Object, TimeProvider.System);
 
-            var task = Task.Run(() => bookingService.MakeBooking(booking));
-            await Task.Delay(100);
-            task.IsCompleted.Should().BeFalse();
+            // Act.
+            await bookingService.MakeBooking(booking);
 
-            leaseManager.WaitHandle.Set();
+            // Assert.
+            _siteLeaseManager.Verify(slm => slm.Acquire(expectedSiteId, expectedFrom), Times.Once());
+            _siteLeaseManager.VerifyNoOtherCalls();
+        }
 
-            await Task.Delay(1000);
-            task.IsCompleted.Should().BeTrue();
+        [Fact]
+        public async Task MakeBookingForTwoDifferentDaysForTheSameSite_AcquiresLockWithDifferentParameters_WhenBooking()
+        {
+            var expectedSiteId = Guid.NewGuid().ToString();
+            var expectedFrom1 = new DateOnly(2077, 1, 1);
+            var expectedUntil1 = expectedFrom1.AddDays(1);
+            var expectedFrom2 = new DateOnly(2077, 1, 2);
+            var expectedUntil2 = expectedFrom2.AddDays(1);
+
+            SessionInstance[] availability =
+            [
+                new(new DateTime(expectedFrom1.Year, expectedFrom1.Month, expectedFrom1.Day, 9, 0, 0, 0), 
+                    new DateTime(expectedFrom1.Year, expectedFrom1.Month, expectedFrom1.Day, 12, 0, 0, 0)
+                    ),
+                new(new DateTime(expectedFrom2.Year, expectedFrom2.Month, expectedFrom2.Day, 9, 0, 0, 0), 
+                    new DateTime(expectedFrom2.Year, expectedFrom2.Month, expectedFrom2.Day, 12, 0, 0, 0)
+                    )
+            ];
+
+            var booking1 = new Booking
+            {
+                Site = expectedSiteId,
+                Service = "TSERV",
+                From = new DateTime(expectedFrom1.Year, expectedFrom1.Month, expectedFrom1.Day, 10, 0, 0, 0),
+                Duration = 10
+            };
+
+            var booking2 = new Booking
+            {
+                Site = expectedSiteId,
+                Service = "TSERV",
+                From = new DateTime(expectedFrom2.Year, expectedFrom2.Month, expectedFrom2.Day, 10, 0, 0, 0),
+                Duration = 10
+            };
+
+            _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync("TEST1");
+
+            var bookingQueryService = new BookingQueryService(_bookingsDocumentStore.Object, TimeProvider.System);
+            var availabilityQueryService =
+                new AvailabilityQueryService(_availabilityStore.Object, _availabilityCreatedEventStore.Object);
+
+            _siteLeaseManager.Setup(x => x.Acquire(expectedSiteId, expectedFrom1)).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(expectedSiteId, expectedFrom2)).Returns(new FakeLeaseContext());
+
+            var bookingService = new BookingWriteService(_bookingsDocumentStore.Object, bookingQueryService,
+                _referenceNumberProvider.Object,
+                _siteLeaseManager.Object, new BookingAvailabilityStateService(availabilityQueryService, bookingQueryService),
+                new EventFactory(), _messageBus.Object, TimeProvider.System);
+
+            // Act.
+            await bookingService.MakeBooking(booking1);
+            await bookingService.MakeBooking(booking2);
+
+            // Assert.
+            _siteLeaseManager.Verify(slm => slm.Acquire(expectedSiteId, expectedFrom1), Times.Once());
+            _siteLeaseManager.Verify(slm => slm.Acquire(expectedSiteId, expectedFrom2), Times.Once());
+            _siteLeaseManager.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task MakeBookingForTheSameDayForTwoDifferentSites_AcquiresLockWithDifferentParameters_WhenBooking()
+        {
+            var expectedSiteId1 = Guid.NewGuid().ToString();
+            var expectedSiteId2 = Guid.NewGuid().ToString();
+            var expectedFrom = new DateOnly(2077, 1, 1);
+            var expectedUntil = expectedFrom.AddDays(1);
+
+            SessionInstance[] availability =
+            [
+                new(new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 9, 0, 0, 0), 
+                    new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 12, 0, 0, 0)
+                   )
+            ];
+
+            var booking1 = new Booking
+            {
+                Site = expectedSiteId1,
+                Service = "TSERV",
+                From = new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 10, 0, 0, 0),
+                Duration = 10
+            };
+
+            var booking2 = new Booking
+            {
+                Site = expectedSiteId2,
+                Service = "TSERV",
+                From = new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 10, 0, 0, 0),
+                Duration = 10
+            };
+
+            _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync("TEST1");
+
+            var bookingQueryService = new BookingQueryService(_bookingsDocumentStore.Object, TimeProvider.System);
+            var availabilityQueryService =
+                new AvailabilityQueryService(_availabilityStore.Object, _availabilityCreatedEventStore.Object);
+
+            _siteLeaseManager.Setup(x => x.Acquire(expectedSiteId1, expectedFrom)).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(expectedSiteId2, expectedFrom)).Returns(new FakeLeaseContext());
+
+            var bookingService = new BookingWriteService(_bookingsDocumentStore.Object, bookingQueryService,
+                _referenceNumberProvider.Object,
+                _siteLeaseManager.Object, new BookingAvailabilityStateService(availabilityQueryService, bookingQueryService),
+                new EventFactory(), _messageBus.Object, TimeProvider.System);
+
+            // Act.
+            await bookingService.MakeBooking(booking1);
+            await bookingService.MakeBooking(booking2);
+
+            // Assert.
+            _siteLeaseManager.Verify(slm => slm.Acquire(expectedSiteId1, expectedFrom), Times.Once());
+            _siteLeaseManager.Verify(slm => slm.Acquire(expectedSiteId2, expectedFrom), Times.Once());
+            _siteLeaseManager.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task MakeBookingTwiceForTheSameDayForTheSameSite_AcquiresLockWithTheSameParameters_WhenBooking()
+        {
+            var expectedSiteId = Guid.NewGuid().ToString();
+            var expectedFrom = new DateOnly(2077, 1, 1);
+            var expectedUntil = expectedFrom.AddDays(1);
+
+            SessionInstance[] availability =
+            [
+                new(new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 9, 0, 0, 0), 
+                    new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 12, 0, 0, 0)
+                   )
+            ];
+
+            var booking1 = new Booking
+            {
+                Site = expectedSiteId,
+                Service = "TSERV",
+                From = new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 10, 0, 0, 0),
+                Duration = 10
+            };
+
+            var booking2 = new Booking
+            {
+                Site = expectedSiteId,
+                Service = "TSERV",
+                From = new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 10, 0, 0, 0),
+                Duration = 10
+            };
+
+            _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync(Guid.NewGuid().ToString());
+
+            var bookingQueryService = new BookingQueryService(_bookingsDocumentStore.Object, TimeProvider.System);
+            var availabilityQueryService =
+                new AvailabilityQueryService(_availabilityStore.Object, _availabilityCreatedEventStore.Object);
+
+            _siteLeaseManager.Setup(x => x.Acquire(expectedSiteId, expectedFrom)).Returns(new FakeLeaseContext());
+
+            var bookingService = new BookingWriteService(_bookingsDocumentStore.Object, bookingQueryService,
+                _referenceNumberProvider.Object,
+                _siteLeaseManager.Object, new BookingAvailabilityStateService(availabilityQueryService, bookingQueryService),
+                new EventFactory(), _messageBus.Object, TimeProvider.System);
+
+            // Act.
+            await bookingService.MakeBooking(booking1);
+            await bookingService.MakeBooking(booking2);
+
+            // Assert.
+            _siteLeaseManager.Verify(slm => slm.Acquire(expectedSiteId, expectedFrom), Times.Exactly(2));
+            _siteLeaseManager.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData("20260328")]
+        [InlineData("20260329")]
+        [InlineData("20260330")]
+        [InlineData("20261024")]
+        [InlineData("20261025")]
+        [InlineData("20261026")]
+        public async Task MakeBookingOnAndAroundDayClocksChange_AcquiresLockForTheCorrectDay_WhenBooking(string dateClocksChangeAsString)
+        {
+            var dayClocksGoForward = DateOnly.ParseExact(dateClocksChangeAsString, "yyyyMMdd");
+
+            var expectedSiteId = Guid.NewGuid().ToString();
+            var expectedFrom = dayClocksGoForward;
+            var expectedUntil = expectedFrom.AddDays(1);
+
+            SessionInstance[] availability =
+            [
+                new(new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 1, 0, 0, 0), 
+                    new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 12, 0, 0, 0)
+                    )
+            ];
+
+            var booking = new Booking
+            {
+                Site = expectedSiteId,
+                Service = "TSERV",
+                From = new DateTime(expectedFrom.Year, expectedFrom.Month, expectedFrom.Day, 1, 30, 0, 0),
+                Duration = 10
+            };
+
+            _referenceNumberProvider.Setup(x => x.GetReferenceNumber(It.IsAny<string>())).ReturnsAsync(Guid.NewGuid().ToString());
+
+            var bookingQueryService = new BookingQueryService(_bookingsDocumentStore.Object, TimeProvider.System);
+            var availabilityQueryService =
+                new AvailabilityQueryService(_availabilityStore.Object, _availabilityCreatedEventStore.Object);
+
+            _siteLeaseManager.Setup(x => x.Acquire(expectedSiteId, expectedFrom)).Returns(new FakeLeaseContext());
+
+            var bookingService = new BookingWriteService(_bookingsDocumentStore.Object, bookingQueryService,
+                _referenceNumberProvider.Object,
+                _siteLeaseManager.Object, new BookingAvailabilityStateService(availabilityQueryService, bookingQueryService),
+                new EventFactory(), _messageBus.Object, TimeProvider.System);
+
+            // Act.
+            await bookingService.MakeBooking(booking);
+
+            // Assert.
+            _siteLeaseManager.Verify(slm => slm.Acquire(expectedSiteId, expectedFrom), Times.Once());
+            _siteLeaseManager.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -94,7 +312,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Booked
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(MockSite, new DateOnly(2077, 1, 1))).Returns(new FakeLeaseContext());
 
             MockAvailability(availability);
 
@@ -134,7 +352,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Provisional
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(MockSite, new DateOnly(2077, 1, 1))).Returns(new FakeLeaseContext());
 
             MockAvailability(availability);
 
@@ -173,7 +391,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Provisional
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(MockSite, new DateOnly(2077, 1, 1))).Returns(new FakeLeaseContext());
 
             _bookingAvailabilityStateService.Setup(x => x.GetAvailableSlots(MockSite,
                     new DateTime(2077, 1, 1, 10, 0, 0, 0),
@@ -262,7 +480,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Provisional
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(MockSite, new DateOnly(2077, 1, 1))).Returns(new FakeLeaseContext());
 
             _bookingAvailabilityStateService.Setup(x => x.GetAvailableSlots(MockSite,
                     new DateTime(2077, 1, 1, 10, 0, 0, 0),
@@ -360,7 +578,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Booked
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(MockSite, new DateOnly(2077, 1, 1))).Returns(new FakeLeaseContext());
 
             MockAvailability(availability);
 
@@ -393,7 +611,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Booked
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(MockSite, new DateOnly(2077, 1, 1))).Returns(new FakeLeaseContext());
 
             MockAvailability(availability);
 
@@ -418,7 +636,7 @@ namespace Nhs.Appointments.Core.UnitTests
                 Status = AppointmentStatus.Booked
             };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(MockSite, new DateOnly(2077, 1, 1))).Returns(new FakeLeaseContext());
 
             _bookingAvailabilityStateService.Setup(x => x.GetAvailableSlots(MockSite,
                     new DateTime(2077, 1, 1, 13, 0, 0, 0),
@@ -964,9 +1182,10 @@ namespace Nhs.Appointments.Core.UnitTests
         [Fact]
         public async Task MakeBooking_CallsAllocationStateService_WhenBooking()
         {
-            var booking = new Booking { Site = "TEST", Service = "TSERV", From = new DateTime(2077, 1, 1) };
+            var siteId = "TEST";
+            var booking = new Booking { Site = siteId, Service = "TSERV", From = new DateTime(2077, 1, 1) };
 
-            _siteLeaseManager.Setup(x => x.Acquire(It.IsAny<string>(), It.IsAny<DateOnly>())).Returns(new FakeLeaseContext());
+            _siteLeaseManager.Setup(x => x.Acquire(siteId, new DateOnly(2077, 1, 1))).Returns(new FakeLeaseContext());
             _bookingAvailabilityStateService
                 .Setup(x => x.GetAvailableSlots(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                 .ReturnsAsync(new List<SessionInstance>());
@@ -1309,7 +1528,7 @@ namespace Nhs.Appointments.Core.UnitTests
 
     public class FakeLeaseContext : ISiteLeaseContext
     {
-        public string SiteKey => throw new NotImplementedException();
+        public string SiteKey => Guid.NewGuid().ToString();
 
         public void Dispose()
         {

--- a/tests/Nhs.Appointments.Core.UnitTests/Bookings/BookingDayRangeTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/Bookings/BookingDayRangeTests.cs
@@ -1,0 +1,30 @@
+using Nhs.Appointments.Core.Bookings;
+
+namespace Nhs.Appointments.Core.UnitTests.Bookings;
+
+public class BookingDayRangeTests
+{
+    [Theory]
+    [MemberData(nameof(DayValuesData))]
+    public void CreateBookingDayRange_WhenDayValuesArePassed_DerivesCorrectStartAndEndValues(DateOnly day)
+    {
+        // Arrange.
+        var expectedStart = new DateTime(day, new TimeOnly(0, 0));
+        var expectedEnd = new DateTime(day, new TimeOnly(23, 59));
+        var sut = new BookingDayRange(day);
+
+        // Act - not required.
+
+        // Assert.
+        sut.Start.Should().Be(expectedStart);
+        sut.End.Should().Be(expectedEnd);
+    }
+
+    public static IEnumerable<object[]> DayValuesData =>
+    [
+        [new DateOnly(2026, 01, 01)],
+        [new DateOnly(2026, 12, 31)], 
+        [new DateOnly(2024, 1, 29)],
+        [new DateOnly(2027, 8, 15)] 
+    ];
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/Concurrency/InMemorySiteLeaseManagerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/Concurrency/InMemorySiteLeaseManagerTests.cs
@@ -26,4 +26,115 @@ public class InMemorySiteLeaseManagerTests
         slc.SiteKey.Should()
             .Be(expectedSiteKey);
     }
+
+    [Fact]
+    public void SameSiteAndSameDayCallsConcurrent_Acquire_AttemptToAcquireTheSameLock()
+    {
+        // Arrange.
+        var siteId = Guid.NewGuid().ToString();
+        var date = DateOnly.FromDateTime(DateTime.UtcNow);
+        var options = new Mock<IOptions<SiteLeaseManagerOptions>>();
+        var slmo = new SiteLeaseManagerOptions { Timeout = new TimeSpan(0, 0, 0, 0, 0, 1) };
+        options.Setup(o => o.Value).Returns(slmo);
+
+        var expectedSiteKey = LeaseKeys.SiteKeyFactory.Create(siteId, date);
+
+        var sut = new InMemorySiteLeaseManager(options.Object);
+
+        // Act.
+        var slc1 = sut.Acquire(siteId, date);
+        Action action = () => sut.Acquire(siteId, date);
+
+        // Assert.
+        slc1.SiteKey.Should()
+            .Be(expectedSiteKey);
+        action.Should()
+            .Throw<AbandonedMutexException>()
+            .WithMessage($"Abandoned attempt to acquire lock for site key {expectedSiteKey}");
+    }
+
+    [Fact]
+    public void SameSiteAndSameDayCallsButNotConcurrent_Acquire_ReturnsMatchingSiteLeaseContexts()
+    {
+        // Arrange.
+        var siteId = Guid.NewGuid().ToString();
+        var date = DateOnly.FromDateTime(DateTime.UtcNow);
+        var options = new Mock<IOptions<SiteLeaseManagerOptions>>();
+        var slmo = new SiteLeaseManagerOptions { Timeout = new TimeSpan(0, 0, 0, 0, 0, 1) };
+        options.Setup(o => o.Value).Returns(slmo);
+
+        var expectedSiteKey = LeaseKeys.SiteKeyFactory.Create(siteId, date);
+
+        var sut = new InMemorySiteLeaseManager(options.Object);
+
+        // Act.
+        var originalSiteKey = "";
+        using (var slc1 = sut.Acquire(siteId, date))
+        {
+            originalSiteKey = slc1.SiteKey;
+        }
+        var slc2 = sut.Acquire(siteId, date);
+
+        // Assert.
+        originalSiteKey.Should()
+            .Be(expectedSiteKey);
+        slc2.SiteKey.Should()
+            .Be(expectedSiteKey);
+    }
+
+    [Fact]
+    public void SameSiteAndDifferentDayCalls_Acquire_ReturnsSeparateSiteLeaseContexts()
+    {
+        // Arrange.
+        var siteId = Guid.NewGuid().ToString();
+        var date1 = DateOnly.FromDateTime(DateTime.UtcNow);
+        var date2 = date1.AddDays(1);
+        var options = new Mock<IOptions<SiteLeaseManagerOptions>>();
+        var slmo = new SiteLeaseManagerOptions { Timeout = new TimeSpan(1, 0, 0) };
+        options.Setup(o => o.Value).Returns(slmo);
+
+        var expectedSiteKey1 = LeaseKeys.SiteKeyFactory.Create(siteId, date1);
+        var expectedSiteKey2 = LeaseKeys.SiteKeyFactory.Create(siteId, date2);
+
+        var sut = new InMemorySiteLeaseManager(options.Object);
+
+        // Act.
+        var slc1 = sut.Acquire(siteId, date1);
+        var slc2 = sut.Acquire(siteId, date2);
+
+        // Assert.
+        slc1.SiteKey.Should()
+            .Be(expectedSiteKey1);
+        slc2.SiteKey.Should()
+            .Be(expectedSiteKey2);
+        expectedSiteKey1.Should().NotBe(expectedSiteKey2);
+    }
+
+    [Fact]
+    public void DifferentSiteAndSameDayCalls_Acquire_ReturnsSeparateSiteLeaseContexts()
+    {
+        // Arrange.
+        var siteId1 = Guid.NewGuid().ToString();
+        var siteId2 = Guid.NewGuid().ToString();
+        var date = DateOnly.FromDateTime(DateTime.UtcNow);
+        var options = new Mock<IOptions<SiteLeaseManagerOptions>>();
+        var slmo = new SiteLeaseManagerOptions { Timeout = new TimeSpan(1, 0, 0) };
+        options.Setup(o => o.Value).Returns(slmo);
+
+        var expectedSiteKey1 = LeaseKeys.SiteKeyFactory.Create(siteId1, date);
+        var expectedSiteKey2 = LeaseKeys.SiteKeyFactory.Create(siteId2, date);
+
+        var sut = new InMemorySiteLeaseManager(options.Object);
+
+        // Act.
+        var slc1 = sut.Acquire(siteId1, date);
+        var slc2 = sut.Acquire(siteId2, date);
+
+        // Assert.
+        slc1.SiteKey.Should()
+            .Be(expectedSiteKey1);
+        slc2.SiteKey.Should()
+            .Be(expectedSiteKey2);
+        expectedSiteKey1.Should().NotBe(expectedSiteKey2);
+    }
 }

--- a/tests/Nhs.Appointments.Core.UnitTests/Concurrency/InMemorySiteLeaseManagerTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/Concurrency/InMemorySiteLeaseManagerTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Options;
+using Nhs.Appointments.Core.Concurrency;
+
+namespace Nhs.Appointments.Core.UnitTests.Concurrency;
+
+public class InMemorySiteLeaseManagerTests
+{
+    [Fact]
+    public void SiteAndDateSupplied_Acquire_ReturnsSiteLeaseContext()
+    {
+        // Arrange.
+        var siteId = Guid.NewGuid().ToString();
+        var date  = DateOnly.FromDateTime(DateTime.UtcNow);
+        var options = new Mock<IOptions<SiteLeaseManagerOptions>>();
+        var slmo = new SiteLeaseManagerOptions { Timeout = new TimeSpan(1, 0, 0) };
+        options.Setup(o => o.Value).Returns(slmo);
+
+        var expectedSiteKey = LeaseKeys.SiteKeyFactory.Create(siteId, date);
+
+        var sut = new InMemorySiteLeaseManager(options.Object);
+
+        // Act.
+        var slc = sut.Acquire(siteId, date);
+
+        // Assert.
+        slc.SiteKey.Should()
+            .Be(expectedSiteKey);
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/Concurrency/LeaseKeysTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/Concurrency/LeaseKeysTests.cs
@@ -1,0 +1,59 @@
+using Nhs.Appointments.Core.Concurrency;
+
+namespace Nhs.Appointments.Core.UnitTests.Concurrency;
+
+public class LeaseKeysTests
+{
+    [Fact]
+    public void SiteIdIsNull_SiteKeyIsCreated_ThrowsArgumentNullException()
+    {
+        // Arrange - not required.
+
+        // Act.
+        Action action = () => LeaseKeys.SiteKeyFactory.Create(null, DateOnly.FromDateTime(DateTime.UtcNow));
+
+        // Assert.
+        action.Should()
+            .Throw<ArgumentNullException>()
+            .WithMessage("Value cannot be null. (Parameter 'siteId')");
+    }
+
+    [Fact]
+    public void SiteIdIsEmpty_SiteKeyIsCreated_ThrowsArgumentException()
+    {
+        // Arrange - not required.
+
+        // Act.
+        Action action = () => LeaseKeys.SiteKeyFactory.Create("", DateOnly.FromDateTime(DateTime.UtcNow));
+
+        // Assert.
+        action.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("The value cannot be an empty string. (Parameter 'siteId')");
+    }
+
+    [Theory]
+    [MemberData(nameof(MemberDataForSiteLeaseFactory))]
+    public void SiteAndDateSupplied_SiteKeyIsCreated_ReturnsCorrectValue(string siteId, DateOnly date, string expectedKey)
+    {
+        // Arrange - not required.
+
+        // Act - not required.
+        
+        // Assert.
+        LeaseKeys.SiteKeyFactory.Create(siteId, date).Should().Be(expectedKey);
+    }
+
+    public static IEnumerable<object[]> MemberDataForSiteLeaseFactory()
+    {
+        var guid1 = Guid.NewGuid().ToString();
+        var guid2 = Guid.NewGuid().ToString();
+        var guid3 = Guid.NewGuid().ToString();
+
+        return new List<object[]> {
+            new object[] { guid1, new DateOnly(2026, 08, 14), $"{guid1}_20260814" },
+            new object[] { guid2, new DateOnly(2026, 12, 31), $"{guid2}_20261231" },
+            new object[] { guid3, new DateOnly(2028, 02, 29), $"{guid3}_20280229" }
+        };
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/Concurrency/SiteLeaseContextTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/Concurrency/SiteLeaseContextTests.cs
@@ -1,0 +1,66 @@
+using Nhs.Appointments.Core.Concurrency;
+
+namespace Nhs.Appointments.Core.UnitTests.Concurrency;
+
+public class SiteLeaseContextTests
+{
+    [Fact]
+    public void SiteKeyNotSupplied_ConstructorCalled_ThrowsArgumentNullException()
+    {
+        // Arrange.
+        Action releaseAction = () => { };
+
+        Action action = () => new SiteLeaseContext("", releaseAction);
+
+        // Act - not required.
+
+        // Assert.
+        action.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("The value cannot be an empty string. (Parameter 'siteKey')");
+    }
+
+    [Fact]
+    public void ReleaseActionNotSupplied_ConstructorCalled_ThrowsArgumentNullException()
+    {
+        // Arrange.
+        Action action = () => new SiteLeaseContext("siteKey", null);
+
+        // Act - not required.
+
+        // Assert.
+        action.Should()
+            .Throw<ArgumentNullException>()
+            .WithMessage("Value cannot be null. (Parameter 'release')");
+    }
+
+    [Fact]
+    public void SiteLeaseContextCreated_SiteKeyRequested_ReturnsCorrectValue()
+    {
+        // Arrange.
+        Action releaseAction = () => { };
+        var randomSiteKey = Guid.NewGuid().ToString();
+        var sut = new SiteLeaseContext(randomSiteKey, releaseAction);
+
+        // Act - not required.
+
+        // Assert.
+        sut.SiteKey.Should()
+            .Be(randomSiteKey);
+    }
+
+    [Fact]
+    public void ReleaseActionSet_SiteLeaseContextDisposed_ReleaseActionCalled()
+    {
+        // Arrange.
+        var releaseAction = new Mock<Action>();
+        var randomSiteKey = Guid.NewGuid().ToString();
+
+        // Act.
+        var sut = new SiteLeaseContext(randomSiteKey, releaseAction.Object);
+        sut.Dispose();
+
+        // Assert.
+        releaseAction.Verify(action => action(), Times.Once());
+    }
+}

--- a/tests/Nhs.Appointments.Core.UnitTests/Concurrency/SiteLeaseContextTests.cs
+++ b/tests/Nhs.Appointments.Core.UnitTests/Concurrency/SiteLeaseContextTests.cs
@@ -57,8 +57,7 @@ public class SiteLeaseContextTests
         var randomSiteKey = Guid.NewGuid().ToString();
 
         // Act.
-        var sut = new SiteLeaseContext(randomSiteKey, releaseAction.Object);
-        sut.Dispose();
+        using (new SiteLeaseContext(randomSiteKey, releaseAction.Object)) { };
 
         // Assert.
         releaseAction.Verify(action => action(), Times.Once());

--- a/tests/Nhs.Appointments.Core.UnitTests/Nhs.Appointments.Core.UnitTests.csproj
+++ b/tests/Nhs.Appointments.Core.UnitTests/Nhs.Appointments.Core.UnitTests.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
-    <PackageReference Include="Moq" Version="4.20.72"/>
-    <PackageReference Include="Okta.Sdk" Version="9.2.3"/>
-    <PackageReference Include="xunit" Version="2.9.3"/>
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Okta.Sdk" Version="9.2.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\api\Nhs.Appointments.Core\Nhs.Appointments.Core.csproj"/>
+    <ProjectReference Include="..\..\src\api\Nhs.Appointments.Core\Nhs.Appointments.Core.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Description

For the areas of the system that already used site locking, refactored this to use the combination of site+day in an attempt to reduce unnecessary collisions.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
- [ ] If I've added/updated an end-point, I've added the appropriate annotations and tested the Swagger documentation reflects the change
