### PR TITLE
APPT-2128 Update back links for change availability & Report - Additional Jest tests for the back link

### DIFF
--- a/src/client/src/app/site/[site]/change-availability/before-you-continue-step.test.tsx
+++ b/src/client/src/app/site/[site]/change-availability/before-you-continue-step.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import render from '@testing/render';
+import { screen } from '@testing-library/react';
 import BeforeYouContinueStep from './before-you-continue-step';
 import { useRouter } from 'next/navigation';
 import { InjectedWizardProps } from '@components/wizard';
@@ -69,8 +70,8 @@ describe('BeforeYouContinueStep', () => {
     ).toBeInTheDocument();
   });
 
-  it('calls goToNextStep when the "Continue to cancel" button is clicked', () => {
-    render(
+  it('calls goToNextStep when the "Continue to cancel" button is clicked', async () => {
+    const { user } = render(
       <BeforeYouContinueStep
         {...defaultProps}
         cancelADateRangeWithBookingsEnabled={false}
@@ -80,7 +81,8 @@ describe('BeforeYouContinueStep', () => {
     const continueButton = screen.getByRole('button', {
       name: /Continue to cancel/i,
     });
-    fireEvent.click(continueButton);
+
+    await user.click(continueButton); // Modern user interaction
 
     expect(mockGoToNextStep).toHaveBeenCalledTimes(1);
   });
@@ -97,10 +99,10 @@ describe('BeforeYouContinueStep', () => {
     expect(backLink).toBeInTheDocument();
   });
 
-  it('calls router.push with the previousUrl when one is provided', () => {
+  it('calls router.push with the previousUrl when one is provided', async () => {
     const customUrl = '/specific-previous-page';
 
-    render(
+    const { user } = render(
       <BeforeYouContinueStep
         {...defaultProps}
         cancelADateRangeWithBookingsEnabled={false}
@@ -109,25 +111,23 @@ describe('BeforeYouContinueStep', () => {
     );
 
     const backLink = screen.getByText(/Back/i);
-    fireEvent.click(backLink);
+    await user.click(backLink);
 
-    // This proves the 'if (previousUrl)' logic works
     expect(mockRouter.push).toHaveBeenCalledWith(customUrl);
   });
 
-  it('calls router.push with "/sites" fallback when previousUrl is missing', () => {
-    render(
+  it('calls router.push with "/sites" fallback when previousUrl is missing', async () => {
+    const { user } = render(
       <BeforeYouContinueStep
         {...defaultProps}
         cancelADateRangeWithBookingsEnabled={false}
-        previousUrl={undefined} // No previous URL
+        previousUrl={undefined}
       />,
     );
 
     const backLink = screen.getByText(/Back/i);
-    fireEvent.click(backLink);
+    await user.click(backLink);
 
-    // External traffic fallback
     expect(mockRouter.push).toHaveBeenCalledWith('/sites');
   });
 });

--- a/src/client/src/app/site/[site]/change-availability/before-you-continue-step.test.tsx
+++ b/src/client/src/app/site/[site]/change-availability/before-you-continue-step.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import BeforeYouContinueStep from './before-you-continue-step';
 import { useRouter } from 'next/navigation';
 import { InjectedWizardProps } from '@components/wizard';
@@ -85,7 +85,7 @@ describe('BeforeYouContinueStep', () => {
     expect(mockGoToNextStep).toHaveBeenCalledTimes(1);
   });
 
-  it('calls router.push when the BackLink is clicked', () => {
+  it('renders the Back link with the correct role', () => {
     render(
       <BeforeYouContinueStep
         {...defaultProps}
@@ -93,10 +93,41 @@ describe('BeforeYouContinueStep', () => {
       />,
     );
 
-    const backButton = screen.getByText(/Back/i);
+    const backLink = screen.getByRole('link', { name: /Back/i });
+    expect(backLink).toBeInTheDocument();
+  });
 
-    fireEvent.click(backButton);
+  it('calls router.push with the previousUrl when one is provided', () => {
+    const customUrl = '/specific-previous-page';
 
-    expect(mockRouter.push).toHaveBeenCalledTimes(1);
+    render(
+      <BeforeYouContinueStep
+        {...defaultProps}
+        cancelADateRangeWithBookingsEnabled={false}
+        previousUrl={customUrl}
+      />,
+    );
+
+    const backLink = screen.getByText(/Back/i);
+    fireEvent.click(backLink);
+
+    // This proves the 'if (previousUrl)' logic works
+    expect(mockRouter.push).toHaveBeenCalledWith(customUrl);
+  });
+
+  it('calls router.push with "/sites" fallback when previousUrl is missing', () => {
+    render(
+      <BeforeYouContinueStep
+        {...defaultProps}
+        cancelADateRangeWithBookingsEnabled={false}
+        previousUrl={undefined} // No previous URL
+      />,
+    );
+
+    const backLink = screen.getByText(/Back/i);
+    fireEvent.click(backLink);
+
+    // External traffic fallback
+    expect(mockRouter.push).toHaveBeenCalledWith('/sites');
   });
 });

--- a/src/client/src/app/site/[site]/change-availability/before-you-continue-step.test.tsx
+++ b/src/client/src/app/site/[site]/change-availability/before-you-continue-step.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import BeforeYouContinueStep from './before-you-continue-step';
 import { useRouter } from 'next/navigation';
 import { InjectedWizardProps } from '@components/wizard';


### PR DESCRIPTION
# Description

As mentioned by @ste-banks in previous PR, I have added additional Jest tests for BeforeYouContinueStep to verify behaviour for both previousUrl (MYA) and /sites (fallback/external) paths.

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
- [ ] If I've added/updated an end-point, I've added the appropriate annotations and tested the Swagger documentation reflects the change
