### PR TITLE
APPT-2128 Back link redirects to incorrect mya url after session timeout

### DIFF
--- a/src/client/src/app/reports/reports-page.test.tsx
+++ b/src/client/src/app/reports/reports-page.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { ReportsPage } from './reports-page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+describe('ReportsPage', () => {
+  const mockPush = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+
+    Object.defineProperty(document, 'referrer', {
+      value: 'http://localhost/internal-path',
+      configurable: true,
+    });
+  });
+
+  it('navigates to the encoded returnUrl when Back is clicked', async () => {
+    const complexUrl = '/daily-appointments?date=2026-04-15&page=1';
+
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (key: string) => (key === 'returnUrl' ? complexUrl : null),
+    });
+
+    const user = userEvent.setup();
+    render(<ReportsPage />);
+
+    const backLink = screen.getByRole('link', { name: /Back/i });
+    await user.click(backLink);
+
+    expect(mockPush).toHaveBeenCalledWith(complexUrl);
+  });
+
+  it('defaults to /sites when no returnUrl is available', async () => {
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: () => null,
+    });
+
+    const user = userEvent.setup();
+    render(<ReportsPage />);
+
+    const backLink = screen.getByRole('link', { name: /Back/i });
+    await user.click(backLink);
+
+    expect(mockPush).toHaveBeenCalledWith('/sites');
+  });
+});

--- a/src/client/src/middleware.ts
+++ b/src/client/src/middleware.ts
@@ -2,7 +2,9 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
-  const pathAndQuery = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+  // Encode the search params (the ?... part) so that ampersands (&)
+  // are treated as text, not as separators for the login page parameters.
+  const pathAndQuery = `${request.nextUrl.pathname}${encodeURIComponent(request.nextUrl.search)}`;
 
   const shouldHandle = !request.nextUrl.pathname.includes('/api/');
 


### PR DESCRIPTION
# Description

This fixes an issue where the back link would redirect to an incorrect or truncated URL following a session timeout.

When a session timed out, the middleware was capturing the current URL as a returnUrl but failing to correctly handle nested query parameters (specifically for the Day, Week, and Month views). Characters like & were being interpreted by the browser as part of the login redirect rather than part of the destination path, causing the return URL to be cut short.

Updated middleware to use encodeURIComponent() when constructing the redirect URL. his ensures that the entire original path—including all query parameters (e.g., ?date=...&page=...)

Fixes # (issue)

# Checklist:

- [ ] My work is behind a feature toggle (if appropriate)
- [ ] If my work is behind a feature toggle, I've added a full suite of tests for both the ON and OFF state
- [ ] The ticket number is in the Pull Request title, with format "APPT-XXX: My Title Here"
- [ ] I have ran npm tsc / lint (in the future these will be ran automatically)
- [ ] My code generates no new .NET warnings (in the future these will be treated as errors)
- [ ] If I've added a new Function, it is disabled in all but one of the terraform groups (e.g. http_functions)
- [ ] If I've added a new Function, it has both unit and integration tests. Any request body validators have unit tests also
- [ ] If I've made UI changes, I've added appropriate Playwright and Jest tests
- [ ] If I've added/updated an end-point, I've added the appropriate annotations and tested the Swagger documentation reflects the change
